### PR TITLE
[Feature//issue-035] 해시태그 배지 컴포넌트 구현

### DIFF
--- a/src/components/Hashtag/HashtagBadge.tsx
+++ b/src/components/Hashtag/HashtagBadge.tsx
@@ -1,0 +1,53 @@
+'use client';
+import { cn } from '@/lib/utils';
+
+interface HashtagBadgeProps {
+  text: string; // 배지 내부에 들어갈 텍스트('#'여부는 페이지 내부에서 설정)
+  type: 'groupInfo' | 'groupCard' | 'userProfile';
+  canClick?: boolean; // 클릭 가능한 배지인지 확인
+  onClick?: () => void; // 배지 클릭 시 실행되는 함수
+  className?: string;
+}
+
+// 타입을 명확히 지정한 badgeStyles 객체
+const badgeStyles: Record<HashtagBadgeProps['type'], string> = {
+  groupInfo:
+    'bg-yellow-200 text-gray-800 py-2 px-4 rounded-full font-semibold cursor-pointer',
+  groupCard:
+    'bg-blue-100 text-blue-600 py-2 px-4 rounded-lg font-medium cursor-pointer',
+  userProfile:
+    'bg-purple-100 text-purple-600 py-2 px-4 rounded-lg font-semibold cursor-pointer',
+};
+
+const HashtagBadge = ({
+  text,
+  type,
+  canClick = false,
+  onClick,
+  className,
+}: HashtagBadgeProps) => {
+  const getBadgeStyle = () => badgeStyles[type]; // 타입별 스타일 반환
+
+  const handleClick = () => {
+    if (onClick) {
+      onClick();
+    }
+  };
+
+  const badgeClasses = cn(getBadgeStyle(), className);
+
+  return (
+    <span
+      className={badgeClasses}
+      onClick={() => {
+        if (canClick) {
+          handleClick();
+        }
+      }}
+    >
+      {text}
+    </span>
+  );
+};
+
+export default HashtagBadge;


### PR DESCRIPTION
### 무엇을 위한 PR인가요? (: 뒤 설명 추가)

- 신규 기능 추가: 해시태그 배지 컴포넌트 구현

### 변경사항 및 이유 (bullet 으로 구분)

- 모임 기본 정보 / 목록 카드 / 유저 프로필에서 공통적으로 사용할 수 있는 배지 스타일 구성

- 클릭 가능 여부를 canClick prop으로 제어하도록 설계

- 재사용 가능한 컴포넌트 구조로 확장성을 고려함

### 작업 내역 (bullet 으로 구분)

- HashtagBadge.tsx 컴포넌트 생성

- type에 따라 스타일 다르게 적용 (groupInfo, groupCard, userProfile)

- canClick에 따라 클릭 여부 제어(default false)

- text, onClick, className prop 지원

### ?작업 후 기대 동작(스크린샷)

- 클릭 가능한 배지는 커서가 포인터로 변경되고 클릭 시 onClick 실행

- 클릭 불가능한 배지는 커서가 기본이며 onClick 무시됨

https://github.com/user-attachments/assets/d5166d7f-c960-40d9-aea0-978b4a4b2be2



### ?PR 특이 사항

- 추후 디자인 시스템 또는 공통 UI 라이브러리에 포함 고려
