### PR TITLE
[Feature/issue-168] ReportItem 컴포넌트 구현 및 테스트, 문서

### DIFF
--- a/src/components/ReportItem/ReportItem.md
+++ b/src/components/ReportItem/ReportItem.md
@@ -1,0 +1,62 @@
+# 📄 ReportItem 컴포넌트
+
+사용자의 신고 내역을 보여주는 UI 컴포넌트입니다.
+신고 날짜와 신고 사유를 간결하게 표시합니다.
+
+## 📦 사용법
+
+```tsx
+import ReportItem from '@/components/ReportItem/ReportItem';
+import { ReportReason } from '@/types/enums';
+
+<ReportItem
+  reportedAt='2025-01-09T07:05:00'
+  reason={ReportReason.PROFANITY}
+  onClick={() => console.log('신고 아이템 클릭됨')}
+/>;
+```
+
+## ✨ Props
+
+| 이름         | 타입               | 필수 | 설명                                              |
+| ------------ | ------------------ | ---- | ------------------------------------------------- |
+| `reportedAt` | `string`           | ✅   | ISO 형식 날짜 문자열 (`"2025-01-09T07:05:00"` 등) |
+| `reason`     | `ReportReasonType` | ✅   | 신고 사유 enum (`PROFANITY`, `SPAM`, 등)          |
+| `onClick`    | `() => void`       | ✅   | 클릭 시 실행될 함수                               |
+| `className`  | `string`           | ❌   | 추가 Tailwind CSS 클래스                          |
+
+## 🧩 주요 렌더링 정보
+
+- 날짜를 컴포넌트 내부에서 "YY.MM.DD HH:mm" 포맷으로 변환, 추후 date-fns으로 적용
+
+- ReportReasonLabels 객체를 통해 신고 사유 한글 문자열로 매핑
+
+- div에 role="button" 적용으로 클릭 가능 요소 명시
+
+## 🎨 스타일 가이드 (Tailwind CSS 기준)
+
+- 디자인 확정 시 수정 필요
+
+## ✅ 테스트 정보
+
+테스트 도구: jest, @testing-library/react
+
+## 🧪 테스트 명세
+
+| 테스트 항목             | 설명                                                                                          |
+| ----------------------- | --------------------------------------------------------------------------------------------- |
+| 날짜 포맷 렌더링 테스트 | `reportedAt` props로 전달된 ISO 문자열이 `"YY.MM.DD HH:mm"` 형식으로 올바르게 표시되는지 확인 |
+| 신고 사유 렌더링 테스트 | `reason` props가 한글 레이블로 올바르게 매핑되어 표시되는지 확인                              |
+| className 적용 테스트   | 외부에서 전달한 `className`이 컴포넌트 최상위 요소에 정상적으로 적용되는지 확인               |
+| 클릭 이벤트 호출 테스트 | 컴포넌트를 클릭했을 때, 전달된 `onClick` 콜백 함수가 정확히 1번 호출되는지 확인               |
+
+---
+
+## 📁 파일 구조
+
+```
+/components/ReportItem
+├── ReportItem.tsx
+└── ReportItem.test.tsx
+└── ReportItem.md
+```

