### PR TITLE
[Feature/issue-063] RadioGroup 컴포넌트  (& 문서, 테스트)

### DIFF
--- a/src/components/RadioGroup/RadioGroup.md
+++ b/src/components/RadioGroup/RadioGroup.md
@@ -1,0 +1,273 @@
+# RadioGroup 컴포넌트
+
+React에서 라디오 버튼 그룹을 쉽게 만들 수 있는 컴포넌트입니다. Context API를 사용하여 상태를 관리하고, 다양한 레이아웃 옵션을 제공합니다.
+
+## 설치 및 가져오기
+
+```javascript
+import { RadioGroup, RadioGroupItem } from '@/components/RadioGroup';
+```
+
+## 기본 사용법
+
+```jsx
+import React, { useState } from 'react';
+import { RadioGroup, RadioGroupItem } from '@/components/RadioGroup';
+
+function App() {
+  const [selectedValue, setSelectedValue] = useState('option1');
+
+  return (
+    <RadioGroup
+      value={selectedValue}
+      onChange={setSelectedValue}
+    >
+      <RadioGroupItem
+        value='option1'
+        label='옵션 1'
+      />
+      <RadioGroupItem
+        value='option2'
+        label='옵션 2'
+      />
+      <RadioGroupItem
+        value='option3'
+        label='옵션 3'
+      />
+    </RadioGroup>
+  );
+}
+```
+
+## RadioGroup Props
+
+| 속성        | 타입                         | 기본값       | 필수 | 설명                              |
+| ----------- | ---------------------------- | ------------ | ---- | --------------------------------- |
+| `direction` | `'horizontal' \| 'vertical'` | `'vertical'` | ❌   | 라디오 버튼들의 배치 방향         |
+| `value`     | `string`                     | `undefined`  | ❌   | 현재 선택된 값                    |
+| `onChange`  | `(value: string) => void`    | `undefined`  | ❌   | 값이 변경될 때 호출되는 콜백 함수 |
+| `name`      | `string`                     | 자동 생성    | ❌   | 라디오 그룹의 name 속성           |
+| `className` | `string`                     | `''`         | ❌   | 추가 CSS 클래스                   |
+| `children`  | `React.ReactNode`            | -            | ✅   | RadioGroupItem 컴포넌트들         |
+| `gap`       | `number`                     | `12`         | ❌   | 아이템 간의 간격 (픽셀)           |
+| `columns`   | `number`                     | `undefined`  | ❌   | 수평 배치 시 열의 개수            |
+
+## RadioGroupItem Props
+
+| 속성             | 타입              | 기본값      | 필수 | 설명                            |
+| ---------------- | ----------------- | ----------- | ---- | ------------------------------- |
+| `value`          | `string`          | -           | ✅   | 라디오 버튼의 값                |
+| `label`          | `string`          | -           | ✅   | 표시될 라벨 텍스트              |
+| `disabled`       | `boolean`         | `false`     | ❌   | 비활성화 여부                   |
+| `className`      | `string`          | `''`        | ❌   | label 요소에 적용될 CSS 클래스  |
+| `labelClassName` | `string`          | `''`        | ❌   | 라벨 텍스트에 적용될 CSS 클래스 |
+| `children`       | `React.ReactNode` | `undefined` | ❌   | label 대신 표시될 커스텀 콘텐츠 |
+
+## 사용 예제
+
+### 1. 세로 배치 (기본)
+
+```jsx
+<RadioGroup
+  value={selectedValue}
+  onChange={setSelectedValue}
+>
+  <RadioGroupItem
+    value='small'
+    label='소형'
+  />
+  <RadioGroupItem
+    value='medium'
+    label='중형'
+  />
+  <RadioGroupItem
+    value='large'
+    label='대형'
+  />
+</RadioGroup>
+```
+
+### 2. 가로 배치
+
+```jsx
+<RadioGroup
+  direction='horizontal'
+  value={selectedValue}
+  onChange={setSelectedValue}
+>
+  <RadioGroupItem
+    value='yes'
+    label='예'
+  />
+  <RadioGroupItem
+    value='no'
+    label='아니오'
+  />
+</RadioGroup>
+```
+
+### 3. 그리드 레이아웃 (열 개수 지정)
+
+```jsx
+<RadioGroup
+  direction='horizontal'
+  columns={2}
+  value={selectedValue}
+  onChange={setSelectedValue}
+  gap={20}
+>
+  <RadioGroupItem
+    value='option1'
+    label='옵션 1'
+  />
+  <RadioGroupItem
+    value='option2'
+    label='옵션 2'
+  />
+  <RadioGroupItem
+    value='option3'
+    label='옵션 3'
+  />
+  <RadioGroupItem
+    value='option4'
+    label='옵션 4'
+  />
+</RadioGroup>
+```
+
+### 4. 비활성화된 옵션
+
+```jsx
+<RadioGroup
+  value={selectedValue}
+  onChange={setSelectedValue}
+>
+  <RadioGroupItem
+    value='available'
+    label='사용 가능'
+  />
+  <RadioGroupItem
+    value='unavailable'
+    label='사용 불가'
+    disabled
+  />
+  <RadioGroupItem
+    value='pending'
+    label='대기 중'
+  />
+</RadioGroup>
+```
+
+### 5. 커스텀 콘텐츠
+
+```jsx
+<RadioGroup
+  value={selectedValue}
+  onChange={setSelectedValue}
+>
+  <RadioGroupItem
+    value='premium'
+    label='프리미엄'
+  >
+    <div>
+      <strong>프리미엄 플랜</strong>
+      <p>모든 기능 이용 가능</p>
+    </div>
+  </RadioGroupItem>
+  <RadioGroupItem
+    value='basic'
+    label='기본'
+  >
+    <div>
+      <strong>기본 플랜</strong>
+      <p>기본 기능만 이용 가능</p>
+    </div>
+  </RadioGroupItem>
+</RadioGroup>
+```
+
+### 6. 스타일 커스터마이제이션
+
+```jsx
+<RadioGroup
+  className='my-radio-group'
+  value={selectedValue}
+  onChange={setSelectedValue}
+>
+  <RadioGroupItem
+    value='option1'
+    label='옵션 1'
+    className='rounded border p-2 hover:bg-gray-100'
+    labelClassName='font-semibold text-blue-600'
+  />
+  <RadioGroupItem
+    value='option2'
+    label='옵션 2'
+    className='rounded border p-2 hover:bg-gray-100'
+    labelClassName='font-semibold text-blue-600'
+  />
+</RadioGroup>
+```
+
+## 접근성 (Accessibility)
+
+이 컴포넌트는 접근성을 고려하여 설계되었습니다:
+
+- `role="radiogroup"`이 자동으로 설정됩니다
+- 키보드 네비게이션을 지원합니다 (Enter, Space 키)
+- 각 라디오 그룹은 고유한 `name` 속성을 가집니다
+- 비활성화된 옵션은 적절한 시각적 피드백을 제공합니다
+
+## 주의사항
+
+1. **RadioGroupItem은 반드시 RadioGroup 내부에서 사용해야 합니다.** 그렇지 않으면 에러가 발생합니다.
+
+2. **value prop은 문자열이어야 합니다.** 다른 타입의 값을 사용하려면 문자열로 변환해서 사용하세요.
+
+3. **onChange 함수를 제공하지 않으면 읽기 전용으로 동작합니다.**
+
+## CSS 스타일링
+
+컴포넌트는 기본적인 Tailwind CSS 클래스를 사용합니다. 커스텀 스타일을 적용하려면:
+
+```css
+.radio-group {
+  /* RadioGroup 컨테이너 스타일 */
+}
+
+.radio-group label {
+  /* RadioGroupItem 라벨 스타일 */
+}
+
+.radio-group label.selected {
+  /* 선택된 아이템 스타일 */
+}
+
+.radio-group input[type='radio'] {
+  /* 라디오 버튼 스타일 */
+}
+```
+
+## 타입 정의
+
+```typescript
+interface RadioGroupProps {
+  direction?: 'horizontal' | 'vertical';
+  value?: string;
+  onChange?: (value: string) => void;
+  name?: string;
+  className?: string;
+  children: React.ReactNode;
+  gap?: number;
+  columns?: number;
+}
+
+interface RadioGroupItemProps {
+  value: string;
+  label: string;
+  disabled?: boolean;
+  className?: string;
+  labelClassName?: string;
+  children?: React.ReactNode;
+}
+```

