### PR TITLE
[Feature/issue-036] Poster 컴포넌트 구현

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    domains: ['cdn.imweb.me', 'picsum.photos'],
+  },
 };
 
 export default nextConfig;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,20 +1,3 @@
-import Poster from "@/components/poster/Poster";
-
-const Home = () => {
-    return (
-      <div className='p-8'>
-        <Poster
-          src='https://picsum.photos/300/450'
-        />
-
-        <Poster
-          src='https://cdn.imweb.me/upload/S20200106a105fd03f4b57/74acf364c7b51.jpg'
-                shadow={false}
-                size="xl"
-        />
-      </div>
-    );
-    
-}
+const Home = () => <div>hello</div>;
 
 export default Home;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,21 @@
-const Home = () => <div>hello</div>;
+import Poster from "@/components/poster/Poster";
+
+const Home = () => {
+    return (
+      <div className='p-8'>
+        <Poster
+          src='https://picsum.photos/300/450'
+          className='mb-4'
+        />
+
+        <Poster
+          src='https://cdn.imweb.me/upload/S20200106a105fd03f4b57/74acf364c7b51.jpg'
+          shadow={false}
+          className='h-60 w-40'
+        />
+      </div>
+    );
+    
+}
 
 export default Home;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,13 +5,12 @@ const Home = () => {
       <div className='p-8'>
         <Poster
           src='https://picsum.photos/300/450'
-          className='mb-4'
         />
 
         <Poster
           src='https://cdn.imweb.me/upload/S20200106a105fd03f4b57/74acf364c7b51.jpg'
-          shadow={false}
-          className='h-60 w-40'
+                shadow={false}
+                size="xl"
         />
       </div>
     );

