### PR TITLE
[Docs/issue-035] HashtagBadge 컴포넌트 README 작성

### DIFF
--- a/src/components/Hashtag/HashtagBadge.md
+++ b/src/components/Hashtag/HashtagBadge.md
@@ -1,0 +1,74 @@
+# 🏷️ HashtagBadge 컴포넌트
+
+공통적으로 사용 가능한 **해시태그 배지 UI 컴포넌트**입니다.  
+모임, 유저, 카드 등 다양한 맥락에서 스타일별로 구분된 태그를 보여줄 수 있으며, 클릭 이벤트도 지원합니다.
+
+---
+
+## 📦 사용법
+
+```tsx
+import HashtagBadge from '@/components/HashtagBadge';
+
+<HashtagBadge
+  type='groupCard'
+  isClickable={true}
+  onClick={() => {
+    console.log('모임 카드 클릭');
+  }}
+  text='#모임카드'
+/>;
+```
+
+## ✨ Props
+
+| 이름          | 타입                                              | 기본값  | 설명                                                        |
+| ------------- | ------------------------------------------------- | ------- | ----------------------------------------------------------- |
+| `text`        | `string`                                          | (필수)  | 배지 내부에 표시될 텍스트 (`#` 포함 여부는 호출부에서 조정) |
+| `type`        | `'groupInfo'` \| `'groupCard'` \| `'userProfile'` | (필수)  | 배지 스타일 유형                                            |
+| `isClickable` | `boolean`                                         | `false` | 클릭 가능한 배지인지 여부                                   |
+| `onClick`     | `() => void`                                      | -       | 클릭 가능 시 실행되는 이벤트 핸들러                         |
+| `className`   | `string`                                          | -       | 사용자 정의 Tailwind 클래스 (스타일 덮어쓰기 또는 확장용)   |
+
+## 🎨 스타일 가이드 (Tailwind CSS 기준)
+
+- 공통 클래스
+
+  - cursor-pointer, px-4 py-2, select-none
+
+- type별 스타일
+
+  - groupInfo: bg-yellow-200 text-gray-800, rounded-full, font-semibold
+
+  - groupCard: bg-blue-100 text-blue-600, rounded-lg, font-medium
+
+  - userProfile: bg-purple-100 text-purple-600, rounded-lg, font-semibold
+
+- className 병합
+
+  - cn() 유틸을 사용하여 스타일에 병합 적용됨
+
+## ✅ 테스트 정보
+
+> 테스트 도구: jest, @testing-library/react
+
+| 테스트 항목                | 설명                                                       |
+| -------------------------- | ---------------------------------------------------------- |
+| 렌더링 테스트              | `text`가 화면에 정상적으로 표시되는지 확인                 |
+| 스타일 클래스 적용 테스트  | `type` 값에 따라 올바른 클래스가 적용되는지 테스트         |
+| className 병합 테스트      | 사용자 정의 클래스가 병합 적용되는지 확인                  |
+| onClick 핸들러 호출 테스트 | 클릭 시 핸들러가 호출되는지 (`isClickable`가 true일 때)    |
+| 클릭 무효화 테스트         | `isClickable = false`일 때 클릭해도 핸들러가 호출되지 않음 |
+| 핸들러 미전달 테스트       | `onClick`이 전달되지 않아도 에러 없이 작동하는지 확인      |
+
+## 🧠 Todo
+
+- 디자인 확정 후 Tailwind 클래스 리팩토링 예정
+
+## 📁 파일 구조
+
+```
+/components/HashtagBadge
+  ├── HashtagBadge.tsx
+  └── HashtagBadge.test.tsx
+```

--- a/src/components/Hashtag/HashtagBadge.tsx
+++ b/src/components/Hashtag/HashtagBadge.tsx
@@ -4,7 +4,7 @@ import { cn } from '@/lib/utils';
 interface HashtagBadgeProps {
   text: string; // 배지 내부에 들어갈 텍스트('#'여부는 페이지 내부에서 설정)
   type: 'groupInfo' | 'groupCard' | 'userProfile';
-  canClick?: boolean; // 클릭 가능한 배지인지 확인
+  isClickable?: boolean; // 클릭 가능한 배지인지 확인
   onClick?: () => void; // 배지 클릭 시 실행되는 함수
   className?: string;
 }