--- a/src/components/RadioGroup/RadioGroup.test.tsx
+++ b/src/components/RadioGroup/RadioGroup.test.tsx
@@ -1,0 +1,319 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import RadioGroup from './RadioGroup';
+import RadioGroupItem from './RadioGroupItem';
+
+const TestRadioGroup = ({
+  value,
+  onChange,
+  direction = 'vertical',
+  disabled = false,
+}: {
+  value?: string;
+  onChange?: (value: string) => void;
+  direction?: 'horizontal' | 'vertical';
+  disabled?: boolean;
+}) => (
+  <RadioGroup
+    value={value}
+    onChange={onChange}
+    direction={direction}
+  >
+    <RadioGroupItem
+      value='option1'
+      label='옵션 1'
+      disabled={disabled}
+    />
+    <RadioGroupItem
+      value='option2'
+      label='옵션 2'
+    />
+    <RadioGroupItem
+      value='option3'
+      label='옵션 3'
+    >
+      커스텀 라벨
+    </RadioGroupItem>
+  </RadioGroup>
+);
+
+describe('RadioGroup', () => {
+  describe('기본 렌더링', () => {
+    it('라디오 그룹이 올바르게 렌더링된다', () => {
+      render(<TestRadioGroup />);
+
+      expect(screen.getByRole('radiogroup')).toBeInTheDocument();
+      expect(screen.getByLabelText('옵션 1')).toBeInTheDocument();
+      expect(screen.getByLabelText('옵션 2')).toBeInTheDocument();
+      expect(screen.getByLabelText('커스텀 라벨')).toBeInTheDocument();
+    });
+
+    it('모든 라디오 버튼이 같은 name 속성을 가진다', () => {
+      render(<TestRadioGroup />);
+
+      const radioButtons = screen.getAllByRole('radio');
+      const firstName = radioButtons[0].getAttribute('name');
+
+      radioButtons.forEach((radio) => {
+        expect(radio).toHaveAttribute('name', firstName);
+      });
+    });
+
+    it('초기값이 없을 때 아무것도 선택되지 않는다', () => {
+      render(<TestRadioGroup />);
+
+      const radioButtons = screen.getAllByRole('radio');
+      radioButtons.forEach((radio) => {
+        expect(radio).not.toBeChecked();
+      });
+    });
+  });
+
+  describe('선택 상태 관리', () => {
+    it('초기값이 설정되면 해당 옵션이 선택된다', () => {
+      render(<TestRadioGroup value='option2' />);
+
+      expect(screen.getByLabelText('옵션 1')).not.toBeChecked();
+      expect(screen.getByLabelText('옵션 2')).toBeChecked();
+      expect(screen.getByLabelText('커스텀 라벨')).not.toBeChecked();
+    });
+
+    it('라디오 버튼 클릭 시 onChange가 호출된다', async () => {
+      const user = userEvent.setup();
+      const mockOnChange = jest.fn();
+
+      render(<TestRadioGroup onChange={mockOnChange} />);
+
+      await user.click(screen.getByLabelText('옵션 2'));
+
+      expect(mockOnChange).toHaveBeenCalledWith('option2');
+      expect(mockOnChange).toHaveBeenCalledTimes(1);
+    });
+
+    it('다른 옵션 선택 시 이전 선택이 해제된다', async () => {
+      const user = userEvent.setup();
+      const mockOnChange = jest.fn();
+
+      render(
+        <TestRadioGroup
+          value='option1'
+          onChange={mockOnChange}
+        />
+      );
+
+      expect(screen.getByLabelText('옵션 1')).toBeChecked();
+
+      await user.click(screen.getByLabelText('옵션 2'));
+
+      expect(mockOnChange).toHaveBeenCalledWith('option2');
+    });
+  });
+
+  describe('키보드 접근성', () => {
+    it('Enter 키로 라디오 버튼을 선택할 수 있다', () => {
+      const mockOnChange = jest.fn();
+      render(<TestRadioGroup onChange={mockOnChange} />);
+
+      const radio = screen.getByLabelText('옵션 2');
+      radio.focus();
+      fireEvent.keyDown(radio, { key: 'Enter' });
+
+      expect(mockOnChange).toHaveBeenCalledWith('option2');
+    });
+
+    it('Space 키로 라디오 버튼을 선택할 수 있다', () => {
+      const mockOnChange = jest.fn();
+      render(<TestRadioGroup onChange={mockOnChange} />);
+
+      // 'option3' value를 가진 라디오 버튼을 직접 찾아서 키보드 이벤트 발생
+      const radio = screen.getByDisplayValue('option3');
+      radio.focus();
+      fireEvent.keyDown(radio, { key: ' ' });
+
+      expect(mockOnChange).toHaveBeenCalledWith('option3');
+    });
+
+    it('다른 키는 무시된다', () => {
+      const mockOnChange = jest.fn();
+      render(<TestRadioGroup onChange={mockOnChange} />);
+
+      const radio = screen.getByLabelText('옵션 1');
+      radio.focus();
+      fireEvent.keyDown(radio, { key: 'a' });
+
+      expect(mockOnChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('비활성화 상태', () => {
+    it('비활성화된 라디오 버튼은 클릭할 수 없다', async () => {
+      const user = userEvent.setup();
+      const mockOnChange = jest.fn();
+
+      render(
+        <TestRadioGroup
+          onChange={mockOnChange}
+          disabled={true}
+        />
+      );
+
+      const disabledRadio = screen.getByLabelText('옵션 1');
+      expect(disabledRadio).toBeDisabled();
+
+      await user.click(disabledRadio);
+      expect(mockOnChange).not.toHaveBeenCalled();
+    });
+
+    it('비활성화된 라디오 버튼은 키보드로 선택할 수 없다', () => {
+      const mockOnChange = jest.fn();
+      render(
+        <TestRadioGroup
+          onChange={mockOnChange}
+          disabled={true}
+        />
+      );
+
+      const disabledRadio = screen.getByLabelText('옵션 1');
+      fireEvent.keyDown(disabledRadio, { key: 'Enter' });
+
+      expect(mockOnChange).not.toHaveBeenCalled();
+    });
+
+    it('비활성화된 요소에 올바른 스타일 클래스가 적용된다', () => {
+      render(<TestRadioGroup disabled={true} />);
+
+      const disabledLabel = screen.getByLabelText('옵션 1').closest('label');
+      expect(disabledLabel).toHaveClass('cursor-not-allowed', 'opacity-60');
+    });
+  });
+
+  describe('커스텀 props', () => {
+    it('커스텀 className이 적용된다', () => {
+      render(
+        <RadioGroup className='custom-class'>
+          <RadioGroupItem
+            value='test'
+            label='테스트'
+          />
+        </RadioGroup>
+      );
+
+      expect(screen.getByRole('radiogroup')).toHaveClass('custom-class');
+    });
+
+    it('커스텀 name이 적용된다', () => {
+      render(
+        <RadioGroup name='custom-name'>
+          <RadioGroupItem
+            value='test'
+            label='테스트'
+          />
+        </RadioGroup>
+      );
+
+      expect(screen.getByRole('radio')).toHaveAttribute('name', 'custom-name');
+    });
+
+    it('RadioGroupItem에 커스텀 className이 적용된다', () => {
+      render(
+        <RadioGroup>
+          <RadioGroupItem
+            value='test'
+            label='테스트'
+            className='custom-item-class'
+          />
+        </RadioGroup>
+      );
+
+      const label = screen.getByLabelText('테스트').closest('label');
+      expect(label).toHaveClass('custom-item-class');
+    });
+
+    it('RadioGroupItem에 커스텀 labelClassName이 적용된다', () => {
+      render(
+        <RadioGroup>
+          <RadioGroupItem
+            value='test'
+            label='테스트'
+            labelClassName='custom-label-class'
+          />
+        </RadioGroup>
+      );
+
+      const span = screen.getByText('테스트');
+      expect(span).toHaveClass('custom-label-class');
+    });
+  });
+
+  describe('children vs label', () => {
+    it('children이 있으면 label 대신 children이 렌더링된다', () => {
+      render(
+        <RadioGroup>
+          <RadioGroupItem
+            value='test'
+            label='원래 라벨'
+          >
+            커스텀 children
+          </RadioGroupItem>
+        </RadioGroup>
+      );
+
+      expect(screen.getByText('커스텀 children')).toBeInTheDocument();
+      expect(screen.queryByText('원래 라벨')).not.toBeInTheDocument();
+      // value로 라디오 버튼을 찾을 수 있는지 확인
+      expect(screen.getByDisplayValue('test')).toBeInTheDocument();
+    });
+
+    it('children이 없으면 label이 렌더링된다', () => {
+      render(
+        <RadioGroup>
+          <RadioGroupItem
+            value='test'
+            label='원래 라벨'
+          />
+        </RadioGroup>
+      );
+
+      expect(screen.getByText('원래 라벨')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('test')).toBeInTheDocument();
+    });
+  });
+
+  describe('방향 설정', () => {
+    it('horizontal 방향이 올바르게 설정된다', () => {
+      render(<TestRadioGroup direction='horizontal' />);
+
+      const radioGroup = screen.getByRole('radiogroup');
+      expect(radioGroup).toHaveStyle('grid-auto-flow: column');
+    });
+
+    it('vertical 방향이 기본값으로 설정된다', () => {
+      render(<TestRadioGroup />);
+
+      const radioGroup = screen.getByRole('radiogroup');
+      expect(radioGroup).toHaveStyle('grid-template-columns: 1fr');
+    });
+  });
+});
+
+describe('RadioGroupContext', () => {
+  it('RadioGroup 외부에서 RadioGroupItem 사용 시 에러가 발생한다', () => {
+    // 콘솔 에러를 숨김
+    const consoleSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    expect(() => {
+      render(
+        <RadioGroupItem
+          value='test'
+          label='테스트'
+        />
+      );
+    }).toThrow('RadioGroupItem은 RadioGroup 내부에서만 사용할 수 있습니다.');
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -1,0 +1,68 @@
+import React, { useId } from 'react';
+import { RadioGroupProvider } from './RadioGroupContext';
+
+interface RadioGroupProps {
+  direction?: 'horizontal' | 'vertical';
+  value?: string;
+  onChange?: (value: string) => void;
+  name?: string;
+  className?: string;
+  children: React.ReactNode;
+  gap?: number;
+  columns?: number;
+}
+
+const RadioGroup: React.FC<RadioGroupProps> = ({
+  direction = 'vertical',
+  value,
+  onChange,
+  name,
+  className = '',
+  children,
+  gap = 12,
+  columns,
+}) => {
+  const generatedId = useId();
+  const groupName = name || `radio-group-${generatedId}`;
+
+  const directionStyles = {
+    horizontal: {
+      ...(columns
+        ? {
+            gridTemplateColumns: `repeat(${columns}, 1fr)`,
+            gridAutoFlow: 'row',
+          }
+        : {
+            gridAutoFlow: 'column',
+            gridAutoColumns: '1fr',
+          }),
+    },
+    vertical: {
+      gridTemplateColumns: '1fr',
+      gridAutoFlow: 'row',
+    },
+  };
+  const gridStyle = {
+    display: 'grid',
+    gap: `${gap}px`,
+    ...directionStyles[direction],
+  };
+
+  return (
+    <RadioGroupProvider
+      value={value}
+      onChange={onChange}
+      name={groupName}
+    >
+      <div
+        className={`radio-group ${className}`}
+        style={gridStyle}
+        role='radiogroup'
+      >
+        {children}
+      </div>
+    </RadioGroupProvider>
+  );
+};
+
+export default RadioGroup;

--- a/src/components/RadioGroup/RadioGroupContext.tsx
+++ b/src/components/RadioGroup/RadioGroupContext.tsx
@@ -1,0 +1,30 @@
+import { createContext, useContext } from 'react';
+
+interface RadioGroupContextType {
+  value?: string;
+  onChange?: (value: string) => void;
+  name: string;
+}
+
+const RadioGroupContext = createContext<RadioGroupContextType | null>(null);
+
+export const useRadioGroup = () => {
+  const context = useContext(RadioGroupContext);
+  if (!context) {
+    throw new Error(
+      'RadioGroupItem은 RadioGroup 내부에서만 사용할 수 있습니다.'
+    );
+  }
+  return context;
+};
+
+export const RadioGroupProvider: React.FC<{
+  value?: string;
+  onChange?: (value: string) => void;
+  name: string;
+  children: React.ReactNode;
+}> = ({ value, onChange, name, children }) => (
+  <RadioGroupContext.Provider value={{ value, onChange, name }}>
+    {children}
+  </RadioGroupContext.Provider>
+);

--- a/src/components/RadioGroup/RadioGroupItem.tsx
+++ b/src/components/RadioGroup/RadioGroupItem.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { useRadioGroup } from './RadioGroupContext';
+
+export interface RadioGroupItemProps {
+  value: string;
+  label: string;
+  disabled?: boolean;
+  className?: string;
+  labelClassName?: string;
+  children?: React.ReactNode;
+}
+
+const RadioGroupItem: React.FC<RadioGroupItemProps> = ({
+  value,
+  label,
+  disabled = false,
+  className = '',
+  labelClassName = '',
+  children,
+}) => {
+  const { value: selectedValue, onChange, name } = useRadioGroup();
+  const isSelected = selectedValue === value;
+
+  const handleChange = () => {
+    if (!disabled && onChange) {
+      onChange(value);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handleChange();
+    }
+  };
+
+  const styleClass = {
+    label: `flex items-center ${disabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'} ${isSelected ? 'selected' : ''} ${className}`,
+    input: 'mr-2 accent-blue-600',
+    labelText: labelClassName,
+  };
+
+  return (
+    <label className={styleClass.label}>
+      <input
+        type='radio'
+        name={name}
+        value={value}
+        checked={isSelected}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        disabled={disabled}
+        className={styleClass.input}
+      />
+      <span className={styleClass.labelText}>{children || label}</span>
+    </label>
+  );
+};
+
+export default RadioGroupItem;

--- a/src/components/RadioGroup/index.tsx
+++ b/src/components/RadioGroup/index.tsx
@@ -1,0 +1,2 @@
+export { default as RadioGroup } from './RadioGroup';
+export { default as RadioGroupItem } from './RadioGroupItem';


### PR DESCRIPTION
# RadioGroup 컴포넌트 추가

### 무엇을 위한 PR인가요? (: 뒤 설명 추가)
- 신규 기능 추가: 재사용 가능한 RadioGroup 컴포넌트

### 변경사항 및 이유 (bullet 으로 구분)
- RadioGroup, RadioGroupItem 컴포넌트 추가
- Context API 기반 상태 관리
- 세로/가로/그리드 레이아웃 지원
- TypeScript 타입 정의 포함
- 키보드 네비게이션 및 접근성 지원

### 작업 내역 (bullet 으로 구분)
- `RadioGroup.tsx` 메인 컨테이너 컴포넌트 구현
- `RadioGroupItem.tsx` 개별 라디오 아이템 컴포넌트 구현
- `RadioGroupContext.tsx` 상태 관리 Context 구현
- `index.ts` named export 설정
- TypeScript 인터페이스 정의

### 작업 후 기대 동작(스크린샷)

- 기본

![radioGroup_vertical](https://github.com/user-attachments/assets/d63bf18c-70b9-4ba2-95a5-de03ca661c52)

- 가로 배치

![radioGroup_horizontal](https://github.com/user-attachments/assets/dc77062c-9369-4f7a-b2fb-08f4acaffd8e)

### PR 특이 사항
- RadioGroupItem은 RadioGroup 내부에서만 사용 가능
- value는 string 타입만 지원

### Issue Number
close: #63 