### PR TITLE
[Feature/issue-068] Modal 컴포넌트 구현 및 테스트 코드 작성, 문서화, Portal컴포넌트 구현 및 테스트 코드 작성

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/jest": "^29.5.14",
         "@types/node": "^20",
         "@types/react": "^19.1.4",
@@ -3144,6 +3145,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tootallnate/once": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "test": "jest",
-    "test:watch":"jest --watch",
+    "test:watch": "jest --watch",
     "prepare": "husky"
   },
   "dependencies": {
@@ -35,6 +35,7 @@
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^29.5.14",
     "@types/node": "^20",
     "@types/react": "^19.1.4",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,6 +12,7 @@ const RootLayout = ({
 }>) => (
   <html lang='ko'>
     <body>
+      <div id='portal' />
       <MSWComponent>
         <QueryProvider>{children}</QueryProvider>
       </MSWComponent>

--- a/src/components/Modal/Modal.md
+++ b/src/components/Modal/Modal.md
@@ -1,0 +1,101 @@
+# NavLink 컴포넌트
+
+재사용 가능한 커스텀 Modal 컴포넌트입니다. 다양한 서브 컴포넌트를 제공하여 유연한 모달 UI 구성이 가능합니다. Context API를 기반으로 하여 모달 상태를 전역에서 관리할 수 있습니다.
+
+---
+
+## 주요 기능
+
+- 모달 열기/닫기 상태를 Context로 관리
+- `<ModalTrigger />`, `<ModalContent />`, `<ModalClose />`, `<ModalAction />`, `<ModalCancel />` 등 분리된 서브 컴포넌트 제공
+- `backdrop` 클릭으로 닫기 허용/비허용 설정 가능
+- `Portal`을 사용한 모달 렌더링
+- 모달 외부 클릭 감지
+
+---
+
+## 컴포넌트 구조
+
+### `<Modal />`
+
+모달의 상태를 관리하고 context를 제공한다.
+
+| 이름                   | 타입                        | 설명                         |
+| ---------------------- | --------------------------- | ---------------------------- |
+| `defaultOpen`          | `boolean` (기본값: `false`) | 초기 열림 상태 여부          |
+| `disableBackdropClose` | `boolean` (기본값: `false`) | 바깥 영역 클릭 시 닫기 방지  |
+| `onClose`              | `() => void` (선택)         | 모달이 닫힐 때 실행되는 콜백 |
+| `children`             | `React.ReactNode` (선택)    | Modal 내부에 렌더링할 콘텐츠 |
+
+### `<ModalTrigger />`
+
+모달을 열기 위한 트리거 버튼을 감싸는 컴포넌트
+
+| 이름        | 타입                             | 설명                                                                                                                      |
+| ----------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `children`  | `ReactNode` (기본값: `<button>`) | 클릭 가능한 요소로 기본값은 `<button>{children}</button>`이며, `ReactElement`타입이 올 경우 감싸는 `<button>`이 제거된다. |
+| `className` | `string` (선택)                  | 트리거 스타일                                                                                                             |
+
+### `<ModalContent />`
+
+모달의 실제 내용을 감싸는 컴포넌트
+Portal을 이용해 body 바깥으로 렌더링되며, `<dialog>` 요소를 사용한다.
+
+| 이름        | 타입            | 설명           |
+| ----------- | --------------- | -------------- |
+| `children`  | `ReactNode`     | 모달 본문 내용 |
+| `className` | `string` (선택) | 모달의 스타일  |
+
+### `<ModalClose />`
+
+모달을 닫는 용도의 닫기 버튼
+자식이 ReactElement일 경우 onClick에 closeModal()이 자동으로 추가됩니다.
+
+| 이름        | 타입            | 설명                        |
+| ----------- | --------------- | --------------------------- |
+| `children`  | `ReactNode`     | 닫기 아이콘 또는 버튼       |
+| `className` | `string` (선택) | 위치 및 스타일 커스터마이징 |
+
+### `<ModalAction />`
+
+모달 내 "확인", "제출" 등의 액션 버튼
+onClick 실행 이후 자동으로 모달이 닫히며, 비동기 함수도 지원됩니다.
+
+| 이름        | 타입               | 설명                     |
+| ----------- | ------------------ | ------------------------ |
+| `onClick`   | `(e) => void`      | 버튼 클릭 시 실행할 로직 |
+| `children`  | `ReactNode` (선택) | 버튼의 children          |
+| `className` | `string` (선택)    | 스타일 커스터마이징      |
+
+### `<ModalCancel />`
+
+모달 내 "취소" 버튼으로 사용
+항상 모달을 닫으며, onClick은 먼저 실행됩니다.
+
+| 이름        | 타입               | 설명                     |
+| ----------- | ------------------ | ------------------------ |
+| `onClick`   | `(e) => void`      | 버튼 클릭 시 실행할 로직 |
+| `children`  | `ReactNode` (선택) | 버튼의 children          |
+| `className` | `string` (선택)    | 스타일 커스터마이징      |
+
+---
+
+## 사용 예시
+
+```tsx
+<Modal>
+  <ModalTrigger>
+    <button>모달 열기</button>
+  </ModalTrigger>
+
+  <ModalContent className='rounded-md bg-white p-4'>
+    <h2 className='text-lg font-bold'>모달 제목</h2>
+    <p>모달 내용입니다.</p>
+    <div className='mt-4 flex justify-end gap-2'>
+      <ModalCancel className='text-gray-500'>취소</ModalCancel>
+      <ModalAction className='text-blue-500'>확인</ModalAction>
+    </div>
+    <ModalClose />
+  </ModalContent>
+</Modal>
+```

--- a/src/components/Modal/Modal.test.tsx
+++ b/src/components/Modal/Modal.test.tsx
@@ -254,4 +254,18 @@ describe('<Modal>컴포넌트 테스트', () => {
     expect(onCloseMock).toHaveBeenCalled();
     expect(closeModalMock).toHaveBeenCalled();
   });
+
+  test('disableBackdropClose가 true일 경우 esc로 닫을 수 없다', async () => {
+    render(
+      <Modal
+        defaultOpen
+        disableBackdropClose
+      >
+        <ModalContent>콘텐츠</ModalContent>
+      </Modal>
+    );
+
+    await userEvent.keyboard('{Escape}');
+    expect(screen.queryByText('콘텐츠')).toBeInTheDocument();
+  });
 });

