### PR TITLE
[Feature/issue-020] Tanstack Query 사용 가능하도록 Provider 설정

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,13 +1,16 @@
+import QueryProvider from '@/providers/QueryProviders';
 import './globals.css';
 
-export default function RootLayout({
+const RootLayout = ({
   children,
 }: Readonly<{
   children: React.ReactNode;
-}>) {
-  return (
-    <html lang='en'>
-      <body>{children}</body>
-    </html>
-  );
-}
+}>) => (
+  <html lang='ko'>
+    <body>
+      <QueryProvider>{children}</QueryProvider>
+    </body>
+  </html>
+);
+
+export default RootLayout;

--- a/src/providers/QueryProviders.tsx
+++ b/src/providers/QueryProviders.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { useState } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+export const QueryProvider = ({ children }: { children: React.ReactNode }) => {
+  const [queryClient] = useState(() => new QueryClient());
+
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+export default QueryProvider;


### PR DESCRIPTION
### 무엇을 위한 PR인가요? (: 뒤 설명 추가)

- 신규 기능 추가: React Query 전역 상태 관리를 위한 Provider 설정

### 변경사항 및 이유 (bullet 으로 구분)

- 앱 전역에서 React Query를 사용할 수 있도록 QueryClientProvider를 설정하기 위함

### 작업 내역 (bullet 으로 구분)

- src/providers/QueryProviders.tsx 파일 생성
- QueryClient 인스턴스 생성 및 QueryClientProvider로 children 감싸는 Provider 구현
- src/app/layout.tsx에서 QueryProviders 컴포넌트로 전체 children 감싸기

### 작업 후 기대 동작(스크린샷)

- 앱 전역에서 React Query 훅 사용 가능
- 서버 상태 관리, 캐싱, 자동 리페치 정상 동작

### PR 특이 사항

- 이후 유지보수성과 오타 방지를 위해 queryKey를 상수화하여 src/constants/queryKeys.ts 또는 유사한 파일에 정리해야 한다.

### Issue Number

close: #20 