@@ -22,7 +22,7 @@ const badgeStyles: Record<HashtagBadgeProps['type'], string> = {
 const HashtagBadge = ({
   text,
   type,
-  canClick = false,
+  isClickable = false,
   onClick,
   className,
 }: HashtagBadgeProps) => {
@@ -40,7 +40,7 @@ const HashtagBadge = ({
     <span
       className={badgeClasses}
       onClick={() => {
-        if (canClick) {
+        if (isClickable) {
           handleClick();
         }
       }}

--- a/src/components/Hashtag/HashtagBadge.tsx
+++ b/src/components/Hashtag/HashtagBadge.tsx
@@ -1,0 +1,53 @@
+'use client';
+import { cn } from '@/lib/utils';
+
+interface HashtagBadgeProps {
+  text: string; // 배지 내부에 들어갈 텍스트('#'여부는 페이지 내부에서 설정)
+  type: 'groupInfo' | 'groupCard' | 'userProfile';
+  canClick?: boolean; // 클릭 가능한 배지인지 확인
+  onClick?: () => void; // 배지 클릭 시 실행되는 함수
+  className?: string;
+}
+
+// 타입을 명확히 지정한 badgeStyles 객체
+const badgeStyles: Record<HashtagBadgeProps['type'], string> = {
+  groupInfo:
+    'bg-yellow-200 text-gray-800 py-2 px-4 rounded-full font-semibold cursor-pointer',
+  groupCard:
+    'bg-blue-100 text-blue-600 py-2 px-4 rounded-lg font-medium cursor-pointer',
+  userProfile:
+    'bg-purple-100 text-purple-600 py-2 px-4 rounded-lg font-semibold cursor-pointer',
+};
+
+const HashtagBadge = ({
+  text,
+  type,
+  canClick = false,
+  onClick,
+  className,
+}: HashtagBadgeProps) => {
+  const getBadgeStyle = () => badgeStyles[type]; // 타입별 스타일 반환
+
+  const handleClick = () => {
+    if (onClick) {
+      onClick();
+    }
+  };
+
+  const badgeClasses = cn(getBadgeStyle(), className);
+
+  return (
+    <span
+      className={badgeClasses}
+      onClick={() => {
+        if (canClick) {
+          handleClick();
+        }
+      }}
+    >
+      {text}
+    </span>
+  );
+};
+
+export default HashtagBadge;

--- a/src/components/Hashtag/HashtagBadge.tsx
+++ b/src/components/Hashtag/HashtagBadge.tsx
@@ -9,14 +9,13 @@ interface HashtagBadgeProps {
   className?: string;
 }
 
-// 타입을 명확히 지정한 badgeStyles 객체
 const badgeStyles: Record<HashtagBadgeProps['type'], string> = {
   groupInfo:
-    'bg-yellow-200 text-gray-800 py-2 px-4 rounded-full font-semibold cursor-pointer',
+    'cursor-pointer rounded-full bg-yellow-200 px-4 py-2 font-semibold text-gray-800 select-none',
   groupCard:
-    'bg-blue-100 text-blue-600 py-2 px-4 rounded-lg font-medium cursor-pointer',
+    'cursor-pointer rounded-lg bg-blue-100 px-4 py-2 font-medium text-blue-600 select-none',
   userProfile:
-    'bg-purple-100 text-purple-600 py-2 px-4 rounded-lg font-semibold cursor-pointer',
+    'cursor-pointer rounded-lg bg-purple-100 px-4 py-2 font-semibold text-purple-600 select-none',
 };
 
 const HashtagBadge = ({
@@ -26,10 +25,10 @@ const HashtagBadge = ({
   onClick,
   className,
 }: HashtagBadgeProps) => {
-  const getBadgeStyle = () => badgeStyles[type]; // 타입별 스타일 반환
+  const getBadgeStyle = () => badgeStyles[type];
 
   const handleClick = () => {
-    if (onClick) {
+    if (isClickable && onClick) {
       onClick();
     }
   };
@@ -39,11 +38,7 @@ const HashtagBadge = ({
   return (
     <span
       className={badgeClasses}
-      onClick={() => {
-        if (isClickable) {
-          handleClick();
-        }
-      }}
+      onClick={handleClick}
     >
       {text}
     </span>


### PR DESCRIPTION
### 무엇을 위한 PR인가요? (: 뒤 설명 추가)

문서 업데이트: HashtagBadge 컴포넌트에 대한 마크다운 문서(HashtagBadge.md) 추가

### 변경사항 및 이유 (bullet 으로 구분)

- 공통 UI 컴포넌트의 사용 방법과 props 정보를 문서로 정리하여 개발자 간 협업 효율 향상

- 테스트 정보, 스타일 가이드 등 추가 설명을 통해 재사용성과 유지보수성 개선

### 작업 내역 (bullet 으로 구분)

- docs/HashtagBadge.md 마크다운 문서 생성

- props 설명, 사용 예시, 스타일 가이드, 테스트 정보 작성

- Todo 항목과 파일 구조 등 개발 참고 정보 포함
