### PR TITLE
[Feature/issue-039] NavLink에 Link 컴포넌트의 기본 props 추가

### DIFF
--- a/src/components/NavLink/NavLink.tsx
+++ b/src/components/NavLink/NavLink.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { cn } from '@/lib/utils';
 
-interface NavLinkProps {
+interface NavLinkProps extends React.ComponentProps<typeof Link> {
   href: string;
   className?: string;
   activeClassName?: string;
@@ -20,6 +20,7 @@ const NavLink = ({
   isActive,
   end,
   children,
+  ...props
 }: PropsWithChildren<NavLinkProps>) => {
   const path = usePathname();
   const activePath =
@@ -34,6 +35,7 @@ const NavLink = ({
       href={href}
       className={cn(activePath && activeClassName, className)}
       aria-current={isActive ? 'page' : undefined}
+      {...props}
     >
       {children}
     </Link>


### PR DESCRIPTION
### 무엇을 위한 PR인가요? (: 뒤 설명 추가)

- 신규 기능 추가: NavLink 컴포넌트에 Link 기본 props 추가

### 변경사항 및 이유 (bullet 으로 구분)

- NavLink에서 next/link의 기본 props (prefetch, replace 등)를 사용할 수 있도록 타입 확장
- 사용자 입장에서 더 유연하게 링크 관련 기능 활용 가능

### 작업 내역 (bullet 으로 구분)

- NavLinkProps에 React.ComponentProps<typeof Link> 확장
- 내부 Link 컴포넌트에 전달되는 props 스프레드 적용 (...props)

### 작업 후 기대 동작

- NavLink 사용 시 Link의 모든 props를 동일하게 사용할 수 있음

### Issue Number

close: #39