### PR TITLE
[Feature/issue-035] HashtagBadge 컴포넌트 구현 및 테스트, 문서

### DIFF
--- a/src/components/Hashtag/HashtagBadge.md
+++ b/src/components/Hashtag/HashtagBadge.md
@@ -1,0 +1,74 @@
+# 🏷️ HashtagBadge 컴포넌트
+
+공통적으로 사용 가능한 **해시태그 배지 UI 컴포넌트**입니다.  
+모임, 유저, 카드 등 다양한 맥락에서 스타일별로 구분된 태그를 보여줄 수 있으며, 클릭 이벤트도 지원합니다.
+
+---
+
+## 📦 사용법
+
+```tsx
+import HashtagBadge from '@/components/HashtagBadge';
+
+<HashtagBadge
+  type='groupCard'
+  isClickable={true}
+  onClick={() => {
+    console.log('모임 카드 클릭');
+  }}
+  text='#모임카드'
+/>;
+```
+
+## ✨ Props
+
+| 이름          | 타입                                              | 기본값  | 설명                                                        |
+| ------------- | ------------------------------------------------- | ------- | ----------------------------------------------------------- |
+| `text`        | `string`                                          | (필수)  | 배지 내부에 표시될 텍스트 (`#` 포함 여부는 호출부에서 조정) |
+| `type`        | `'groupInfo'` \| `'groupCard'` \| `'userProfile'` | (필수)  | 배지 스타일 유형                                            |
+| `isClickable` | `boolean`                                         | `false` | 클릭 가능한 배지인지 여부                                   |
+| `onClick`     | `() => void`                                      | -       | 클릭 가능 시 실행되는 이벤트 핸들러                         |
+| `className`   | `string`                                          | -       | 사용자 정의 Tailwind 클래스 (스타일 덮어쓰기 또는 확장용)   |
+
+## 🎨 스타일 가이드 (Tailwind CSS 기준)
+
+- 공통 클래스
+
+  - cursor-pointer, px-4 py-2, select-none
+
+- type별 스타일
+
+  - groupInfo: bg-yellow-200 text-gray-800, rounded-full, font-semibold
+
+  - groupCard: bg-blue-100 text-blue-600, rounded-lg, font-medium
+
+  - userProfile: bg-purple-100 text-purple-600, rounded-lg, font-semibold
+
+- className 병합
+
+  - cn() 유틸을 사용하여 스타일에 병합 적용됨
+
+## ✅ 테스트 정보
+
+> 테스트 도구: jest, @testing-library/react
+
+| 테스트 항목                | 설명                                                       |
+| -------------------------- | ---------------------------------------------------------- |
+| 렌더링 테스트              | `text`가 화면에 정상적으로 표시되는지 확인                 |
+| 스타일 클래스 적용 테스트  | `type` 값에 따라 올바른 클래스가 적용되는지 테스트         |
+| className 병합 테스트      | 사용자 정의 클래스가 병합 적용되는지 확인                  |
+| onClick 핸들러 호출 테스트 | 클릭 시 핸들러가 호출되는지 (`isClickable`가 true일 때)    |
+| 클릭 무효화 테스트         | `isClickable = false`일 때 클릭해도 핸들러가 호출되지 않음 |
+| 핸들러 미전달 테스트       | `onClick`이 전달되지 않아도 에러 없이 작동하는지 확인      |
+
+## 🧠 Todo
+
+- 디자인 확정 후 Tailwind 클래스 리팩토링 예정
+
+## 📁 파일 구조
+
+```
+/components/HashtagBadge
+  ├── HashtagBadge.tsx
+  └── HashtagBadge.test.tsx
+```

