### PR TITLE
[Fix/issue-123] 이미지 파일 import를 위한 TypeScript 모듈 선언 추가

### DIFF
--- a/src/types/images.d.ts
+++ b/src/types/images.d.ts
@@ -1,0 +1,14 @@
+declare module '*.png' {
+  const value: string;
+  export default value;
+}
+
+declare module '*.jpg' {
+  const value: string;
+  export default value;
+}
+
+declare module '*.svg' {
+  const value: string;
+  export default value;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,19 +1,9 @@
 {
   "compilerOptions": {
-    "types": [
-      "jest",
-      "node"
-    ],
-    "typeRoots": [
-      "./node_modules/@types",
-      "./src/types"
-    ],
+    "types": ["jest", "node"],
+    "typeRoots": ["./node_modules/@types", "./src/types"],
     "target": "ES2017",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -31,9 +21,7 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./src/*"
-      ]
+      "@/*": ["./src/*"]
     }
   },
   "include": [
@@ -43,15 +31,13 @@
     ".next/types/**/*.ts, **.",
     "next-env.d.ts",
     "src",
+    "src/types",
     "tests",
-    ".next/types/**/*.ts"
-, "src/mocks"  ],
-  "exclude": [
-    "node_modules"
+    ".next/types/**/*.ts",
+    "src/mocks"
   ],
+  "exclude": ["node_modules"],
   "typeAcquisition": {
-    "include": [
-      "jest"
-    ]
+    "include": ["jest"]
   }
 }


### PR DESCRIPTION
### 무엇을 위한 PR인가요? (: 뒤 설명 추가)
- 기타: 이미지 파일 import를 위한 TypeScript 모듈 선언 추가

### 변경사항 및 이유 (bullet 으로 구분)
- TypeScript에서 `.png`, `.jpg`, `.svg` 파일을 import할 때 발생하는 타입 오류를 해결하기 위함
- 이미지 자산을 직접 import하여 사용하는 컴포넌트(예: ProfileImage 등)에서 타입 안전성을 확보

### 작업 내역 (bullet 으로 구분)
- `src/types/images.d.ts` 파일 생성
- `.png`, `.jpg`, `.svg`에 대한 모듈 선언 추가
- `tsconfig.json`에 `src/types` 경로 포함 (`include`)

### ?작업 후 기대 동작(스크린샷)
- `.png`, `.jpg`, `.svg` 파일 import 시 TypeScript 오류가 발생하지 않음
- 이미지 관련 컴포넌트에서 타입 에러 없이 정상 개발 가능

### Issue Number

close: #123 