--- a/src/components/poster/Poster.tsx
+++ b/src/components/poster/Poster.tsx
@@ -1,5 +1,5 @@
-import { cn } from "@/lib/utils";
-import Image from "next/image";
+import Image from 'next/image';
+import { cn } from '@/lib/utils';
 
 interface PosterProps {
   src: string;
@@ -11,10 +11,10 @@ interface PosterProps {
 }
 
 const sizeMap = {
-  sm: 'w-20 h-28', 
-  md: 'w-28 h-40', 
-  lg: 'w-40 h-56', 
-  xl: 'w-52 h-72', 
+  sm: 'w-20 h-28',
+  md: 'w-28 h-40',
+  lg: 'w-40 h-56',
+  xl: 'w-52 h-72',
 };
 
 const Poster = ({
@@ -38,12 +38,7 @@ const Poster = ({
         className
       )}
     >
-      <Image
-        src={src}
-        alt={alt}
-        fill
-        className='object-contain'
-      />
+      <Image src={src} alt={alt} fill className='object-contain' />
     </div>
   );
 };

--- a/src/components/poster/Poster.tsx
+++ b/src/components/poster/Poster.tsx
@@ -28,17 +28,20 @@ const Poster = ({
   const sizeClass = sizeMap[size] ?? '';
 
   return (
-    <div className={cn('relative', sizeClass)}>
+    <div
+      className={cn(
+        'relative overflow-hidden',
+        sizeClass,
+        shadow && 'shadow-md',
+        border && 'border border-gray-300',
+        className
+      )}
+    >
       <Image
         src={src}
         alt={alt}
         fill
-        className={cn(
-          'object-contain',
-          shadow && 'shadow-md',
-          border && 'border border-gray-300',
-          className
-        )}
+        className='object-contain'
       />
     </div>
   );

--- a/src/components/poster/Poster.tsx
+++ b/src/components/poster/Poster.tsx
@@ -1,0 +1,27 @@
+import Image from "next/image";
+
+interface PosterProps {
+  src: string;
+  alt?: string;
+  width?: string | number;
+  height?: string | number;
+  shadow?: boolean;
+  className?: string;
+}
+
+const Poster = ({
+  src,
+  alt = '포스터 이미지',
+  width = '100%',
+  height = 'auto',
+  shadow = true,
+  className,
+}: PosterProps) => {
+  return (
+    <Image
+      src={src}
+      alt={alt}
+      style={{ width, height }}
+      className="b"
+    )
+}

--- a/src/components/poster/Poster.tsx
+++ b/src/components/poster/Poster.tsx
@@ -31,8 +31,7 @@ const Poster = ({
     <Image
       src={src}
       alt={alt}
-      width={160}
-      height={240}
+      fill
       className={clsx(
         'object-contain',
         sizeClass,

--- a/src/components/poster/Poster.tsx
+++ b/src/components/poster/Poster.tsx
@@ -4,20 +4,29 @@ import Image from "next/image";
 interface PosterProps {
   src: string;
   alt?: string;
-  width?: string | number;
-  height?: string | number;
   shadow?: boolean;
   border?: boolean;
+  size?: 'sm' | 'md' | 'lg' | 'xl';
   className?: string;
 }
+
+const sizeMap = {
+  sm: 'w-20 h-28', 
+  md: 'w-28 h-40', 
+  lg: 'w-40 h-60', 
+  xl: 'w-52 h-72', 
+};
 
 const Poster = ({
   src,
   alt = '포스터 이미지',
   shadow = true,
   border = true,
+  size = 'md',
   className,
 }: PosterProps) => {
+  const sizeClass = sizeMap[size] ?? '';
+
   return (
     <Image
       src={src}
@@ -26,6 +35,7 @@ const Poster = ({
       height={240}
       className={clsx(
         'object-contain',
+        sizeClass,
         shadow && 'shadow-md',
         border && 'border border-gray-300',
         className

--- a/src/components/poster/Poster.tsx
+++ b/src/components/poster/Poster.tsx
@@ -32,6 +32,7 @@ const Poster = ({
       className={cn(
         'relative overflow-hidden',
         sizeClass,
+        'bg-gray-100',
         shadow && 'shadow-md',
         border && 'border border-gray-300',
         className

--- a/src/components/poster/Poster.tsx
+++ b/src/components/poster/Poster.tsx
@@ -1,3 +1,4 @@
+import clsx from "clsx";
 import Image from "next/image";
 
 interface PosterProps {
@@ -6,22 +7,31 @@ interface PosterProps {
   width?: string | number;
   height?: string | number;
   shadow?: boolean;
+  border?: boolean;
   className?: string;
 }
 
 const Poster = ({
   src,
   alt = '포스터 이미지',
-  width = '100%',
-  height = 'auto',
   shadow = true,
+  border = true,
   className,
 }: PosterProps) => {
   return (
     <Image
       src={src}
       alt={alt}
-      style={{ width, height }}
-      className="b"
-    )
-}
+      width={160}
+      height={240}
+      className={clsx(
+        'object-contain',
+        shadow && 'shadow-md',
+        border && 'border border-gray-300',
+        className
+      )}
+    />
+  );
+};
+
+export default Poster;

--- a/src/components/poster/Poster.tsx
+++ b/src/components/poster/Poster.tsx
@@ -13,7 +13,7 @@ interface PosterProps {
 const sizeMap = {
   sm: 'w-20 h-28', 
   md: 'w-28 h-40', 
-  lg: 'w-40 h-60', 
+  lg: 'w-40 h-56', 
   xl: 'w-52 h-72', 
 };
 

--- a/src/components/poster/Poster.tsx
+++ b/src/components/poster/Poster.tsx
@@ -28,18 +28,19 @@ const Poster = ({
   const sizeClass = sizeMap[size] ?? '';
 
   return (
-    <Image
-      src={src}
-      alt={alt}
-      fill
-      className={cn(
-        'object-contain',
-        sizeClass,
-        shadow && 'shadow-md',
-        border && 'border border-gray-300',
-        className
-      )}
-    />
+    <div className={cn('relative', sizeClass)}>
+      <Image
+        src={src}
+        alt={alt}
+        fill
+        className={cn(
+          'object-contain',
+          shadow && 'shadow-md',
+          border && 'border border-gray-300',
+          className
+        )}
+      />
+    </div>
   );
 };
 

--- a/src/components/poster/Poster.tsx
+++ b/src/components/poster/Poster.tsx
@@ -1,4 +1,4 @@
-import clsx from "clsx";
+import { cn } from "@/lib/utils";
 import Image from "next/image";
 
 interface PosterProps {
@@ -32,7 +32,7 @@ const Poster = ({
       src={src}
       alt={alt}
       fill
-      className={clsx(
+      className={cn(
         'object-contain',
         sizeClass,
         shadow && 'shadow-md',


### PR DESCRIPTION
### 무엇을 위한 PR인가요? (: 뒤 설명 추가)

- 신규 기능 추가: 포스터 이미지 전용 Poster 컴포넌트

### 변경사항 및 이유 (bullet 으로 구분)
- 포스터 이미지를 통일된 UI로 출력하기 위한 전용 컴포넌트 신설
- size, border, shadow, className 등의 props를 통해 유연하게 대응 가능
- 추후 디자인 변경 시에도 sizeMap 또는 className을 통해 일관성 유지 및 빠른 대응 가능
- 이미지 최적화를 위해 next/image 기반으로 구현

### 작업 내역 (bullet 으로 구분)
- props:
  - `src`: 이미지 URL (필수)
  - `alt`: 대체 텍스트 (기본값: '포스터 이미지')
  - `size`: 'sm' | 'md' | 'lg' | 'xl' (기본값: 'md')
  - `shadow`: 그림자 적용 여부 (기본값: true)
  - `border`: 테두리 적용 여부 (기본값: true)
  - `className`: Tailwind 스타일 확장용 클래스
 - Tailwind 기반 sizeMap 정의
 - 기본 스타일: object-contain, shadow-md, border-gray-300, rounded-lg
 - 사용 예시:
```tsx
<Poster src="..." size="lg" shadow={false} border={false} className="rounded-xl" />
```

### ?작업 후 기대 동작(스크린샷)
- <Poster src="..." size="md" /> 형태로 여러 곳에서 재사용 가능
- size, border, shadow props를 조합하여 스타일 제어 가능
- 기본 비율은 실제 포스터(약 1:1.4 비율) 기반으로 설계됨
![image](https://github.com/user-attachments/assets/775523b9-2760-470b-a68c-a0ff8c1e8193)


### ?PR 특이 사항
- 포스터는 rounded는 필요없을것 같아서 제외
- 추가적으로 필요한 프롭스가 있으면 추가해보겠습니다.

### Issue Number

close: #36 