--- a/src/components/Hashtag/HashtagBadge.test.tsx
+++ b/src/components/Hashtag/HashtagBadge.test.tsx
@@ -1,0 +1,107 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import HashtagBadge from './HashtagBadge';
+
+describe('HashtagBadge 컴포넌트 테스트', () => {
+  test('배지 및 text가 화면에 정상적으로 렌더링된다', () => {
+    render(
+      <HashtagBadge
+        text='펜타포트'
+        type='userProfile'
+      />
+    );
+    const badge = screen.getByText('펜타포트');
+    expect(badge).toBeInTheDocument();
+  });
+
+  //   Todo: 스타일 변경에 따른 리팩토링 필요
+  test('type props에 따라 올바른 클래스가 적용된다', () => {
+    render(
+      <>
+        <HashtagBadge
+          text='groupInfo'
+          type='groupInfo'
+        />
+        <HashtagBadge
+          text='groupCard'
+          type='groupCard'
+        />
+        <HashtagBadge
+          text='userProfile'
+          type='userProfile'
+        />
+      </>
+    );
+    const groupInfo = screen.getByText('groupInfo');
+    const groupCard = screen.getByText('groupCard');
+    const userProfile = screen.getByText('userProfile');
+    expect(groupInfo).toBeInTheDocument();
+    expect(groupCard).toBeInTheDocument();
+    expect(userProfile).toBeInTheDocument();
+    expect(groupInfo).toHaveClass(
+      'cursor-pointer rounded-full bg-yellow-200 px-4 py-2 font-semibold text-gray-800 select-none'
+    );
+    expect(groupCard).toHaveClass(
+      'cursor-pointer rounded-lg bg-blue-100 px-4 py-2 font-medium text-blue-600 select-none'
+    );
+    expect(userProfile).toHaveClass(
+      'cursor-pointer rounded-lg bg-purple-100 px-4 py-2 font-semibold text-purple-600 select-none'
+    );
+  });
+
+  test('className props를 할당했을 때 올바른 클래스가 적용된다', () => {
+    render(
+      <HashtagBadge
+        text='펜타포트'
+        type='userProfile'
+        className='font-extrabold'
+      />
+    );
+    const badge = screen.getByText('펜타포트');
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveClass('font-extrabold');
+  });
+
+  test('배지 클릭 시 onClick 핸들러가 호출된다', () => {
+    const handleClick = jest.fn();
+    render(
+      <HashtagBadge
+        text='클릭'
+        type='groupInfo'
+        isClickable={true}
+        onClick={handleClick}
+      />
+    );
+    const badge = screen.getByText('클릭');
+    fireEvent.click(badge);
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('isClickable = false일 때 onClick이 실행되지 않는다', () => {
+    const handleClick = jest.fn();
+    render(
+      <HashtagBadge
+        text='클릭'
+        type='groupInfo'
+        isClickable={false}
+        onClick={handleClick}
+      />
+    );
+    const badge = screen.getByText('클릭');
+    fireEvent.click(badge);
+    expect(handleClick).toHaveBeenCalledTimes(0);
+  });
+
+  test('onClick props를 할당하지 않으면 isClickable = true여도 onClick이 실행되지 않는다', () => {
+    const handleClick = jest.fn();
+    render(
+      <HashtagBadge
+        text='클릭'
+        type='groupInfo'
+        isClickable={true}
+      />
+    );
+    const badge = screen.getByText('클릭');
+    fireEvent.click(badge);
+    expect(handleClick).toHaveBeenCalledTimes(0);
+  });
+});

--- a/src/components/Hashtag/HashtagBadge.tsx
+++ b/src/components/Hashtag/HashtagBadge.tsx
@@ -1,0 +1,48 @@
+'use client';
+import { cn } from '@/lib/utils';
+
+interface HashtagBadgeProps {
+  text: string; // 배지 내부에 들어갈 텍스트('#'여부는 페이지 내부에서 설정)
+  type: 'groupInfo' | 'groupCard' | 'userProfile';
+  isClickable?: boolean; // 클릭 가능한 배지인지 확인
+  onClick?: () => void; // 배지 클릭 시 실행되는 함수
+  className?: string;
+}
+
+const badgeStyles: Record<HashtagBadgeProps['type'], string> = {
+  groupInfo:
+    'cursor-pointer rounded-full bg-yellow-200 px-4 py-2 font-semibold text-gray-800 select-none',
+  groupCard:
+    'cursor-pointer rounded-lg bg-blue-100 px-4 py-2 font-medium text-blue-600 select-none',
+  userProfile:
+    'cursor-pointer rounded-lg bg-purple-100 px-4 py-2 font-semibold text-purple-600 select-none',
+};
+
+const HashtagBadge = ({
+  text,
+  type,
+  isClickable = false,
+  onClick,
+  className,
+}: HashtagBadgeProps) => {
+  const getBadgeStyle = () => badgeStyles[type];
+
+  const handleClick = () => {
+    if (isClickable && onClick) {
+      onClick();
+    }
+  };
+
+  const badgeClasses = cn(getBadgeStyle(), className);
+
+  return (
+    <span
+      className={badgeClasses}
+      onClick={handleClick}
+    >
+      {text}
+    </span>
+  );
+};
+
+export default HashtagBadge;

--- a/src/components/Hashtag/HashtagBadge.tsx
+++ b/src/components/Hashtag/HashtagBadge.tsx
@@ -13,7 +13,7 @@ const badgeStyles: Record<HashtagBadgeProps['type'], string> = {
   groupInfo:
     'cursor-pointer rounded-full bg-yellow-200 px-4 py-2 font-semibold text-gray-800 select-none',
   groupCard:
-    'cursor-pointer rounded-lg bg-blue-100 px-4 py-2 font-medium text-blue-600 select-none',
+    'max-w-40 overflow-hidden text-ellipsis whitespace-nowrap cursor-pointer rounded-lg bg-blue-100 px-4 py-2 font-medium text-blue-600 select-none',
   userProfile:
     'cursor-pointer rounded-lg bg-purple-100 px-4 py-2 font-semibold text-purple-600 select-none',
 };


### PR DESCRIPTION
### 무엇을 위한 PR인가요? (: 뒤 설명 추가)

- 기타: 해시태그 base를 develop에 스쿼시 머지

### 변경사항 및 이유 (bullet 으로 구분)

해시태그 base를 develop에 스쿼시 머지

### 작업 내역 (bullet 으로 구분)

- feat: 해시태그 배지 컴포넌트 구현

- chore: props canClick을 isClickable으로 변경

- refactor: 인라인 함수 제거, select-none 추가

- [Docs/issue-035] HashtagBadge 컴포넌트 README 작성 (#80)

- [Test/issue-035] HashtagBadge 컴포넌트 테스트 코드 작성 (#79)

### 특이사항

text-ellipsis 글자수 초과시 ... 줄여서 표시 기능 추가

### Issue Number

close: #35