--- a/src/components/ReportItem/ReportItem.test.tsx
+++ b/src/components/ReportItem/ReportItem.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import { ReportReason } from '@/types/enums';
+import ReportItem from './ReportItem';
+
+const mockReportItem = {
+  reportedAt: '2025-01-09T07:05:00',
+  reason: ReportReason.PROFANITY,
+  onClick: jest.fn(),
+};
+
+describe('ReportItem 컴포넌트', () => {
+  test('reportedAt props가 올바르게 포맷되어 렌더링된다', () => {
+    render(<ReportItem {...mockReportItem} />);
+    expect(screen.getByText('25.01.09 07:05')).toBeInTheDocument();
+  });
+
+  test('reason props가 올바르게 렌더링된다', () => {
+    render(<ReportItem {...mockReportItem} />);
+    expect(screen.getByText('욕설, 비방, 차별, 혐오')).toBeInTheDocument();
+  });
+
+  test('className props를 추가로 입력하면 정상적으로 렌더링된다', () => {
+    render(
+      <ReportItem
+        {...mockReportItem}
+        className='text-2xl'
+      />
+    );
+    const container = screen.getByRole('button');
+    expect(container.className).toContain('text-2xl');
+  });
+
+  test('onClick props가 정상적으로 호출된다', () => {
+    const handleClick = jest.fn();
+    render(
+      <ReportItem
+        {...mockReportItem}
+        onClick={handleClick}
+      />
+    );
+
+    screen.getByRole('button').click();
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/ReportItem/ReportItem.tsx
+++ b/src/components/ReportItem/ReportItem.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import type { KeyboardEvent } from 'react';
+import { ReportReasonLabels } from '@/constants/reportLabels';
+import { cn } from '@/lib/utils';
+import { ReportReasonType } from '@/types/enums';
+
+interface ReportItemProps {
+  reportedAt: string;
+  reason: ReportReasonType;
+  onClick: () => void;
+  className?: string;
+}
+
+// TODO: date-fns 적용 후 제거 예정
+const formatDateTime = (iso: string): string => {
+  const date = new Date(iso);
+  const pad = (n: number) => n.toString().padStart(2, '0');
+
+  const year = date.getFullYear().toString().slice(-2);
+  const month = pad(date.getMonth() + 1);
+  const day = pad(date.getDate());
+  const hours = pad(date.getHours());
+  const minutes = pad(date.getMinutes());
+
+  return `${year}.${month}.${day} ${hours}:${minutes}`;
+};
+
+const ReportItem = ({
+  reportedAt,
+  reason,
+  onClick,
+  className,
+}: ReportItemProps) => {
+  // 키보드 조작
+  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      onClick();
+    }
+  };
+
+  return (
+    <div
+      role='button'
+      tabIndex={0}
+      onClick={onClick}
+      onKeyDown={handleKeyDown}
+      className={cn(
+        'flex flex-col gap-1 rounded-md border border-gray-200 bg-white p-4 shadow-sm',
+        className
+      )}
+    >
+      <div className='text-xs text-gray-500'>{formatDateTime(reportedAt)}</div>
+      <div className='text-base font-medium text-gray-800'>
+        {ReportReasonLabels[reason]}
+      </div>
+    </div>
+  );
+};
+
+export default ReportItem;

--- a/src/constants/reportLabels.ts
+++ b/src/constants/reportLabels.ts
@@ -1,0 +1,10 @@
+import { ReportReason } from '@/types/enums';
+
+export const ReportReasonLabels: Record<string, string> = {
+  [ReportReason.PROFANITY]: '욕설, 비방, 차별, 혐오',
+  [ReportReason.ADVERTISEMENT]: '홍보, 영리목적',
+  [ReportReason.ILLEGAL]: '불법 정보',
+  [ReportReason.SEXUAL]: '음란, 청소년 유해',
+  [ReportReason.PERSONAL_INFO]: '개인정보 노출, 유포, 거래',
+  [ReportReason.SPAM]: '도배, 스팸',
+};

--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -14,3 +14,14 @@ export const Gender = {
 } as const;
 
 export type GenderType = (typeof Gender)[keyof typeof Gender];
+
+export const ReportReason = {
+  PROFANITY: 'PROFANITY',
+  ADVERTISEMENT: 'ADVERTISEMENT',
+  ILLEGAL: 'ILLEGAL',
+  SEXUAL: 'SEXUAL',
+  PERSONAL_INFO: 'PERSONAL_INFO',
+  SPAM: 'SPAM',
+} as const;
+
+export type ReportReasonType = (typeof ReportReason)[keyof typeof ReportReason];

--- a/src/utils/reportResonEnumLabels.ts
+++ b/src/utils/reportResonEnumLabels.ts
@@ -1,0 +1,4 @@
+import { ReportReasonLabels } from '@/constants/reportLabels';
+
+export const getReportReasonLabels = (reason: string): string =>
+  ReportReasonLabels[reason];


### PR DESCRIPTION
### 무엇을 위한 PR인가요? (: 뒤 설명 추가)

- 신규 기능 추가: ReportItem 컴포넌트 구현

- 테스트 코드 작성 및 문서화

### 변경사항 및 이유 (bullet 으로 구분)

- 신고 내역을 카드 형태로 보여주는 ReportItem 컴포넌트를 추가하였습니다.

- 날짜와 신고 사유를 명확하게 표현하여 UX 개선

- 클릭 이벤트를 통해 모달 또는 상세보기로 연동 가능하도록 구성

### 작업 내역 (bullet 으로 구분)

- ReportItem 컴포넌트 구현

- props: reportedAt, reason, onClick, className 추가

- 페이지내에서 신고일시 YY-MM-dd HH:mm 포맷

- 테스트 코드 작성 (@testing-library/react)

- 컴포넌트 및 테스트 문서 작성 

### ?작업 후 기대 동작(스크린샷)


https://github.com/user-attachments/assets/5fff04d0-134d-4345-9539-b59af02a908c


### ?PR 특이 사항

- 날짜 포맷 유틸은 추후 date-fns 기반으로 통합 예정

- 현재는 formatDateTime 임시 함수 사용

- 추후 API 연동 시, 모달 내 상세 데이터 바인딩 예정