--- a/src/components/Modal/Modal.test.tsx
+++ b/src/components/Modal/Modal.test.tsx
@@ -1,0 +1,257 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Modal from './Modal';
+import ModalClose from './ModalClose';
+import ModalContent from './ModalContent';
+import { ModalContext } from './ModalContext';
+import ModalTrigger from './ModalTrigger';
+
+describe('<Modal>컴포넌트 테스트', () => {
+  beforeAll(() => {
+    if (!HTMLDialogElement.prototype.showModal) {
+      HTMLDialogElement.prototype.showModal = function () {
+        this.open = true;
+      };
+    }
+
+    if (!HTMLDialogElement.prototype.close) {
+      HTMLDialogElement.prototype.close = function () {
+        this.open = false;
+      };
+    }
+
+    const portal = document.createElement('div');
+    portal.setAttribute('id', 'portal');
+    document.body.appendChild(portal);
+  });
+
+  afterAll(() => {
+    const portal = document.getElementById('portal');
+    if (portal) {
+      document.body.removeChild(portal);
+    }
+  });
+
+  test('defaultOpen을 설정하지 않은 경우 초기에 닫힌 상태여야 한다', () => {
+    render(
+      <Modal>
+        <ModalTrigger>열기</ModalTrigger>
+        <ModalContent>내용</ModalContent>
+      </Modal>
+    );
+
+    const content = screen.queryByText('내용');
+    expect(content).not.toBeInTheDocument();
+  });
+
+  test('defaultOpen을 true로 설정한 경우 초기에 열린 상태여야 한다.', () => {
+    render(
+      <Modal defaultOpen>
+        <ModalTrigger>열기</ModalTrigger>
+        <ModalContent>내용</ModalContent>
+      </Modal>
+    );
+
+    const content = screen.getByText('내용');
+    expect(content).toBeInTheDocument();
+  });
+
+  test('<ModalTrigger> chilren에 ReactElement가 아닌 것이 들어오면 <button>으로 감싸져야 하며, 클릭시 열려야 한다.', async () => {
+    render(
+      <Modal defaultOpen>
+        <ModalTrigger>열기</ModalTrigger>
+        <ModalContent>내용</ModalContent>
+      </Modal>
+    );
+
+    const triggerButton = screen.getByRole('button', { name: '모달 열기' });
+    expect(triggerButton).toBeInTheDocument();
+    expect(triggerButton).toHaveTextContent('열기');
+
+    await userEvent.click(triggerButton);
+    const content = screen.getByText('내용');
+    expect(content).toBeInTheDocument();
+    expect(content).toHaveTextContent('내용');
+  });
+
+  test('<ModalTrigger> chilren에 ReactElement가 들어오면 <button>으로 감싸지지 않아야 하며, 클릭시 모달이 열려야 한다.', async () => {
+    const mockFn = jest.fn();
+    render(
+      <Modal defaultOpen>
+        <ModalTrigger>
+          <div onClick={mockFn}>열기</div>
+        </ModalTrigger>
+        <ModalContent>내용</ModalContent>
+      </Modal>
+    );
+
+    const triggerButton = screen.queryByRole('button', { name: '모달 열기' });
+    expect(triggerButton).not.toBeInTheDocument();
+
+    const triggerDiv = screen.getByLabelText('모달 열기');
+    expect(triggerDiv).toBeInTheDocument();
+    expect(triggerDiv).toHaveTextContent('열기');
+
+    await userEvent.click(triggerDiv);
+    const content = screen.getByText('내용');
+    expect(content).toBeInTheDocument();
+    expect(content).toHaveTextContent('내용');
+    expect(mockFn).toHaveBeenCalled();
+  });
+
+  test('open 상태에 따라 showModal/close 호출', async () => {
+    render(
+      <Modal>
+        <ModalTrigger>열기</ModalTrigger>
+        <ModalContent>
+          내용
+          <ModalClose />
+        </ModalContent>
+      </Modal>
+    );
+
+    const triggerButton = screen.getByRole('button', { name: '모달 열기' });
+    await userEvent.click(triggerButton);
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toBeInTheDocument();
+
+    const closeButton = screen.getByLabelText('모달 닫기');
+    await userEvent.click(closeButton);
+
+    expect(dialog).not.toBeInTheDocument();
+  });
+
+  test('disableBackdropClose가 false면 배경 클릭시 dialog.close 호출됨', async () => {
+    const closeMock = jest.fn();
+    HTMLDialogElement.prototype.close = closeMock;
+
+    render(
+      <Modal
+        disableBackdropClose={false}
+        defaultOpen
+      >
+        <ModalContent>내용</ModalContent>
+      </Modal>
+    );
+
+    const dialog = screen.getByRole('dialog');
+    await userEvent.click(dialog);
+
+    expect(closeMock).toHaveBeenCalled();
+  });
+
+  test('disableBackdropClose가 true면 배경 클릭시 dialog.close 무시됨', async () => {
+    const closeMock = jest.fn();
+    HTMLDialogElement.prototype.close = closeMock;
+
+    render(
+      <Modal
+        disableBackdropClose
+        defaultOpen
+      >
+        <ModalContent>내용</ModalContent>
+      </Modal>
+    );
+
+    const dialog = screen.getByRole('dialog');
+    await userEvent.click(dialog);
+
+    expect(closeMock).not.toHaveBeenCalled();
+  });
+
+  test('ModalClose 클릭 시 모달이 닫힌다', async () => {
+    render(
+      <Modal defaultOpen>
+        <ModalContent>
+          <div>내용</div>
+          <ModalClose />
+        </ModalContent>
+      </Modal>
+    );
+
+    const closeButton = screen.getByLabelText('모달 닫기');
+    await userEvent.click(closeButton);
+
+    await waitFor(() => {
+      expect(screen.queryByText('내용')).not.toBeInTheDocument();
+    });
+  });
+
+  test('<ModalClose> chilren에 ReactElement가 들어오면 <button>으로 감싸지지 않아야 하며, 클릭시 모달이 닫혀야 한다.', async () => {
+    const mockFn = jest.fn();
+    render(
+      <Modal defaultOpen>
+        <ModalTrigger>열기</ModalTrigger>
+        <ModalContent>
+          내용
+          <ModalClose>
+            <div onClick={mockFn}>닫기</div>
+          </ModalClose>
+        </ModalContent>
+      </Modal>
+    );
+
+    const triggerButton = screen.queryByRole('button', { name: '모달 닫기' });
+    expect(triggerButton).not.toBeInTheDocument();
+
+    const triggerDiv = screen.getByLabelText('모달 닫기');
+    expect(triggerDiv).toBeInTheDocument();
+    expect(triggerDiv).toHaveTextContent('닫기');
+
+    await userEvent.click(triggerDiv);
+    const content = screen.queryByText('내용');
+    expect(content).not.toBeInTheDocument();
+    expect(mockFn).toHaveBeenCalled();
+  });
+
+  test('children이 ReactElement이면 cloneElement로 감싼다', () => {
+    const Child = () => <p>리액트 엘리먼트</p>;
+
+    render(
+      <Modal defaultOpen>
+        <ModalContent>
+          <Child />
+        </ModalContent>
+      </Modal>
+    );
+
+    expect(screen.getByText('리액트 엘리먼트')).toBeInTheDocument();
+  });
+
+  test('<Modal>과 관련된 컴포넌트를 단독으로 사용시 에러가 발생해야 한다.', () => {
+    expect(() => {
+      render(<ModalContent>콘텐츠</ModalContent>);
+    }).toThrow(
+      '<Modal>과 관련된 컴포넌트는 <Modal>컴포넌트 내부에서만 사용해야합니다!'
+    );
+  });
+
+  test('handleClose 호출 시 onClose와 closeModal이 호출되어야 한다', () => {
+    const onCloseMock = jest.fn();
+    const closeModalMock = jest.fn();
+
+    render(
+      <ModalContext.Provider
+        value={{
+          open: true,
+          openModal: jest.fn(),
+          closeModal: closeModalMock,
+          onClose: onCloseMock,
+          disableBackdropClose: false,
+        }}
+      >
+        <ModalContent>테스트</ModalContent>
+      </ModalContext.Provider>
+    );
+
+    const dialog = document.querySelector('dialog')!;
+    dialog.close();
+
+    const event = new Event('close');
+    dialog.dispatchEvent(event);
+
+    expect(onCloseMock).toHaveBeenCalled();
+    expect(closeModalMock).toHaveBeenCalled();
+  });
+});

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -5,11 +5,13 @@ import { ModalContext } from './ModalContext';
 
 interface ModalProps {
   defaultOpen?: boolean;
+  disableBackdropClose?: boolean;
   onClose?: () => void;
 }
 
 const Modal = ({
   defaultOpen = false,
+  disableBackdropClose = false,
   onClose,
   children,
 }: PropsWithChildren<ModalProps>) => {
@@ -21,6 +23,7 @@ const Modal = ({
 
   const ModalValue = {
     open,
+    disableBackdropClose,
     openModal,
     closeModal,
     onClose,

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -3,15 +3,27 @@
 import { PropsWithChildren, useState } from 'react';
 import { ModalContext } from './ModalContext';
 
-const Modal = ({ children }: PropsWithChildren) => {
-  const [open, setOpen] = useState(false);
+interface ModalProps {
+  defaultOpen?: boolean;
+  onClose?: () => void;
+}
+
+const Modal = ({
+  defaultOpen = false,
+  onClose,
+  children,
+}: PropsWithChildren<ModalProps>) => {
+  const [open, setOpen] = useState(defaultOpen);
   const openModal = () => setOpen(true);
-  const closeModal = () => setOpen(false);
+  const closeModal = () => {
+    setOpen(false);
+  };
 
   const ModalValue = {
     open,
     openModal,
     closeModal,
+    onClose,
   };
 
   return <ModalContext value={ModalValue}>{children}</ModalContext>;

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { PropsWithChildren, useState } from 'react';
+import { ModalContext } from './ModalContext';
+
+const Modal = ({ children }: PropsWithChildren) => {
+  const [open, setOpen] = useState(false);
+  const openModal = () => setOpen(true);
+  const closeModal = () => setOpen(false);
+
+  const ModalValue = {
+    open,
+    openModal,
+    closeModal,
+  };
+
+  return <ModalContext value={ModalValue}>{children}</ModalContext>;
+};
+
+export default Modal;

--- a/src/components/Modal/ModalAction.tsx
+++ b/src/components/Modal/ModalAction.tsx
@@ -1,0 +1,33 @@
+import React, {
+  ButtonHTMLAttributes,
+  MouseEvent,
+  PropsWithChildren,
+} from 'react';
+import { cn } from '@/lib/utils';
+import { useModalContext } from './ModalContext';
+
+const ModalAction = ({
+  className,
+  children,
+  onClick,
+  ...props
+}: PropsWithChildren<ButtonHTMLAttributes<HTMLButtonElement>>) => {
+  const { closeModal } = useModalContext();
+  const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
+    const result = onClick?.(e);
+    Promise.resolve(result).then(() => closeModal());
+  };
+
+  return (
+    <button
+      className={cn('cursor-pointer', className)}
+      aria-label='모달 제출'
+      onClick={handleClick}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default ModalAction;

--- a/src/components/Modal/ModalCancel.tsx
+++ b/src/components/Modal/ModalCancel.tsx
@@ -1,0 +1,33 @@
+import React, {
+  ButtonHTMLAttributes,
+  MouseEvent,
+  PropsWithChildren,
+} from 'react';
+import { cn } from '@/lib/utils';
+import { useModalContext } from './ModalContext';
+
+const ModalCancel = ({
+  className,
+  children,
+  onClick,
+  ...props
+}: PropsWithChildren<ButtonHTMLAttributes<HTMLButtonElement>>) => {
+  const { closeModal } = useModalContext();
+  const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
+    onClick?.(e);
+    closeModal();
+  };
+
+  return (
+    <button
+      className={cn('cursor-pointer', className)}
+      aria-label='모달 취소'
+      onClick={handleClick}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default ModalCancel;

--- a/src/components/Modal/ModalClose.tsx
+++ b/src/components/Modal/ModalClose.tsx
@@ -24,6 +24,7 @@ const ModalClose = ({
     const child = children as ReactElement<any>;
 
     return cloneElement(child, {
+      'aria-label': '모달 닫기',
       onClick: (e: MouseEvent) => {
         child.props.onClick?.(e);
         closeModal();
@@ -42,6 +43,7 @@ const ModalClose = ({
         className
       )}
       onClick={closeModal}
+      aria-label='모달 닫기'
     >
       <XIcon className='h-4 w-4' />
     </button>

--- a/src/components/Modal/ModalClose.tsx
+++ b/src/components/Modal/ModalClose.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import {
+  cloneElement,
+  isValidElement,
+  PropsWithChildren,
+  ReactElement,
+} from 'react';
+import { XIcon } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useModalContext } from './ModalContext';
+
+interface ModalCloseProps {
+  className?: string;
+}
+
+const ModalClose = ({
+  className,
+  children,
+}: PropsWithChildren<ModalCloseProps>) => {
+  const { closeModal } = useModalContext();
+
+  if (isValidElement(children)) {
+    const child = children as ReactElement<any>;
+
+    return cloneElement(child, {
+      onClick: (e: MouseEvent) => {
+        child.props.onClick?.(e);
+        closeModal();
+      },
+      className: cn(
+        'absolute top-2 right-2 h-fit w-fit cursor-pointer',
+        child.props.className
+      ),
+    });
+  }
+
+  return (
+    <button
+      className={cn(
+        'absolute top-2 right-2 h-fit w-fit cursor-pointer',
+        className
+      )}
+      onClick={closeModal}
+    >
+      <XIcon className='h-4 w-4' />
+    </button>
+  );
+};
+
+export default ModalClose;

--- a/src/components/Modal/ModalContent.tsx
+++ b/src/components/Modal/ModalContent.tsx
@@ -53,6 +53,7 @@ const ModalContent = ({
         className
       )}
       onClose={closeModal}
+      aria-modal='true'
     >
       {isValidElement(children) ? (
         cloneElement(children)

--- a/src/components/Modal/ModalContent.tsx
+++ b/src/components/Modal/ModalContent.tsx
@@ -7,6 +7,7 @@ import React, {
   useRef,
 } from 'react';
 import { cn } from '@/lib/utils';
+import Portal from '../Portal';
 import { useModalContext } from './ModalContext';
 
 interface ModalContentProps {
@@ -50,22 +51,26 @@ const ModalContent = ({
     return () => dialog.removeEventListener('click', handleBackdropClick);
   }, [disableBackdropClose]);
 
+  if (!open) return null;
+
   return (
-    <dialog
-      ref={dialogRef}
-      className={cn(
-        'fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2',
-        className
-      )}
-      onClose={handleClose}
-      aria-modal='true'
-    >
-      {isValidElement(children) ? (
-        cloneElement(children)
-      ) : (
-        <div>{children}</div>
-      )}
-    </dialog>
+    <Portal>
+      <dialog
+        ref={dialogRef}
+        className={cn(
+          'fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2',
+          className
+        )}
+        onClose={handleClose}
+        aria-modal='true'
+      >
+        {isValidElement(children) ? (
+          cloneElement(children)
+        ) : (
+          <div>{children}</div>
+        )}
+      </dialog>
+    </Portal>
   );
 };
 

--- a/src/components/Modal/ModalContent.tsx
+++ b/src/components/Modal/ModalContent.tsx
@@ -1,0 +1,66 @@
+'use client';
+import React, {
+  cloneElement,
+  isValidElement,
+  PropsWithChildren,
+  useEffect,
+  useRef,
+} from 'react';
+import { cn } from '@/lib/utils';
+import { useModalContext } from './ModalContext';
+
+interface ModalContentProps {
+  className?: string;
+}
+
+const ModalContent = ({
+  className,
+  children,
+}: PropsWithChildren<ModalContentProps>) => {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const { open, closeModal } = useModalContext();
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    if (open && !dialog.open) {
+      dialog.showModal();
+    } else if (!open && dialog.open) {
+      dialog.close();
+    }
+  }, [open]);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    const handleBackdropClick = (event: MouseEvent) => {
+      if (event.target === dialog) {
+        dialog.close();
+      }
+    };
+
+    dialog.addEventListener('click', handleBackdropClick);
+    return () => dialog.removeEventListener('click', handleBackdropClick);
+  }, []);
+
+  return (
+    <dialog
+      ref={dialogRef}
+      className={cn(
+        'fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2',
+        className
+      )}
+      onClose={closeModal}
+    >
+      {isValidElement(children) ? (
+        cloneElement(children)
+      ) : (
+        <div>{children}</div>
+      )}
+    </dialog>
+  );
+};
+
+export default ModalContent;

--- a/src/components/Modal/ModalContent.tsx
+++ b/src/components/Modal/ModalContent.tsx
@@ -18,7 +18,7 @@ const ModalContent = ({
   children,
 }: PropsWithChildren<ModalContentProps>) => {
   const dialogRef = useRef<HTMLDialogElement>(null);
-  const { open, closeModal, onClose } = useModalContext();
+  const { open, disableBackdropClose, closeModal, onClose } = useModalContext();
 
   const handleClose = () => {
     onClose?.();
@@ -41,14 +41,14 @@ const ModalContent = ({
     if (!dialog) return;
 
     const handleBackdropClick = (event: MouseEvent) => {
-      if (event.target === dialog) {
+      if (event.target === dialog && !disableBackdropClose) {
         dialog.close();
       }
     };
 
     dialog.addEventListener('click', handleBackdropClick);
     return () => dialog.removeEventListener('click', handleBackdropClick);
-  }, []);
+  }, [disableBackdropClose]);
 
   return (
     <dialog

--- a/src/components/Modal/ModalContent.tsx
+++ b/src/components/Modal/ModalContent.tsx
@@ -18,7 +18,12 @@ const ModalContent = ({
   children,
 }: PropsWithChildren<ModalContentProps>) => {
   const dialogRef = useRef<HTMLDialogElement>(null);
-  const { open, closeModal } = useModalContext();
+  const { open, closeModal, onClose } = useModalContext();
+
+  const handleClose = () => {
+    onClose?.();
+    closeModal();
+  };
 
   useEffect(() => {
     const dialog = dialogRef.current;
@@ -52,7 +57,7 @@ const ModalContent = ({
         'fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2',
         className
       )}
-      onClose={closeModal}
+      onClose={handleClose}
       aria-modal='true'
     >
       {isValidElement(children) ? (

--- a/src/components/Modal/ModalContent.tsx
+++ b/src/components/Modal/ModalContent.tsx
@@ -51,6 +51,18 @@ const ModalContent = ({
     return () => dialog.removeEventListener('click', handleBackdropClick);
   }, [disableBackdropClose]);
 
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && disableBackdropClose) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [disableBackdropClose]);
+
   if (!open) return null;
 
   return (

--- a/src/components/Modal/ModalContext.ts
+++ b/src/components/Modal/ModalContext.ts
@@ -6,6 +6,7 @@ interface IModalContext {
   open: boolean;
   openModal: () => void;
   closeModal: () => void;
+  onClose?: () => void;
 }
 
 export const ModalContext = createContext<IModalContext | null>(null);

--- a/src/components/Modal/ModalContext.ts
+++ b/src/components/Modal/ModalContext.ts
@@ -1,0 +1,23 @@
+'use client';
+
+import { createContext, useContext } from 'react';
+
+interface IModalContext {
+  open: boolean;
+  openModal: () => void;
+  closeModal: () => void;
+}
+
+export const ModalContext = createContext<IModalContext | null>(null);
+
+export const useModalContext = () => {
+  const ctx = useContext(ModalContext);
+
+  if (!ctx) {
+    throw Error(
+      '<Modal>과 관련된 컴포넌트는 <Modal>컴포넌트 내부에서만 사용해야합니다!'
+    );
+  }
+
+  return ctx;
+};

--- a/src/components/Modal/ModalContext.ts
+++ b/src/components/Modal/ModalContext.ts
@@ -4,6 +4,7 @@ import { createContext, useContext } from 'react';
 
 interface IModalContext {
   open: boolean;
+  disableBackdropClose?: boolean;
   openModal: () => void;
   closeModal: () => void;
   onClose?: () => void;

--- a/src/components/Modal/ModalTrigger.tsx
+++ b/src/components/Modal/ModalTrigger.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import React, {
+  cloneElement,
+  isValidElement,
+  MouseEvent,
+  PropsWithChildren,
+  ReactElement,
+} from 'react';
+import { cn } from '@/lib/utils';
+import { useModalContext } from './ModalContext';
+
+interface ModalTriggerProps {
+  className?: string;
+}
+
+const ModalTrigger = ({
+  className,
+  children,
+}: PropsWithChildren<ModalTriggerProps>) => {
+  const { openModal } = useModalContext();
+
+  if (isValidElement(children)) {
+    const child = children as ReactElement<any>;
+
+    return cloneElement(child, {
+      onClick: (e: MouseEvent) => {
+        child.props.onClick?.(e);
+        openModal();
+      },
+    });
+  }
+
+  return (
+    <button
+      onClick={openModal}
+      className={cn('cursor-pointer', className)}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default ModalTrigger;

--- a/src/components/Modal/ModalTrigger.tsx
+++ b/src/components/Modal/ModalTrigger.tsx
@@ -24,6 +24,7 @@ const ModalTrigger = ({
     const child = children as ReactElement<any>;
 
     return cloneElement(child, {
+      'aria-label': '모달 열기',
       onClick: (e: MouseEvent) => {
         child.props.onClick?.(e);
         openModal();
@@ -35,6 +36,7 @@ const ModalTrigger = ({
     <button
       onClick={openModal}
       className={cn('cursor-pointer', className)}
+      aria-label='모달 열기'
     >
       {children}
     </button>

--- a/src/components/Portal.test.tsx
+++ b/src/components/Portal.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import Portal from './Portal';
+
+describe('<Portal> 컴포넌트', () => {
+  beforeAll(() => {
+    const portalRoot = document.createElement('div');
+    portalRoot.setAttribute('id', 'portal');
+    document.body.appendChild(portalRoot);
+  });
+
+  afterAll(() => {
+    const portalRoot = document.getElementById('portal');
+    if (portalRoot) {
+      document.body.removeChild(portalRoot);
+    }
+  });
+
+  test('children을 #portal 엘리먼트에 포탈로 렌더링한다', () => {
+    render(
+      <Portal>
+        <div data-testid='portal-child'>포탈 내용</div>
+      </Portal>
+    );
+
+    const child = screen.getByTestId('portal-child');
+    expect(child).toBeInTheDocument();
+
+    const portal = document.getElementById('portal');
+    expect(portal).toContainElement(child);
+  });
+
+  test('window가 없거나 #portal 엘리먼트가 없으면 null을 반환한다', () => {
+    const portalRoot = document.getElementById('portal');
+    if (portalRoot) document.body.removeChild(portalRoot);
+
+    const { container } = render(
+      <Portal>
+        <div>내용</div>
+      </Portal>
+    );
+
+    expect(container.firstChild).toBeNull();
+
+    const newPortalRoot = document.createElement('div');
+    newPortalRoot.setAttribute('id', 'portal');
+    document.body.appendChild(newPortalRoot);
+  });
+});

--- a/src/components/Portal.tsx
+++ b/src/components/Portal.tsx
@@ -1,0 +1,15 @@
+import { ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+
+interface PortalProps {
+  children: ReactNode;
+}
+
+const Portal = ({ children }: PortalProps) => {
+  const element =
+    typeof window !== 'undefined' && document.querySelector(`#portal`);
+
+  return element && children ? createPortal(children, element) : null;
+};
+
+export default Portal;


### PR DESCRIPTION
### 무엇을 위한 PR인가요? (: 뒤 설명 추가)

- 신규 기능 추가: 모달 및 포탈 컴포넌트 구현
- 문서 업데이트: 컴포넌트 사용법, 예제 등 상세 문서 작성

### 변경사항 및 이유 (bullet 으로 구분)

- 모달 컴포넌트 구현으로 사용자와의 상호작용에 유연한 UI 제공 가능
- 포탈을 통해 모달이 DOM 최상단에서 렌더링되도록 구조 분리
- SSR 환경에서도 오류 없이 작동하도록 조건 분기 추가
- Modal 컴포넌트의 props 명세 및 사용 예시 문서화

### 작업 내역 (bullet 으로 구분)

- Modal 합성 컴포넌트 구현
- Portal 컴포넌트 구현
- Modal 컴포넌트 테스트 코드 작성 및 문서화

### 작업 후 기대 동작(스크린샷)

https://github.com/user-attachments/assets/7ff5eda5-61f1-48a9-a8c9-3aae253f4680

### Issue Number

close: #68