### PR TITLE
[Feature/issue-060] 공연 카드 추가 (#203)

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -15,6 +15,7 @@ const config: Config = {
   testEnvironment: 'jest-fixed-jsdom',
   // 테스트 전에 실행할 설정 파일을 지정
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  moduleNameMapper: { '^@/(.*)$': '<rootDir>/src/$1' },
 };
 
 export default createJestConfig(config);

--- a/src/components/PerformanceCard/PerformanceCard.md
+++ b/src/components/PerformanceCard/PerformanceCard.md
@@ -1,0 +1,280 @@
+# PerformanceCard 컴포넌트
+
+공연 정보 표시용 재사용 가능 컴포넌트 (Compound Component + Headless UI 패턴)
+
+## 특징
+
+- Type prop으로 간편한 카드 타입 선택
+- Compound Component 패턴으로 유연한 커스터마이징
+- Headless UI 구조로 스타일과 로직 분리
+- 4가지 사전 정의 카드 레이아웃
+- **가시성 제어 Props로 각 요소 표시/숨김 제어**
+- 접근성 지원 (키보드 네비게이션, ARIA)
+- TypeScript 완전 지원
+
+## 사용법
+
+### 1. Type Prop 방식 (권장)
+
+```tsx
+// 기본 카드
+<PerformanceCard
+  performance={performance}
+  type="default"
+  onCardClick={handleClick}
+  onLikeClick={handleLike}
+  isLiked={false}
+/>
+
+// 타입별 카드
+<PerformanceCard performance={performance} type="compact" />
+<PerformanceCard performance={performance} type="vertical" />
+<PerformanceCard performance={performance} type="detailed" />
+
+// 가시성 제어
+<PerformanceCard
+  performance={performance}
+  type="compact"
+  showCast={false}
+  showPrice={false}
+/>
+```
+
+### 2. Compound Component 방식 (커스터마이징)
+
+```tsx
+import PerformanceCard from './PerformanceCard';
+
+<PerformanceCard.Root
+  performance={performance}
+  onCardClick={handleClick}
+>
+  <PerformanceCard.LikeButton isLiked={isLiked} />
+  <div className='flex gap-4'>
+    <PerformanceCard.Image className='h-40 w-32' />
+    <div>
+      <PerformanceCard.Title />
+      <PerformanceCard.Status />
+      <PerformanceCard.DateRange />
+      <PerformanceCard.Location />
+      <PerformanceCard.Price />
+    </div>
+  </div>
+</PerformanceCard.Root>;
+```
+
+### 3. Named Import 방식 (트리 쉐이킹)
+
+```tsx
+import { Root, Title, Image, Status } from './PerformanceCard';
+
+<Root performance={performance}>
+  <Image />
+  <Title />
+  <Status />
+</Root>;
+```
+
+## API
+
+### PerformanceCard (메인 컴포넌트)
+
+- `performance`: Performance (필수) - 공연 데이터
+- `type`: 'default' | 'compact' | 'vertical' | 'detailed' (기본: 'default')
+- `onCardClick`: (performance) => void - 카드 클릭 핸들러
+- `onLikeClick`: (performance, isLiked) => void - 좋아요 핸들러
+- `isLiked`: boolean (기본: false) - 좋아요 상태
+- `className`: string
+
+#### 가시성 제어 Props
+
+- `showImage`: boolean - 이미지 표시 여부
+- `showTitle`: boolean - 제목 표시 여부
+- `showStatus`: boolean - 상태 표시 여부
+- `showDateRange`: boolean - 공연 기간 표시 여부
+- `showLocation`: boolean - 장소 표시 여부
+- `showCast`: boolean - 출연진 표시 여부
+- `showPrice`: boolean - 가격 표시 여부
+- `showLikeButton`: boolean - 좋아요 버튼 표시 여부
+
+### Compound Components
+
+#### PerformanceCard.Root
+
+- `performance`: Performance (필수)
+- `onCardClick`: (performance) => void
+- `onLikeClick`: (performance, isLiked) => void
+- `children`: ReactNode (필수)
+- `className`: string
+
+#### PerformanceCard.Image
+
+- `className`: string
+- `alt`: string - 이미지 대체 텍스트
+- `fallback`: ReactNode - 이미지 없을 때 표시
+- `priority`: boolean - Next.js Image 우선 로딩
+
+#### PerformanceCard.LikeButton
+
+- `isLiked`: boolean (기본: false)
+- `showText`: boolean (기본: false) - 텍스트 표시 여부
+- `icon`: { liked, unliked } - 커스텀 아이콘
+- `children`: ReactNode - 커스텀 텍스트
+
+#### 기타 컴포넌트
+
+- `Title`, `Status`, `DateRange`, `Location`, `Cast`, `Price`
+- 공통 props: `className`, `children`, `fallback`
+
+## 카드 타입
+
+- **default**: 표준 가로형, 모든 정보 표시
+- **compact**: 압축형 가로형, 주요 정보만 표시 (출연진 기본 숨김)
+- **vertical**: 세로형, 이미지 상단 배치
+- **detailed**: 확장형 가로형, 상세 정보 강조
+
+### 카드 타입별 기본 가시성
+
+- **default/detailed/vertical**: 모든 요소 표시
+- **compact**: `showCast=false` (출연진 기본 숨김)
+
+## 예제
+
+### 동적 타입 선택
+
+```tsx
+const cardType = isMobile ? 'compact' : 'default';
+
+<PerformanceCard
+  performance={performance}
+  type={cardType}
+  onCardClick={handleClick}
+/>;
+```
+
+### 가시성 제어
+
+```tsx
+// 특정 요소만 표시
+<PerformanceCard
+  performance={performance}
+  type="compact"
+  showImage={true}
+  showTitle={true}
+  showStatus={false}  // 상태 숨김
+  showPrice={false}   // 가격 숨김
+  showCast={false}    // 출연진 숨김
+/>
+
+// 이미지 없는 카드
+<PerformanceCard
+  performance={performance}
+  showImage={false}
+  showLikeButton={false}
+/>
+
+// 최소 정보만 표시
+<PerformanceCard
+  performance={performance}
+  type="compact"
+  showTitle={true}
+  showStatus={true}
+  showImage={false}
+  showDateRange={false}
+  showLocation={false}
+  showCast={false}
+  showPrice={false}
+  showLikeButton={false}
+/>
+```
+
+### 리스트 렌더링
+
+```tsx
+{
+  performances.map((perf) => (
+    <PerformanceCard
+      key={perf.id}
+      performance={perf}
+      type='compact'
+      onCardClick={handleClick}
+      isLiked={likedPerfs.includes(perf.id)}
+      showCast={false} // 리스트에서는 출연진 숨김
+    />
+  ));
+}
+```
+
+### 완전 커스터마이징
+
+```tsx
+<PerformanceCard.Root performance={performance}>
+  <div className='rounded-lg bg-white p-4 shadow-lg'>
+    <div className='mb-2 flex items-start justify-between'>
+      <PerformanceCard.Title className='text-xl font-bold' />
+      <PerformanceCard.LikeButton showText />
+    </div>
+    <PerformanceCard.Image className='mb-3 h-48 w-full' />
+    <div className='space-y-1'>
+      <PerformanceCard.Status />
+      <PerformanceCard.DateRange className='text-gray-600' />
+      <PerformanceCard.Location className='text-gray-600' />
+      <PerformanceCard.Price className='font-medium text-blue-600' />
+    </div>
+  </div>
+</PerformanceCard.Root>
+```
+
+### Named Import로 최적화
+
+```tsx
+import { Root, Image, Title, Status } from './PerformanceCard';
+
+<Root performance={performance}>
+  <Image priority />
+  <Title />
+  <Status />
+</Root>;
+```
+
+## Export 방식
+
+### Default Export
+
+```tsx
+import PerformanceCard from './PerformanceCard';
+// 메인 컴포넌트 + Compound 방식 모두 사용 가능
+```
+
+### Named Exports
+
+```tsx
+import { Root, Title, Image } from './PerformanceCard';
+// 개별 컴포넌트만 import (트리 쉐이킹 최적화)
+```
+
+### Compound Properties
+
+```tsx
+import PerformanceCard from './PerformanceCard';
+// PerformanceCard.Root, PerformanceCard.Title 등으로 사용
+```
+
+## 주요 규칙
+
+- 모든 하위 컴포넌트는 `Root` 내부에서 사용 필수
+- `onCardClick` 제공 시에만 카드 클릭 가능
+- `onLikeClick` 제공 시에만 좋아요 버튼 표시
+- 이미지 없을 경우 자동 fallback UI 표시
+- Context 밖에서 하위 컴포넌트 사용 시 에러 발생
+- **가시성 Props가 `false`일 때 해당 요소는 DOM에서 완전히 제거됨**
+- `onLikeClick` 제공 시에만 좋아요 버튼 표시
+- 이미지 없을 경우 자동 fallback UI 표시
+- Context 밖에서 하위 컴포넌트 사용 시 에러 발생
+
+## 접근성
+
+- 클릭 가능한 카드: `role="button"`, `tabIndex={0}`, 키보드 이벤트 지원
+- 좋아요 버튼: 적절한 `aria-label` 설정
+- 이미지: 의미있는 `alt` 텍스트 자동 생성
+- 키보드 네비게이션: Enter, Space 키 지원

--- a/src/components/PerformanceCard/PerformanceCard.messages.ts
+++ b/src/components/PerformanceCard/PerformanceCard.messages.ts
@@ -1,0 +1,44 @@
+export const PERFORMANCE_CARD_MESSAGES = {
+  // Context 에러 메시지
+  CONTEXT_ERROR:
+    'PerformanceCard 컴포넌트는 PerformanceCard.Root 내부에서 사용해야 합니다.',
+
+  // 접근성 레이블
+  CARD_DETAIL_LABEL: (title: string) => `${title} 공연 상세 보기`,
+  LIKE_BUTTON_LABEL: '좋아요',
+  UNLIKE_BUTTON_LABEL: '좋아요 취소',
+
+  // 이미지 alt 텍스트
+  POSTER_ALT: (title: string) => `${title} 포스터`,
+  NO_IMAGE_FALLBACK: 'No Image',
+
+  // 좋아요 버튼 텍스트
+  LIKE_TEXT: '좋아요',
+  UNLIKE_TEXT: '좋아요 취소',
+
+  // 상태 메시지
+  STATUS: {
+    AVAILABLE: '예매 가능',
+    SOLD_OUT: '매진',
+    ENDED: '공연 종료',
+    UPCOMING: '공연 예정',
+  },
+
+  // 에러 메시지
+  ERROR: {
+    LOAD_FAILED: '공연 정보를 불러올 수 없습니다.',
+    IMAGE_LOAD_FAILED: '이미지를 불러올 수 없습니다.',
+  },
+
+  // 빈 상태 메시지
+  EMPTY: {
+    NO_TITLE: '제목 없음',
+    NO_LOCATION: '장소 미정',
+    NO_CAST: '출연진 정보 없음',
+    NO_PRICE: '가격 미정',
+    NO_DATE: '날짜 미정',
+  },
+} as const;
+
+// 타입 안전성을 위한 타입 정의
+export type PerformanceCardMessages = typeof PERFORMANCE_CARD_MESSAGES;

--- a/src/components/PerformanceCard/PerformanceCard.styles.ts
+++ b/src/components/PerformanceCard/PerformanceCard.styles.ts
@@ -1,0 +1,84 @@
+export const performanceCardStyles = {
+  card: {
+    base: 'border rounded-lg bg-white transition-shadow cursor-pointer relative',
+    variant: {
+      default: 'p-4 hover:shadow-lg',
+      compact: 'p-3 hover:shadow-md',
+      detailed: 'p-6 hover:shadow-xl',
+    },
+  },
+
+  likeButton: {
+    base: 'absolute z-10 flex items-center justify-center rounded-full bg-white/80 hover:bg-white transition-colors',
+    size: 'w-8 h-8',
+    position: {
+      default: 'right-3 top-3',
+      compact: 'right-2 top-2',
+    },
+  },
+
+  image: {
+    container: 'relative overflow-hidden',
+    fallback:
+      'w-full h-full bg-gray-200 flex items-center justify-center text-gray-400 text-sm',
+    size: {
+      vertical: 'aspect-[3/4] w-full mb-3 rounded',
+      compact: 'h-16 w-12 rounded flex-shrink-0',
+      default: 'h-32 w-24 rounded flex-shrink-0',
+    },
+  },
+
+  title: {
+    base: 'font-bold',
+    size: {
+      compact: 'text-sm font-semibold mb-1 truncate',
+      default: 'text-lg mb-2',
+      detailed: 'text-xl mb-2',
+      verticalDefault: 'text-base',
+      verticalDetailed: 'text-lg',
+    },
+  },
+
+  status: {
+    base: 'inline-block rounded px-2 py-1 mr-2',
+    size: {
+      compact: 'text-xs',
+      default: 'text-sm',
+    },
+    state: {
+      ended: 'bg-gray-100 text-gray-600',
+      ongoing: 'bg-green-100 text-green-700',
+      upcoming: 'bg-blue-100 text-blue-700',
+    },
+  },
+
+  info: {
+    container: 'space-y-1 text-gray-600',
+    size: {
+      compact: 'text-xs',
+      default: 'text-sm',
+    },
+  },
+
+  price: {
+    compact: 'font-medium text-blue-600',
+    default: 'font-semibold text-blue-600',
+  },
+
+  layout: {
+    vertical: {
+      container: 'space-y-2',
+      info: 'space-y-1 text-sm text-gray-600',
+    },
+    horizontal: {
+      compact: {
+        container: 'flex items-center gap-3 pr-10',
+        content: 'min-w-0 flex-1',
+      },
+      default: {
+        container: 'flex gap-4 pr-12',
+        content: 'min-w-0 flex-1',
+      },
+    },
+  },
+} as const;

--- a/src/components/PerformanceCard/PerformanceCard.test.tsx
+++ b/src/components/PerformanceCard/PerformanceCard.test.tsx
@@ -1,0 +1,446 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { Performance } from '@/types/performance';
+import { PerformanceCard } from './PerformanceCard';
+import { PERFORMANCE_CARD_MESSAGES } from './PerformanceCard.messages';
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: {
+    src: string;
+    alt: string;
+    fill?: boolean;
+    priority?: boolean;
+    className?: string;
+  }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src={props.src}
+      alt={props.alt}
+      className={props.className}
+    />
+  ),
+}));
+
+// 현재 진행중인 공연으로 설정 (현재 날짜 포함)
+const today = new Date();
+const yesterday = new Date(today);
+yesterday.setDate(today.getDate() - 1);
+const futureDate = new Date(today);
+futureDate.setMonth(today.getMonth() + 2); // 2개월 후 종료
+
+const mockPerformance: Performance = {
+  id: '1',
+  title: '레미제라블',
+  startDate: yesterday.toISOString(),
+  endDate: futureDate.toISOString(),
+  location: '블루스퀘어 신한카드홀',
+  cast: ['홍광호', '김소향', '정성화'],
+  price: ['77000', '99000', '121000'],
+  poster: '/images/les-miserables-poster.jpg',
+  state: 'available',
+  visit: 'domestic',
+  time: ['19:30', '14:00'],
+};
+
+describe('PerformanceCard', () => {
+  describe('Root Component', () => {
+    it('기본 렌더링이 정상적으로 동작한다', () => {
+      render(
+        <PerformanceCard.Root performance={mockPerformance}>
+          <div>Test Content</div>
+        </PerformanceCard.Root>
+      );
+
+      expect(screen.getByText('Test Content')).toBeInTheDocument();
+    });
+
+    describe('Messages Integration', () => {
+      it('메시지 객체가 export되어 접근 가능하다', () => {
+        expect(PERFORMANCE_CARD_MESSAGES).toBeDefined();
+        expect(PERFORMANCE_CARD_MESSAGES.CONTEXT_ERROR).toBe(
+          PERFORMANCE_CARD_MESSAGES.CONTEXT_ERROR
+        );
+      });
+
+      it('함수형 메시지가 올바르게 동작한다', () => {
+        const title = '레미제라블';
+        expect(PERFORMANCE_CARD_MESSAGES.CARD_DETAIL_LABEL(title)).toBe(
+          `${title} 공연 상세 보기`
+        );
+        expect(PERFORMANCE_CARD_MESSAGES.POSTER_ALT(title)).toBe(
+          `${title} 포스터`
+        );
+      });
+
+      it('메시지를 외부에서 직접 참조할 수 있다', () => {
+        expect(typeof PERFORMANCE_CARD_MESSAGES.LIKE_TEXT).toBe('string');
+        expect(typeof PERFORMANCE_CARD_MESSAGES.UNLIKE_TEXT).toBe('string');
+      });
+    });
+
+    it('onCardClick이 전달되면 클릭 이벤트가 동작한다', async () => {
+      const user = userEvent.setup();
+      const mockOnCardClick = jest.fn();
+
+      render(
+        <PerformanceCard.Root
+          performance={mockPerformance}
+          onCardClick={mockOnCardClick}
+        >
+          <div>Clickable Content</div>
+        </PerformanceCard.Root>
+      );
+
+      const cardElement = screen.getByRole('button');
+      await user.click(cardElement);
+
+      expect(mockOnCardClick).toHaveBeenCalledWith(mockPerformance);
+    });
+
+    it('onCardClick이 전달되면 키보드 이벤트가 동작한다', () => {
+      const mockOnCardClick = jest.fn();
+
+      render(
+        <PerformanceCard.Root
+          performance={mockPerformance}
+          onCardClick={mockOnCardClick}
+        >
+          <div>Keyboard Accessible</div>
+        </PerformanceCard.Root>
+      );
+
+      const cardElement = screen.getByRole('button');
+      fireEvent.keyDown(cardElement, { key: 'Enter' });
+      expect(mockOnCardClick).toHaveBeenCalledWith(mockPerformance);
+
+      fireEvent.keyDown(cardElement, { key: ' ' });
+      expect(mockOnCardClick).toHaveBeenCalledTimes(2);
+    });
+
+    it('onCardClick이 없으면 button role이 없다', () => {
+      render(
+        <PerformanceCard.Root performance={mockPerformance}>
+          <div>Non-clickable Content</div>
+        </PerformanceCard.Root>
+      );
+
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Individual Components', () => {
+    const renderWithContext = (children: React.ReactNode) =>
+      render(
+        <PerformanceCard.Root performance={mockPerformance}>
+          {children}
+        </PerformanceCard.Root>
+      );
+
+    it('Title 컴포넌트가 제목을 렌더링한다', () => {
+      renderWithContext(<PerformanceCard.Title />);
+      expect(screen.getByText('레미제라블')).toBeInTheDocument();
+    });
+
+    it('Title 컴포넌트에 custom children을 전달할 수 있다', () => {
+      renderWithContext(
+        <PerformanceCard.Title>커스텀 제목</PerformanceCard.Title>
+      );
+      expect(screen.getByText('커스텀 제목')).toBeInTheDocument();
+    });
+
+    it('Status 컴포넌트가 상태를 렌더링한다', () => {
+      renderWithContext(<PerformanceCard.Status />);
+      expect(screen.getByText('공연 중')).toBeInTheDocument();
+    });
+
+    it('DateRange 컴포넌트가 날짜를 렌더링한다', () => {
+      renderWithContext(<PerformanceCard.DateRange />);
+      const currentYear = new Date().getFullYear();
+      const dateRangeElement = screen.getByText(new RegExp(`${currentYear}`));
+      expect(dateRangeElement).toBeInTheDocument();
+    });
+
+    it('Location 컴포넌트가 장소를 렌더링한다', () => {
+      renderWithContext(<PerformanceCard.Location />);
+      expect(screen.getByText('블루스퀘어 신한카드홀')).toBeInTheDocument();
+    });
+
+    it('Cast 컴포넌트가 출연진을 렌더링한다', () => {
+      renderWithContext(<PerformanceCard.Cast />);
+      expect(screen.getByText('홍광호, 김소향 외 1명')).toBeInTheDocument();
+    });
+
+    it('Price 컴포넌트가 가격을 렌더링한다', () => {
+      renderWithContext(<PerformanceCard.Price />);
+      expect(screen.getByText('77,000원 - 121,000원')).toBeInTheDocument();
+    });
+
+    it('Image 컴포넌트가 이미지를 렌더링한다', () => {
+      renderWithContext(<PerformanceCard.Image />);
+      const image = screen.getByAltText(
+        PERFORMANCE_CARD_MESSAGES.POSTER_ALT('레미제라블')
+      );
+      expect(image).toBeInTheDocument();
+      expect(image.getAttribute('src')).toContain(
+        '/images/les-miserables-poster.jpg'
+      );
+    });
+
+    it('Image 컴포넌트가 fallback을 렌더링한다', () => {
+      const performanceWithoutImage = { ...mockPerformance, poster: '' };
+      render(
+        <PerformanceCard.Root performance={performanceWithoutImage}>
+          <PerformanceCard.Image />
+        </PerformanceCard.Root>
+      );
+      expect(
+        screen.getByText(PERFORMANCE_CARD_MESSAGES.NO_IMAGE_FALLBACK)
+      ).toBeInTheDocument();
+    });
+
+    it('Image 컴포넌트에 custom fallback을 전달할 수 있다', () => {
+      const performanceWithoutImage = { ...mockPerformance, poster: '' };
+      render(
+        <PerformanceCard.Root performance={performanceWithoutImage}>
+          <PerformanceCard.Image fallback={<div>커스텀 Fallback</div>} />
+        </PerformanceCard.Root>
+      );
+      expect(screen.getByText('커스텀 Fallback')).toBeInTheDocument();
+    });
+  });
+
+  describe('LikeButton Component', () => {
+    const renderLikeButtonWithContext = (
+      props: Parameters<typeof PerformanceCard.LikeButton>[0] = {}
+    ) => {
+      const mockOnLikeClick = jest.fn();
+      return {
+        mockOnLikeClick,
+        ...render(
+          <PerformanceCard.Root
+            performance={mockPerformance}
+            onLikeClick={mockOnLikeClick}
+          >
+            <PerformanceCard.LikeButton {...props} />
+          </PerformanceCard.Root>
+        ),
+      };
+    };
+
+    it('좋아요 버튼이 렌더링된다', () => {
+      renderLikeButtonWithContext();
+      const likeButton = screen.getByRole('button', {
+        name: PERFORMANCE_CARD_MESSAGES.LIKE_BUTTON_LABEL,
+      });
+      expect(likeButton).toBeInTheDocument();
+    });
+
+    it('좋아요 버튼 클릭이 동작한다', async () => {
+      const user = userEvent.setup();
+      const { mockOnLikeClick } = renderLikeButtonWithContext({
+        isLiked: false,
+      });
+
+      const likeButton = screen.getByRole('button', {
+        name: PERFORMANCE_CARD_MESSAGES.LIKE_BUTTON_LABEL,
+      });
+      await user.click(likeButton);
+
+      expect(mockOnLikeClick).toHaveBeenCalledWith(mockPerformance, true);
+    });
+
+    it('좋아요 취소 버튼 클릭이 동작한다', async () => {
+      const user = userEvent.setup();
+      const { mockOnLikeClick } = renderLikeButtonWithContext({
+        isLiked: true,
+      });
+
+      const likeButton = screen.getByRole('button', {
+        name: PERFORMANCE_CARD_MESSAGES.UNLIKE_BUTTON_LABEL,
+      });
+      await user.click(likeButton);
+
+      expect(mockOnLikeClick).toHaveBeenCalledWith(mockPerformance, false);
+    });
+
+    it('좋아요 버튼 클릭 시 이벤트 전파가 중단된다', async () => {
+      const user = userEvent.setup();
+      const mockOnCardClick = jest.fn();
+      const mockOnLikeClick = jest.fn();
+
+      render(
+        <PerformanceCard.Root
+          performance={mockPerformance}
+          onCardClick={mockOnCardClick}
+          onLikeClick={mockOnLikeClick}
+        >
+          <PerformanceCard.LikeButton />
+        </PerformanceCard.Root>
+      );
+
+      const likeButton = screen.getByRole('button', {
+        name: PERFORMANCE_CARD_MESSAGES.LIKE_BUTTON_LABEL,
+      });
+      await user.click(likeButton);
+
+      expect(mockOnLikeClick).toHaveBeenCalled();
+      expect(mockOnCardClick).not.toHaveBeenCalled();
+    });
+
+    it('onLikeClick이 없으면 좋아요 버튼이 렌더링되지 않는다', () => {
+      render(
+        <PerformanceCard.Root performance={mockPerformance}>
+          <PerformanceCard.LikeButton />
+        </PerformanceCard.Root>
+      );
+
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+
+    it('showText가 true이면 텍스트가 표시된다', () => {
+      renderLikeButtonWithContext({ showText: true });
+      expect(
+        screen.getByText(PERFORMANCE_CARD_MESSAGES.LIKE_TEXT)
+      ).toBeInTheDocument();
+    });
+
+    it('커스텀 아이콘을 설정할 수 있다', () => {
+      renderLikeButtonWithContext({
+        icon: { liked: '💖', unliked: '🖤' },
+        isLiked: false,
+      });
+      expect(screen.getByText('🖤')).toBeInTheDocument();
+    });
+  });
+
+  describe('Preset Components', () => {
+    it('DefaultCard가 기본 스타일로 렌더링된다', () => {
+      render(
+        <PerformanceCard
+          type='default'
+          performance={mockPerformance}
+          onCardClick={jest.fn()}
+        />
+      );
+
+      expect(screen.getByText('레미제라블')).toBeInTheDocument();
+      expect(screen.getByText('공연 중')).toBeInTheDocument();
+      expect(screen.getByText('블루스퀘어 신한카드홀')).toBeInTheDocument();
+    });
+
+    it('CompactCard가 컴팩트 스타일로 렌더링된다', () => {
+      render(
+        <PerformanceCard
+          type='compact'
+          performance={mockPerformance}
+          onCardClick={jest.fn()}
+        />
+      );
+
+      expect(screen.getByText('레미제라블')).toBeInTheDocument();
+    });
+
+    it('VerticalCard가 세로 스타일로 렌더링된다', () => {
+      render(
+        <PerformanceCard
+          type='vertical'
+          performance={mockPerformance}
+          onCardClick={jest.fn()}
+        />
+      );
+
+      expect(screen.getByText('레미제라블')).toBeInTheDocument();
+    });
+
+    it('DetailedCard가 상세 스타일로 렌더링된다', () => {
+      render(
+        <PerformanceCard
+          type='detailed'
+          performance={mockPerformance}
+          onCardClick={jest.fn()}
+        />
+      );
+
+      expect(screen.getByText('레미제라블')).toBeInTheDocument();
+    });
+  });
+
+  describe('Context Error Handling', () => {
+    it('Context 밖에서 하위 컴포넌트를 사용하면 에러가 발생한다', () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      expect(() => {
+        render(<PerformanceCard.Title />);
+      }).toThrow(PERFORMANCE_CARD_MESSAGES.CONTEXT_ERROR);
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('클릭 가능한 카드에 적절한 aria-label이 설정된다', () => {
+      render(
+        <PerformanceCard.Root
+          performance={mockPerformance}
+          onCardClick={jest.fn()}
+        >
+          <div>Content</div>
+        </PerformanceCard.Root>
+      );
+
+      const button = screen.getByRole('button');
+      expect(button).toHaveAttribute(
+        'aria-label',
+        PERFORMANCE_CARD_MESSAGES.CARD_DETAIL_LABEL('레미제라블')
+      );
+    });
+
+    it('좋아요 버튼에 적절한 aria-label이 설정된다', () => {
+      render(
+        <PerformanceCard.Root
+          performance={mockPerformance}
+          onLikeClick={jest.fn()}
+        >
+          <PerformanceCard.LikeButton isLiked={false} />
+        </PerformanceCard.Root>
+      );
+
+      const likeButton = screen.getByRole('button');
+      expect(likeButton).toHaveAttribute(
+        'aria-label',
+        PERFORMANCE_CARD_MESSAGES.LIKE_BUTTON_LABEL
+      );
+    });
+  });
+
+  describe('Custom Props', () => {
+    it('className이 적절히 적용된다', () => {
+      const { container } = render(
+        <PerformanceCard.Root
+          performance={mockPerformance}
+          className='custom-class'
+        >
+          <div>Content</div>
+        </PerformanceCard.Root>
+      );
+
+      expect(container.firstChild).toHaveClass('custom-class');
+    });
+
+    it('data-testid 같은 custom props가 전달된다', () => {
+      render(
+        <PerformanceCard.Root
+          performance={mockPerformance}
+          data-testid='performance-card'
+        >
+          <div>Content</div>
+        </PerformanceCard.Root>
+      );
+
+      expect(screen.getByTestId('performance-card')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/PerformanceCard/PerformanceCard.tsx
+++ b/src/components/PerformanceCard/PerformanceCard.tsx
@@ -1,0 +1,578 @@
+/* eslint-disable react-refresh/only-export-components */
+import React from 'react';
+import Image from 'next/image';
+import { cn } from '@/lib/utils';
+import { Performance } from '@/types/performance';
+import formatPerformanceData from '@/utils/formatPerformanceData';
+import { PERFORMANCE_CARD_MESSAGES } from './PerformanceCard.messages';
+import { performanceCardStyles as styles } from './PerformanceCard.styles';
+
+/* Context */
+interface PerformanceCardContextValue {
+  performance: Performance;
+  data: ReturnType<typeof formatPerformanceData>;
+  onCardClick?: (performance: Performance) => void;
+  onLikeClick?: (performance: Performance, isLiked: boolean) => void;
+}
+
+const PerformanceCardContext =
+  React.createContext<PerformanceCardContextValue | null>(null);
+
+const usePerformanceCardContext = () => {
+  const context = React.useContext(PerformanceCardContext);
+  if (!context) {
+    throw new Error(PERFORMANCE_CARD_MESSAGES.CONTEXT_ERROR);
+  }
+  return context;
+};
+
+/* Headless Component */
+
+// Root
+interface RootProps {
+  performance: Performance;
+  onCardClick?: (performance: Performance) => void;
+  onLikeClick?: (performance: Performance, isLiked: boolean) => void;
+  children: React.ReactNode;
+  className?: string;
+}
+
+const Root = ({
+  performance,
+  onCardClick,
+  onLikeClick,
+  children,
+  className,
+  ...props
+}: RootProps & Omit<React.HTMLAttributes<HTMLDivElement>, 'onClick'>) => {
+  const data = formatPerformanceData(performance);
+
+  const contextValue: PerformanceCardContextValue = {
+    performance,
+    data,
+    onCardClick,
+    onLikeClick,
+  };
+
+  const handleClick = () => onCardClick?.(performance);
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (onCardClick && (e.key === 'Enter' || e.key === ' ')) {
+      e.preventDefault();
+      onCardClick(performance);
+    }
+  };
+
+  return (
+    <PerformanceCardContext.Provider value={contextValue}>
+      <div
+        className={className}
+        onClick={onCardClick ? handleClick : undefined}
+        onKeyDown={onCardClick ? handleKeyDown : undefined}
+        role={onCardClick ? 'button' : undefined}
+        tabIndex={onCardClick ? 0 : undefined}
+        aria-label={
+          onCardClick
+            ? PERFORMANCE_CARD_MESSAGES.CARD_DETAIL_LABEL(data.title)
+            : undefined
+        }
+        {...props}
+      >
+        {children}
+      </div>
+    </PerformanceCardContext.Provider>
+  );
+};
+
+// Image
+interface ImageProps {
+  className?: string;
+  alt?: string;
+  fallback?: React.ReactNode;
+  priority?: boolean;
+}
+
+const ImageComponent = ({
+  className,
+  alt,
+  fallback,
+  priority = false,
+  ...props
+}: ImageProps & React.HTMLAttributes<HTMLDivElement>) => {
+  const { data } = usePerformanceCardContext();
+
+  return (
+    <div
+      className={cn(styles.image.container, className)}
+      {...props}
+    >
+      {data.mainImage ? (
+        <Image
+          fill
+          src={data.mainImage}
+          alt={alt || PERFORMANCE_CARD_MESSAGES.POSTER_ALT(data.title)}
+          className='object-cover'
+          priority={priority}
+        />
+      ) : (
+        fallback || (
+          <div className={styles.image.fallback}>
+            {PERFORMANCE_CARD_MESSAGES.NO_IMAGE_FALLBACK}
+          </div>
+        )
+      )}
+    </div>
+  );
+};
+
+// Content
+interface ContentProps {
+  className?: string;
+  children?: React.ReactNode;
+  fallback?: React.ReactNode;
+}
+
+const Title = ({
+  className,
+  children,
+  fallback,
+  ...props
+}: ContentProps & React.HTMLAttributes<HTMLHeadingElement>) => {
+  const { data } = usePerformanceCardContext();
+  return (
+    <h3
+      className={cn(styles.title.base, className)}
+      {...props}
+    >
+      {children || data.title || fallback}
+    </h3>
+  );
+};
+
+const Status = ({
+  className,
+  children,
+  fallback,
+  ...props
+}: ContentProps & React.HTMLAttributes<HTMLSpanElement>) => {
+  const { data } = usePerformanceCardContext();
+
+  const stateClass = data.isEnded
+    ? styles.status.state.ended
+    : data.isOngoing
+      ? styles.status.state.ongoing
+      : styles.status.state.upcoming;
+
+  return (
+    <span
+      className={cn(styles.status.base, stateClass, className)}
+      {...props}
+    >
+      {children || data.status || fallback}
+    </span>
+  );
+};
+
+const DateRange = ({
+  className,
+  children,
+  fallback,
+  ...props
+}: ContentProps & React.HTMLAttributes<HTMLDivElement>) => {
+  const { data } = usePerformanceCardContext();
+  return (
+    <div
+      className={className}
+      {...props}
+    >
+      {children || data.dateRange || fallback}
+    </div>
+  );
+};
+
+const Location = ({
+  className,
+  children,
+  fallback,
+  ...props
+}: ContentProps & React.HTMLAttributes<HTMLDivElement>) => {
+  const { data } = usePerformanceCardContext();
+  return (
+    <div
+      className={className}
+      {...props}
+    >
+      {children || data.location || fallback}
+    </div>
+  );
+};
+
+const Cast = ({
+  className,
+  children,
+  fallback,
+  ...props
+}: ContentProps & React.HTMLAttributes<HTMLDivElement>) => {
+  const { data } = usePerformanceCardContext();
+  return (
+    <div
+      className={className}
+      {...props}
+    >
+      {children || data.castSummary || fallback}
+    </div>
+  );
+};
+
+const Price = ({
+  className,
+  children,
+  fallback,
+  ...props
+}: ContentProps & React.HTMLAttributes<HTMLDivElement>) => {
+  const { data } = usePerformanceCardContext();
+  return (
+    <div
+      className={className}
+      {...props}
+    >
+      {children || data.priceRange || fallback}
+    </div>
+  );
+};
+
+// LikeButton
+interface LikeButtonProps {
+  isLiked?: boolean;
+  showText?: boolean;
+  className?: string;
+  children?: React.ReactNode;
+  icon?: {
+    liked: React.ReactNode;
+    unliked: React.ReactNode;
+  };
+}
+
+const LikeButton = ({
+  isLiked = false,
+  showText = false,
+  className,
+  children,
+  icon = { liked: '❤️', unliked: '🤍' },
+  ...props
+}: LikeButtonProps
+  & Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'onClick'>) => {
+  const { performance, onLikeClick } = usePerformanceCardContext();
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onLikeClick?.(performance, !isLiked);
+  };
+
+  if (!onLikeClick) return null;
+
+  return (
+    <button
+      onClick={handleClick}
+      className={cn(styles.likeButton.base, className)}
+      aria-label={
+        isLiked
+          ? PERFORMANCE_CARD_MESSAGES.UNLIKE_BUTTON_LABEL
+          : PERFORMANCE_CARD_MESSAGES.LIKE_BUTTON_LABEL
+      }
+      {...props}
+    >
+      <span>{isLiked ? icon.liked : icon.unliked}</span>
+      {showText && (
+        <span className='ml-1'>
+          {children
+            || (isLiked
+              ? PERFORMANCE_CARD_MESSAGES.UNLIKE_TEXT
+              : PERFORMANCE_CARD_MESSAGES.LIKE_TEXT)}
+        </span>
+      )}
+    </button>
+  );
+};
+
+/* compound */
+
+interface VisibilityProps {
+  showImage?: boolean;
+  showTitle?: boolean;
+  showStatus?: boolean;
+  showDateRange?: boolean;
+  showLocation?: boolean;
+  showCast?: boolean;
+  showPrice?: boolean;
+  showLikeButton?: boolean;
+}
+
+// variants
+const DefaultCard = ({
+  isLiked = false,
+  showImage = true,
+  showTitle = true,
+  showStatus = true,
+  showDateRange = true,
+  showLocation = true,
+  showCast = true,
+  showPrice = true,
+  showLikeButton = true,
+}: { isLiked?: boolean } & VisibilityProps) => (
+  <>
+    {showLikeButton && (
+      <LikeButton
+        isLiked={isLiked}
+        className={cn(
+          styles.likeButton.size,
+          styles.likeButton.position.default
+        )}
+      />
+    )}
+    <div className={styles.layout.horizontal.default.container}>
+      {showImage && <ImageComponent className={styles.image.size.default} />}
+      <div className={styles.layout.horizontal.default.content}>
+        {showTitle && <Title className={styles.title.size.default} />}
+        <div className={cn(styles.info.container, styles.info.size.default)}>
+          {showStatus && <Status className={styles.status.size.default} />}
+          {showDateRange && <DateRange />}
+          {showLocation && <Location />}
+          {showCast && <Cast />}
+          {showPrice && <Price className={styles.price.default} />}
+        </div>
+      </div>
+    </div>
+  </>
+);
+
+const CompactCard = ({
+  isLiked = false,
+  showImage = true,
+  showTitle = true,
+  showStatus = true,
+  showDateRange = true,
+  showLocation = true,
+  showCast = false,
+  showPrice = true,
+  showLikeButton = true,
+}: { isLiked?: boolean } & VisibilityProps) => (
+  <>
+    {showLikeButton && (
+      <LikeButton
+        isLiked={isLiked}
+        className={cn(
+          styles.likeButton.size,
+          styles.likeButton.position.compact
+        )}
+      />
+    )}
+    <div className={styles.layout.horizontal.compact.container}>
+      {showImage && <ImageComponent className={styles.image.size.compact} />}
+      <div className={styles.layout.horizontal.compact.content}>
+        {showTitle && <Title className={styles.title.size.compact} />}
+        <div className={cn(styles.info.container, styles.info.size.compact)}>
+          {showStatus && <Status className={styles.status.size.compact} />}
+          {showDateRange && <DateRange />}
+          {showLocation && <Location />}
+          {showCast && <Cast />}
+          {showPrice && <Price className={styles.price.compact} />}
+        </div>
+      </div>
+    </div>
+  </>
+);
+
+const VerticalCard = ({
+  isLiked = false,
+  showImage = true,
+  showTitle = true,
+  showStatus = true,
+  showDateRange = true,
+  showLocation = true,
+  showCast = true,
+  showPrice = true,
+  showLikeButton = true,
+}: { isLiked?: boolean } & VisibilityProps) => (
+  <>
+    {showLikeButton && (
+      <LikeButton
+        isLiked={isLiked}
+        className={cn(
+          styles.likeButton.size,
+          styles.likeButton.position.default
+        )}
+      />
+    )}
+    {showImage && <ImageComponent className={styles.image.size.vertical} />}
+    <div className={styles.layout.vertical.container}>
+      {showTitle && <Title className={styles.title.size.verticalDefault} />}
+      <div className={styles.layout.vertical.info}>
+        {showStatus && <Status className={styles.status.size.default} />}
+        {showDateRange && <DateRange />}
+        {showLocation && <Location />}
+        {showCast && <Cast />}
+        {showPrice && <Price className={styles.price.default} />}
+      </div>
+    </div>
+  </>
+);
+
+const DetailedCard = ({
+  isLiked = false,
+  showImage = true,
+  showTitle = true,
+  showStatus = true,
+  showDateRange = true,
+  showLocation = true,
+  showCast = true,
+  showPrice = true,
+  showLikeButton = true,
+}: { isLiked?: boolean } & VisibilityProps) => (
+  <>
+    {showLikeButton && (
+      <LikeButton
+        isLiked={isLiked}
+        className={cn(
+          styles.likeButton.size,
+          styles.likeButton.position.default
+        )}
+      />
+    )}
+    <div className={styles.layout.horizontal.default.container}>
+      {showImage && <ImageComponent className={styles.image.size.default} />}
+      <div className={styles.layout.horizontal.default.content}>
+        {showTitle && <Title className={styles.title.size.detailed} />}
+        <div className={cn(styles.info.container, styles.info.size.default)}>
+          {showStatus && <Status className={styles.status.size.default} />}
+          {showDateRange && <DateRange />}
+          {showLocation && <Location />}
+          {showCast && <Cast />}
+          {showPrice && <Price className={styles.price.default} />}
+        </div>
+      </div>
+    </div>
+  </>
+);
+
+/* export */
+type CardType = 'default' | 'compact' | 'vertical' | 'detailed';
+
+interface PerformanceCardProps extends VisibilityProps {
+  performance: Performance;
+  type?: CardType;
+  className?: string;
+  onCardClick?: (performance: Performance) => void;
+  onLikeClick?: (performance: Performance, isLiked: boolean) => void;
+  isLiked?: boolean;
+}
+
+const PerformanceCard = ({
+  performance,
+  type = 'default',
+  className,
+  onCardClick,
+  onLikeClick,
+  isLiked = false,
+  showImage,
+  showTitle,
+  showStatus,
+  showDateRange,
+  showLocation,
+  showCast,
+  showPrice,
+  showLikeButton,
+}: PerformanceCardProps) => {
+  const visibilityProps = {
+    showImage,
+    showTitle,
+    showStatus,
+    showDateRange,
+    showLocation,
+    showCast,
+    showPrice,
+    showLikeButton,
+  };
+
+  const getCardContent = () => {
+    switch (type) {
+      case 'compact':
+        return (
+          <CompactCard
+            isLiked={isLiked}
+            {...visibilityProps}
+          />
+        );
+      case 'vertical':
+        return (
+          <VerticalCard
+            isLiked={isLiked}
+            {...visibilityProps}
+          />
+        );
+      case 'detailed':
+        return (
+          <DetailedCard
+            isLiked={isLiked}
+            {...visibilityProps}
+          />
+        );
+      default:
+        return (
+          <DefaultCard
+            isLiked={isLiked}
+            {...visibilityProps}
+          />
+        );
+    }
+  };
+
+  const getCardVariantClass = () => {
+    switch (type) {
+      case 'compact':
+        return styles.card.variant.compact;
+      case 'detailed':
+        return styles.card.variant.detailed;
+      default:
+        return styles.card.variant.default;
+    }
+  };
+
+  return (
+    <Root
+      performance={performance}
+      onCardClick={onCardClick}
+      onLikeClick={onLikeClick}
+      className={cn(styles.card.base, getCardVariantClass(), className)}
+    >
+      {getCardContent()}
+    </Root>
+  );
+};
+
+export default PerformanceCard;
+
+export {
+  PerformanceCard,
+  Root,
+  ImageComponent as Image,
+  Title,
+  Status,
+  DateRange,
+  Location,
+  Cast,
+  Price,
+  LikeButton,
+  usePerformanceCardContext,
+  type VisibilityProps,
+};
+
+PerformanceCard.Root = Root;
+PerformanceCard.Image = ImageComponent;
+PerformanceCard.Title = Title;
+PerformanceCard.Status = Status;
+PerformanceCard.DateRange = DateRange;
+PerformanceCard.Location = Location;
+PerformanceCard.Cast = Cast;
+PerformanceCard.Price = Price;
+PerformanceCard.LikeButton = LikeButton;
+PerformanceCard.useContext = usePerformanceCardContext;

--- a/src/types/performance.ts
+++ b/src/types/performance.ts
@@ -1,0 +1,26 @@
+export interface Performance {
+  id: string; // 공연 ID
+  title: string; // 공연명
+  startDate: string; // 공연 시작 날짜 (ISO 8601)
+  endDate: string; // 공연 종료 날짜 (ISO 8601)
+  location: string; // 공연 장소
+  cast: string[]; // 공연 출연진
+  crew?: string[]; // 공연 제작진
+  runtime?: string; // 공연 런타임
+  age?: string; // 관람 연령
+  productionCompany?: string[]; // 제작사
+  agency?: string[]; // 기획사
+  host?: string[]; // 주최
+  organizer?: string[]; // 주관
+  price: string[]; // 티켓 가격
+  poster?: string; // 포스터 이미지 URL
+  state: string; // 공연 상태
+  visit: string; // 내한 여부
+  imgs?: {
+    // 소개 이미지 목록
+    id: string; // 이미지 ID
+    src: string; // 소개 이미지 URL
+    alt?: string; // 소개 이미지 설명
+  }[];
+  time: string[]; // 공연 시간 (ISO 8601) 배열
+}

--- a/src/utils/formatPerformanceData.ts
+++ b/src/utils/formatPerformanceData.ts
@@ -1,0 +1,93 @@
+import {
+  format,
+  parseISO,
+  isAfter,
+  isBefore,
+  differenceInDays,
+  isWithinInterval,
+} from 'date-fns';
+import { ko } from 'date-fns/locale';
+import { Performance } from '@/types/performance';
+
+const formatPerformanceData = (performance: Performance, locale = ko) => {
+  const startDate = parseISO(performance.startDate);
+  const endDate = parseISO(performance.endDate);
+  const now = new Date();
+
+  const formattedStartDate = format(startDate, 'yyyy.MM.dd', { locale });
+  const formattedEndDate = format(endDate, 'yyyy.MM.dd', { locale });
+
+  const dateRange =
+    formattedStartDate === formattedEndDate
+      ? formattedStartDate
+      : `${formattedStartDate} - ${formattedEndDate}`;
+
+  const daysUntilStart = differenceInDays(startDate, now);
+  const isOngoing = isWithinInterval(now, { start: startDate, end: endDate });
+  const isUpcoming = isAfter(startDate, now);
+  const isEnded = isBefore(endDate, now);
+
+  const STATUS_MESSAGES = {
+    ENDED: '공연 종료',
+    ONGOING: '공연 중',
+    SCHEDULED: '공연 예정',
+    D_DAY: (days: number) => `D-${days}`,
+  };
+
+  const status = (() => {
+    if (isEnded) return STATUS_MESSAGES.ENDED;
+    if (isOngoing) return STATUS_MESSAGES.ONGOING;
+    if (daysUntilStart <= 7) return STATUS_MESSAGES.D_DAY(daysUntilStart);
+    return STATUS_MESSAGES.SCHEDULED;
+  })();
+
+  const prices = performance.price
+    .map((p) => parseInt(p.replace(/[^\d]/g, '')))
+    .filter((p) => !isNaN(p))
+    .sort((a, b) => a - b);
+
+  const priceRange = (() => {
+    if (prices.length === 0) return '가격 미정';
+    if (prices.length === 1) return `${prices[0].toLocaleString()}원`;
+    return `${prices[0].toLocaleString()}원 - ${prices[prices.length - 1].toLocaleString()}원`;
+  })();
+
+  const CAST_MAX_NUM = 2;
+
+  const castSummary = ((cast: string[]) => {
+    if (cast.length === 0) return '출연진 미정';
+    if (cast.length <= CAST_MAX_NUM) return cast.join(', ');
+    return `${cast.slice(0, CAST_MAX_NUM).join(', ')} 외 ${cast.length - CAST_MAX_NUM}명`;
+  })(performance.cast);
+
+  const mainImage = performance.poster || performance.imgs?.[0]?.src;
+
+  return {
+    id: performance.id,
+    title: performance.title,
+    location: performance.location,
+    runtime: performance.runtime,
+    age: performance.age,
+
+    dateRange,
+    status,
+    priceRange,
+    castSummary,
+    mainImage,
+
+    isOngoing,
+    isUpcoming,
+    isEnded,
+    isTicketAvailable: performance.state === 'available',
+
+    startDate,
+    endDate,
+    formattedStartDate,
+    formattedEndDate,
+    daysUntilStart,
+
+    getDetailUrl: () => `/performances/${performance.id}`,
+  };
+};
+
+export default formatPerformanceData;


### PR DESCRIPTION
* feat: Performance Type 추가

* design: 공연 카드 디자인 파일 추가

* feat: 공연 카드 데이터 포매팅 함수 추가

* feat: 공연 카드 컴포넌트 추가

* refactor: fallback 추가 및 타입 구조 개선

* refactor: 메세지 모듈로 분리

* chore: test 설정에 aliases 추가

* test: 공연 카드 테스트 추가

* rename: 테스트 오타 수정

* refactor: props로 type 지정하도록 변경

* test: refactor에 맞춰 테스트 수정

* docs: 공연 카드 readme 추가

* refactor: 각 요소 가시성 커스텀 prop 추가

* docs: 가시성 제어 추가