### PR TITLE
[Refacotr/issue-208] PerformanceCard 컴포넌트 리펙토링

### DIFF
--- a/src/components/common/PerformanceCard/PerformanceCard.md
+++ b/src/components/common/PerformanceCard/PerformanceCard.md
@@ -1,280 +1,699 @@
 # PerformanceCard 컴포넌트
 
-공연 정보 표시용 재사용 가능 컴포넌트 (Compound Component + Headless UI 패턴)
+공연 정보를 표시하는 재사용 가능한 컴포넌트입니다. Compound Component 패턴을 사용하여 유연한 커스터마이징을 제공합니다.
 
-## 특징
+## 🎯 특징
 
-- Type prop으로 간편한 카드 타입 선택
-- Compound Component 패턴으로 유연한 커스터마이징
-- Headless UI 구조로 스타일과 로직 분리
-- 4가지 사전 정의 카드 레이아웃
-- **가시성 제어 Props로 각 요소 표시/숨김 제어**
-- 접근성 지원 (키보드 네비게이션, ARIA)
-- TypeScript 완전 지원
+- **Compound Component 패턴**: 개별 요소를 자유롭게 조합
+- **스타일 분리**: 로직과 스타일의 완전한 분리
+- **TypeScript 완전 지원**: 타입 안전성 보장
+- **접근성 지원**: 키보드 네비게이션, ARIA 레이블
+- **Context 기반**: 효율적인 데이터 공유
 
-## 사용법
+## 📋 목차
 
-### 1. Type Prop 방식 (권장)
+1. [기본 사용법](#기본-사용법)
+2. [Import 방법](#import-방법)
+3. [컴포넌트 구조](#컴포넌트-구조)
+4. [API Reference](#api-reference)
+5. [유의사항](#유의사항)
+6. [예제 모음](#예제-모음)
 
-```tsx
-// 기본 카드
-<PerformanceCard
-  performance={performance}
-  type="default"
-  onCardClick={handleClick}
-  onLikeClick={handleLike}
-  isLiked={false}
-/>
+## 🚀 기본 사용법
 
-// 타입별 카드
-<PerformanceCard performance={performance} type="compact" />
-<PerformanceCard performance={performance} type="vertical" />
-<PerformanceCard performance={performance} type="detailed" />
+### 1단계: Import 하기
 
-// 가시성 제어
-<PerformanceCard
-  performance={performance}
-  type="compact"
-  showCast={false}
-  showPrice={false}
-/>
+```typescript
+// 방법 1: Named import (권장 - 트리 쉐이킹 최적화)
+import {
+  Root,
+  Image,
+  Title,
+  Status,
+  LikeButton,
+} from '@/components/PerformanceCard';
+
+// 방법 2: 전체 import
+import * as PerformanceCard from '@/components/PerformanceCard';
 ```
 
-### 2. Compound Component 방식 (커스터마이징)
+### 2단계: Root 컴포넌트로 감싸기
 
-```tsx
-import PerformanceCard from './PerformanceCard';
+**⚠️ 중요**: 모든 하위 컴포넌트는 반드시 `Root` 내부에서 사용해야 합니다!
 
-<PerformanceCard.Root
-  performance={performance}
-  onCardClick={handleClick}
->
-  <PerformanceCard.LikeButton isLiked={isLiked} />
-  <div className='flex gap-4'>
-    <PerformanceCard.Image className='h-40 w-32' />
-    <div>
-      <PerformanceCard.Title />
-      <PerformanceCard.Status />
-      <PerformanceCard.DateRange />
-      <PerformanceCard.Location />
-      <PerformanceCard.Price />
-    </div>
-  </div>
-</PerformanceCard.Root>;
-```
-
-### 3. Named Import 방식 (트리 쉐이킹)
-
-```tsx
-import { Root, Title, Image, Status } from './PerformanceCard';
-
-<Root performance={performance}>
-  <Image />
+```typescript
+// ✅ 올바른 사용법
+<Root performance={performanceData}>
   <Title />
   <Status />
-</Root>;
+  <Image />
+</Root>
+
+// ❌ 잘못된 사용법 - 에러 발생!
+<Title />  {/* Context 에러 발생 */}
+<Status /> {/* Context 에러 발생 */}
 ```
 
-## API
+### 3단계: 필요한 컴포넌트 조합하기
 
-### PerformanceCard (메인 컴포넌트)
+```typescript
+function PerformanceCardExample() {
+  const handleCardClick = (performance) => {
+    console.log('카드 클릭:', performance.title);
+  };
 
-- `performance`: Performance (필수) - 공연 데이터
-- `type`: 'default' | 'compact' | 'vertical' | 'detailed' (기본: 'default')
-- `onCardClick`: (performance) => void - 카드 클릭 핸들러
-- `onLikeClick`: (performance, isLiked) => void - 좋아요 핸들러
-- `isLiked`: boolean (기본: false) - 좋아요 상태
-- `className`: string
+  const handleLikeClick = (performance, isLiked) => {
+    console.log(`좋아요 ${isLiked ? '추가' : '제거'}:`, performance.title);
+  };
 
-#### 가시성 제어 Props
-
-- `showImage`: boolean - 이미지 표시 여부
-- `showTitle`: boolean - 제목 표시 여부
-- `showStatus`: boolean - 상태 표시 여부
-- `showDateRange`: boolean - 공연 기간 표시 여부
-- `showLocation`: boolean - 장소 표시 여부
-- `showCast`: boolean - 출연진 표시 여부
-- `showPrice`: boolean - 가격 표시 여부
-- `showLikeButton`: boolean - 좋아요 버튼 표시 여부
-
-### Compound Components
-
-#### PerformanceCard.Root
-
-- `performance`: Performance (필수)
-- `onCardClick`: (performance) => void
-- `onLikeClick`: (performance, isLiked) => void
-- `children`: ReactNode (필수)
-- `className`: string
-
-#### PerformanceCard.Image
-
-- `className`: string
-- `alt`: string - 이미지 대체 텍스트
-- `fallback`: ReactNode - 이미지 없을 때 표시
-- `priority`: boolean - Next.js Image 우선 로딩
-
-#### PerformanceCard.LikeButton
-
-- `isLiked`: boolean (기본: false)
-- `showText`: boolean (기본: false) - 텍스트 표시 여부
-- `icon`: { liked, unliked } - 커스텀 아이콘
-- `children`: ReactNode - 커스텀 텍스트
-
-#### 기타 컴포넌트
-
-- `Title`, `Status`, `DateRange`, `Location`, `Cast`, `Price`
-- 공통 props: `className`, `children`, `fallback`
-
-## 카드 타입
-
-- **default**: 표준 가로형, 모든 정보 표시
-- **compact**: 압축형 가로형, 주요 정보만 표시 (출연진 기본 숨김)
-- **vertical**: 세로형, 이미지 상단 배치
-- **detailed**: 확장형 가로형, 상세 정보 강조
-
-### 카드 타입별 기본 가시성
-
-- **default/detailed/vertical**: 모든 요소 표시
-- **compact**: `showCast=false` (출연진 기본 숨김)
-
-## 예제
-
-### 동적 타입 선택
-
-```tsx
-const cardType = isMobile ? 'compact' : 'default';
-
-<PerformanceCard
-  performance={performance}
-  type={cardType}
-  onCardClick={handleClick}
-/>;
-```
-
-### 가시성 제어
-
-```tsx
-// 특정 요소만 표시
-<PerformanceCard
-  performance={performance}
-  type="compact"
-  showImage={true}
-  showTitle={true}
-  showStatus={false}  // 상태 숨김
-  showPrice={false}   // 가격 숨김
-  showCast={false}    // 출연진 숨김
-/>
-
-// 이미지 없는 카드
-<PerformanceCard
-  performance={performance}
-  showImage={false}
-  showLikeButton={false}
-/>
-
-// 최소 정보만 표시
-<PerformanceCard
-  performance={performance}
-  type="compact"
-  showTitle={true}
-  showStatus={true}
-  showImage={false}
-  showDateRange={false}
-  showLocation={false}
-  showCast={false}
-  showPrice={false}
-  showLikeButton={false}
-/>
-```
-
-### 리스트 렌더링
-
-```tsx
-{
-  performances.map((perf) => (
-    <PerformanceCard
-      key={perf.id}
-      performance={perf}
-      type='compact'
-      onCardClick={handleClick}
-      isLiked={likedPerfs.includes(perf.id)}
-      showCast={false} // 리스트에서는 출연진 숨김
-    />
-  ));
+  return (
+    <Root
+      performance={performanceData}
+      onCardClick={handleCardClick}
+      onLikeClick={handleLikeClick}
+    >
+      <div className="flex gap-4 p-4 border rounded-lg">
+        <Image className="w-24 h-32" />
+        <div className="flex-1">
+          <Title />
+          <Status />
+          <DateRange />
+          <Location />
+          <Cast />
+          <Price />
+        </div>
+        <LikeButton isLiked={false} />
+      </div>
+    </Root>
+  );
 }
 ```
 
-### 완전 커스터마이징
+## 📦 Import 방법
 
-```tsx
-<PerformanceCard.Root performance={performance}>
-  <div className='rounded-lg bg-white p-4 shadow-lg'>
-    <div className='mb-2 flex items-start justify-between'>
-      <PerformanceCard.Title className='text-xl font-bold' />
-      <PerformanceCard.LikeButton showText />
-    </div>
-    <PerformanceCard.Image className='mb-3 h-48 w-full' />
-    <div className='space-y-1'>
-      <PerformanceCard.Status />
-      <PerformanceCard.DateRange className='text-gray-600' />
-      <PerformanceCard.Location className='text-gray-600' />
-      <PerformanceCard.Price className='font-medium text-blue-600' />
-    </div>
-  </div>
+### Named Import (권장)
+
+```typescript
+import {
+  Root,
+  Image,
+  Title,
+  Status,
+  DateRange,
+  Location,
+  Cast,
+  Price,
+  LikeButton
+} from '@/components/PerformanceCard';
+
+// 사용법
+<Root performance={data}>
+  <Title />
+  <Status />
+</Root>
+```
+
+**장점**: 사용하지 않는 컴포넌트는 번들에 포함되지 않음 (트리 쉐이킹)
+
+### Namespace Import
+
+```typescript
+import * as PerformanceCard from '@/components/PerformanceCard';
+
+// 사용법
+<PerformanceCard.Root performance={data}>
+  <PerformanceCard.Title />
+  <PerformanceCard.Status />
 </PerformanceCard.Root>
 ```
 
-### Named Import로 최적화
+**장점**: 네임스페이스로 명확한 구분, IDE 자동완성 지원
 
-```tsx
-import { Root, Image, Title, Status } from './PerformanceCard';
+## 🏗️ 컴포넌트 구조
 
-<Root performance={performance}>
-  <Image priority />
+### Context 기반 아키텍처
+
+```
+Root (Context Provider)
+├── 공연 데이터 제공
+├── 이벤트 핸들러 관리
+└── 하위 컴포넌트들이 데이터 접근 가능
+    ├── Image
+    ├── Title
+    ├── Status
+    ├── DateRange
+    ├── Location
+    ├── Cast
+    ├── Price
+    └── LikeButton
+```
+
+### 데이터 흐름
+
+1. `Root`가 `performance` 데이터를 받음
+2. `formatPerformanceData`로 데이터 가공
+3. Context를 통해 모든 하위 컴포넌트에서 접근 가능
+4. 각 컴포넌트는 필요한 데이터만 추출하여 렌더링
+
+## 📚 API Reference
+
+### Root
+
+루트 컴포넌트로, 모든 하위 컴포넌트를 감싸는 컨테이너입니다.
+
+```typescript
+interface RootProps {
+  performance: Performance; // 필수: 공연 데이터
+  onCardClick?: (performance) => void; // 카드 클릭 핸들러
+  onLikeClick?: (performance, isLiked) => void; // 좋아요 핸들러
+  children: React.ReactNode; // 필수: 하위 컴포넌트들
+  className?: string; // 추가 CSS 클래스
+}
+```
+
+### Image
+
+공연 포스터 이미지를 표시합니다.
+
+```typescript
+interface ImageProps {
+  className?: string; // CSS 클래스
+  alt?: string; // 대체 텍스트 (기본: "공연제목 포스터")
+  fallback?: ReactNode; // 이미지 없을 때 표시할 컴포넌트
+  priority?: boolean; // Next.js Image 우선 로딩
+}
+```
+
+### 컨텐츠 컴포넌트들
+
+Title, Status, DateRange, Location, Cast, Price 모두 동일한 인터페이스를 사용합니다.
+
+```typescript
+interface ContentProps {
+  className?: string; // CSS 클래스
+  children?: ReactNode; // 커스텀 내용 (기본값 대신 사용)
+  fallback?: ReactNode; // 데이터 없을 때 표시할 내용
+}
+```
+
+### LikeButton
+
+좋아요 버튼 컴포넌트입니다.
+
+```typescript
+interface LikeButtonProps {
+  isLiked?: boolean; // 좋아요 상태 (기본: false)
+  showText?: boolean; // 텍스트 표시 여부 (기본: false)
+  className?: string; // CSS 클래스
+  children?: ReactNode; // 커스텀 텍스트
+  icon?: {
+    // 커스텀 아이콘
+    liked: ReactNode; // 좋아요 상태 아이콘
+    unLiked: ReactNode; // 좋아요 해제 상태 아이콘
+  };
+}
+```
+
+## 🏗️ 컴포넌트 구조 및 의존성 다이어그램
+
+### 전체 아키텍처 Overview
+
+```
+📦 사용자 컴포넌트 (User Component)
+ │
+ ├── 📋 Performance 데이터 (필수)
+ ├── 🎯 이벤트 핸들러 (선택)
+ │   ├── onCardClick (카드 클릭용)
+ │   └── onLikeClick (좋아요용) ⚠️ 없으면 LikeButton 미표시
+ │
+ └── 🎨 PerformanceCard.Root
+     │
+     ├── 📊 Context Provider (데이터 공급자)
+     │   ├── performance → formatPerformanceData()
+     │   ├── onCardClick (조건부 버튼 role 부여)
+     │   └── onLikeClick (조건부 LikeButton 렌더링)
+     │
+     └── 🧩 하위 컴포넌트들 (Context 소비자)
+         ├── Image (poster 이미지)
+         ├── Title (공연 제목)
+         ├── Status (공연 상태 + 상태별 스타일)
+         ├── DateRange (공연 기간)
+         ├── Location (공연 장소)
+         ├── Cast (출연진)
+         ├── Price (가격 범위)
+         └── LikeButton ⚠️ onLikeClick 필수!
+```
+
+### 의존성 주입 흐름
+
+```
+외부 의존성 → Root → Context → 하위 컴포넌트들
+
+Performance 데이터 ──┐
+onCardClick (선택)  ──┤
+onLikeClick (선택)  ──┼──→ Root ──→ Context ──→ 모든 하위 컴포넌트
+className (선택)    ──┤
+기타 props (선택)   ──┘
+```
+
+## ⚠️ 유의사항
+
+### 🚨 Critical: 조건부 렌더링 규칙
+
+#### 1. LikeButton은 onLikeClick 필수!
+
+```typescript
+// ✅ LikeButton이 표시됨
+<Root
+  performance={data}
+  onLikeClick={handleLike} // 🔑 이것이 있어야 LikeButton 렌더링
+>
+  <LikeButton isLiked={true} />
+</Root>
+
+// ❌ LikeButton이 아예 표시되지 않음!
+<Root performance={data}>
+  <LikeButton isLiked={true} /> {/* null 반환! */}
+</Root>
+```
+
+**⚠️ 중요**: `onLikeClick`이 없으면 `LikeButton` 컴포넌트는 DOM에서 완전히 제거됩니다.
+
+#### 2. 카드 클릭 가능성은 onCardClick에 의존
+
+```typescript
+// ✅ 클릭 가능한 카드 (role="button", tabIndex="0")
+<Root
+  performance={data}
+  onCardClick={handleClick} // 🔑 클릭 핸들러 제공
+>
+  {/* 카드가 버튼처럼 동작 */}
+</Root>
+
+// ✅ 클릭 불가능한 정적 카드
+<Root performance={data}>
+  {/* 일반 div로 렌더링 */}
+</Root>
+```
+
+### 🏗️ Context 사용 규칙
+
+**모든 하위 컴포넌트는 반드시 Root 내부에서 사용!**
+
+```typescript
+// ✅ 올바른 사용법
+<Root performance={data}>
   <Title />
   <Status />
-</Root>;
+  <LikeButton /> {/* Context에서 데이터 접근 */}
+</Root>
+
+// ❌ 잘못된 사용법 - 런타임 에러!
+<Title />  {/* Error: usePerformanceCardContext must be used within... */}
+<Status /> {/* Context 접근 불가 */}
 ```
 
-## Export 방식
+### 📦 Import 가이드
 
-### Default Export
+```typescript
+// ✅ 권장: Named Import (트리 쉐이킹)
+import { Root, Title, Status, LikeButton } from '@/components/PerformanceCard';
 
-```tsx
-import PerformanceCard from './PerformanceCard';
-// 메인 컴포넌트 + Compound 방식 모두 사용 가능
+// ✅ 대안: Namespace Import
+import * as PerformanceCard from '@/components/PerformanceCard';
+
+// ❌ 지원하지 않음
+import PerformanceCard from '@/components/PerformanceCard'; // default export 없음
 ```
 
-### Named Exports
+### 🎯 외부에서 주입해야 하는 필수 의존성
 
-```tsx
-import { Root, Title, Image } from './PerformanceCard';
-// 개별 컴포넌트만 import (트리 쉐이킹 최적화)
+#### 필수 의존성
+
+```typescript
+interface RequiredDependencies {
+  // 1. 공연 데이터 (필수)
+  performance: Performance; // ⚠️ 모든 필수 필드 포함 필요
+
+  // 2. Next.js Image 컴포넌트 (내부 사용)
+  // 3. Tailwind CSS 클래스 (스타일링)
+  // 4. formatPerformanceData 유틸리티 (내부 사용)
+  // 5. cn 유틸리티 함수 (클래스 병합)
+}
 ```
 
-### Compound Properties
+#### Performance 타입 요구사항
 
-```tsx
-import PerformanceCard from './PerformanceCard';
-// PerformanceCard.Root, PerformanceCard.Title 등으로 사용
+```typescript
+// ⚠️ 모든 필드가 필수입니다!
+interface Performance {
+  id: string;
+  title: string;
+  startDate: string; // ISO 날짜 문자열
+  endDate: string; // ISO 날짜 문자열
+  location: string;
+  cast: string[]; // 출연진 배열
+  price: string[]; // 가격 배열
+  poster: string; // 이미지 URL (빈 문자열 가능)
+  state: string;
+  visit: string;
+  time: string[];
+  groupCount: number; // 🚨 누락 시 TypeScript 에러
+  favoriteCount: number; // 🚨 누락 시 TypeScript 에러
+}
 ```
 
-## 주요 규칙
+#### 선택적 의존성
 
-- 모든 하위 컴포넌트는 `Root` 내부에서 사용 필수
-- `onCardClick` 제공 시에만 카드 클릭 가능
-- `onLikeClick` 제공 시에만 좋아요 버튼 표시
-- 이미지 없을 경우 자동 fallback UI 표시
-- Context 밖에서 하위 컴포넌트 사용 시 에러 발생
-- **가시성 Props가 `false`일 때 해당 요소는 DOM에서 완전히 제거됨**
-- `onLikeClick` 제공 시에만 좋아요 버튼 표시
-- 이미지 없을 경우 자동 fallback UI 표시
-- Context 밖에서 하위 컴포넌트 사용 시 에러 발생
+```typescript
+interface OptionalDependencies {
+  // 카드 클릭 기능을 원할 때
+  onCardClick?: (performance: Performance) => void;
 
-## 접근성
+  // 좋아요 기능을 원할 때 (LikeButton 표시용)
+  onLikeClick?: (performance: Performance, isLiked: boolean) => void;
 
-- 클릭 가능한 카드: `role="button"`, `tabIndex={0}`, 키보드 이벤트 지원
-- 좋아요 버튼: 적절한 `aria-label` 설정
-- 이미지: 의미있는 `alt` 텍스트 자동 생성
-- 키보드 네비게이션: Enter, Space 키 지원
+  // 커스텀 스타일링
+  className?: string;
+
+  // 각 컴포넌트별 커스텀 props
+  // (fallback, priority, icon 등)
+}
+```
+
+### 🎨 스타일 의존성
+
+```typescript
+// 외부에서 제공되어야 하는 스타일 시스템
+interface StyleDependencies {
+  // 1. Tailwind CSS 설치 및 설정
+  // 2. cn() 함수 (clsx + tailwind-merge)
+  // 3. PerformanceCard.styles.ts의 스타일 정의
+}
+```
+
+### 🔄 데이터 흐름 상세
+
+```
+1. 사용자가 performance 데이터 제공
+   ↓
+2. Root가 formatPerformanceData()로 데이터 가공
+   ↓
+3. Context Provider가 가공된 데이터 제공
+   ↓
+4. 하위 컴포넌트들이 Context에서 필요한 데이터 추출
+   ↓
+5. 각 컴포넌트가 해당 데이터를 렌더링
+
+특별한 경우:
+- LikeButton: onLikeClick 없으면 early return (null)
+- 카드 클릭: onCardClick 없으면 일반 div, 있으면 button role
+```
+
+### 💡 실제 사용 시 체크리스트
+
+#### ✅ 사용 전 확인사항
+
+1. **Performance 데이터 완성도**
+
+   ```typescript
+   // 모든 필수 필드가 있는지 확인
+   const isValid =
+     performance.groupCount !== undefined
+     && performance.favoriteCount !== undefined;
+   ```
+
+2. **좋아요 기능 사용 여부**
+
+   ```typescript
+   // LikeButton을 사용하려면 onLikeClick 필수
+   const needsLikeButton = true;
+   const onLikeClick = needsLikeButton ? handleLikeClick : undefined;
+   ```
+
+3. **Context 내부 사용 확인**
+   ```typescript
+   // 모든 컴포넌트가 Root 안에 있는지 확인
+   <Root performance={data} onLikeClick={onLikeClick}>
+     {/* 여기 안에만 하위 컴포넌트들 */}
+   </Root>
+   ```
+
+### 4. 스타일 커스터마이징
+
+스타일은 `PerformanceCard.styles.ts`에서 중앙 관리됩니다.
+
+```typescript
+// className으로 추가 스타일 적용
+<Title className="text-2xl font-bold text-blue-600" />
+
+// 기본 스타일 + 커스텀 스타일이 병합됨
+// cn() 함수가 자동으로 처리
+```
+
+### 5. TypeScript 타입 안전성
+
+```typescript
+// Performance 타입이 올바르게 정의되어야 함
+interface Performance {
+  id: string;
+  title: string;
+  startDate: string;
+  endDate: string;
+  location: string;
+  cast: string[];
+  price: string[];
+  poster: string;
+  state: string;
+  visit: string;
+  time: string[];
+  groupCount: number; // 필수
+  favoriteCount: number; // 필수
+}
+```
+
+## 💡 예제 모음
+
+### 기본 카드
+
+```typescript
+import { Root, Image, Title, Status, DateRange, Location, Price } from '@/components/PerformanceCard';
+
+function BasicCard({ performance }) {
+  return (
+    <Root performance={performance}>
+      <div className="flex gap-4 p-4 border rounded-lg">
+        <Image className="w-24 h-32" />
+        <div>
+          <Title />
+          <Status />
+          <DateRange />
+          <Location />
+          <Price />
+        </div>
+      </div>
+    </Root>
+  );
+}
+```
+
+### 클릭 가능한 카드
+
+```typescript
+import { Root, Image, Title, Status } from '@/components/PerformanceCard';
+
+function ClickableCard({ performance }) {
+  const handleCardClick = (perf) => {
+    router.push(`/performance/${perf.id}`);
+  };
+
+  return (
+    <Root
+      performance={performance}
+      onCardClick={handleCardClick}
+    >
+      <div className="p-4 border rounded-lg hover:shadow-lg cursor-pointer">
+        <Image />
+        <Title />
+        <Status />
+      </div>
+    </Root>
+  );
+}
+```
+
+### 좋아요 기능이 있는 카드
+
+```typescript
+import { Root, Image, Title, LikeButton } from '@/components/PerformanceCard';
+
+function LikableCard({ performance, isLiked }) {
+  const handleLikeClick = (perf, liked) => {
+    if (liked) {
+      addToFavorites(perf.id);
+    } else {
+      removeFromFavorites(perf.id);
+    }
+  };
+
+  return (
+    <Root
+      performance={performance}
+      onLikeClick={handleLikeClick}
+    >
+      <div className="relative p-4 border rounded-lg">
+        <LikeButton isLiked={isLiked} />
+        <Image />
+        <Title />
+      </div>
+    </Root>
+  );
+}
+```
+
+### 컴팩트 카드
+
+```typescript
+import { Root, Title, Status, Price } from '@/components/PerformanceCard';
+
+function CompactCard({ performance }) {
+  return (
+    <Root performance={performance}>
+      <div className="flex items-center gap-2 p-2 border rounded">
+        <div>
+          <Title className="text-sm font-medium" />
+          <Status />
+        </div>
+        <Price className="ml-auto text-xs" />
+      </div>
+    </Root>
+  );
+}
+```
+
+### 세로형 카드
+
+```typescript
+import { Root, Image, Title, Status, Location } from '@/components/PerformanceCard';
+
+function VerticalCard({ performance }) {
+  return (
+    <Root performance={performance}>
+      <div className="w-48 border rounded-lg overflow-hidden">
+        <Image className="w-full h-64" />
+        <div className="p-3">
+          <Title />
+          <Status />
+          <Location />
+        </div>
+      </div>
+    </Root>
+  );
+}
+```
+
+### 리스트에서 사용
+
+```typescript
+import { Root, Image, Title, Status, DateRange } from '@/components/PerformanceCard';
+
+function PerformanceList({ performances }) {
+  return (
+    <div className="space-y-4">
+      {performances.map((performance) => (
+        <Root key={performance.id} performance={performance}>
+          <div className="flex gap-4 p-4 border rounded-lg">
+            <Image className="w-16 h-20" />
+            <div className="flex-1">
+              <Title />
+              <Status />
+              <DateRange />
+            </div>
+          </div>
+        </Root>
+      ))}
+    </div>
+  );
+}
+```
+
+### 커스텀 fallback 사용
+
+```typescript
+import { Root, Image, Title, Cast } from '@/components/PerformanceCard';
+
+function CustomFallbackCard({ performance }) {
+  return (
+    <Root performance={performance}>
+      <div className="p-4 border rounded-lg">
+        <Image
+          fallback={
+            <div className="w-24 h-32 bg-gray-100 flex items-center justify-center">
+              <span className="text-gray-400">이미지 없음</span>
+            </div>
+          }
+        />
+        <Title fallback="제목 미정" />
+        <Cast fallback="출연진 정보 없음" />
+      </div>
+    </Root>
+  );
+}
+```
+
+## 🎨 스타일링 가이드
+
+### 기본 스타일 클래스
+
+컴포넌트별 기본 스타일은 `PerformanceCard.styles.ts`에 정의되어 있습니다:
+
+```typescript
+// 예시: Status 컴포넌트의 기본 스타일
+const statusStyles = {
+  base: 'mr-2 inline-block rounded px-2 py-1 text-sm',
+  ended: 'bg-gray-100 text-gray-600', // 종료된 공연
+  ongoing: 'bg-green-100 text-green-700', // 진행 중인 공연
+  upcoming: 'bg-blue-100 text-blue-700', // 예정된 공연
+};
+```
+
+### 커스텀 스타일 적용
+
+```typescript
+// className prop으로 추가 스타일 적용
+<Title className="text-2xl font-bold text-purple-600" />
+<Status className="rounded-full px-3 py-1" />
+<Image className="rounded-lg shadow-lg" />
+```
+
+## 🔧 트러블슈팅
+
+### 자주 발생하는 에러
+
+1. **Context 에러**
+
+   ```
+   Error: usePerformanceCardContext must be used within PerformanceCardContext
+   ```
+
+   **해결법**: 모든 하위 컴포넌트를 `Root`로 감싸세요.
+
+2. **Import 에러**
+
+   ```
+   Module not found: Can't resolve 'PerformanceCard'
+   ```
+
+   **해결법**: Named import를 사용하세요: `import { Root } from './PerformanceCard'`
+
+3. **TypeScript 타입 에러**
+   ```
+   Property 'groupCount' is missing in type
+   ```
+   **해결법**: Performance 인터페이스에 누락된 속성을 추가하세요.
+
+### 성능 최적화 팁
+
+1. **Named Import 사용**: 필요한 컴포넌트만 import하여 번들 크기 최적화
+2. **Image priority 설정**: 중요한 이미지에 `priority={true}` 설정
+3. **메모화**: 자주 렌더링되는 카드는 `React.memo` 사용 고려

--- a/src/components/common/PerformanceCard/PerformanceCard.messages.ts
+++ b/src/components/common/PerformanceCard/PerformanceCard.messages.ts
@@ -1,4 +1,4 @@
-export const PERFORMANCE_CARD_MESSAGES = {
+export const MESSAGES = {
   // Context 에러 메시지
   CONTEXT_ERROR:
     'PerformanceCard 컴포넌트는 PerformanceCard.Root 내부에서 사용해야 합니다.',
@@ -41,4 +41,4 @@ export const PERFORMANCE_CARD_MESSAGES = {
 } as const;
 
 // 타입 안전성을 위한 타입 정의
-export type PerformanceCardMessages = typeof PERFORMANCE_CARD_MESSAGES;
+export type PerformanceCardMessages = typeof MESSAGES;

--- a/src/components/common/PerformanceCard/PerformanceCard.styles.ts
+++ b/src/components/common/PerformanceCard/PerformanceCard.styles.ts
@@ -1,84 +1,30 @@
-export const performanceCardStyles = {
-  card: {
-    base: 'border rounded-lg bg-white transition-shadow cursor-pointer relative',
-    variant: {
-      default: 'p-4 hover:shadow-lg',
-      compact: 'p-3 hover:shadow-md',
-      detailed: 'p-6 hover:shadow-xl',
-    },
-  },
-
-  likeButton: {
-    base: 'absolute z-10 flex items-center justify-center rounded-full bg-white/80 hover:bg-white transition-colors',
-    size: 'w-8 h-8',
-    position: {
-      default: 'right-3 top-3',
-      compact: 'right-2 top-2',
-    },
-  },
+export const STYLES = {
+  root: 'relative cursor-pointer rounded-lg border bg-white p-4 transition-shadow hover:shadow-lg',
 
   image: {
-    container: 'relative overflow-hidden',
+    container: 'relative aspect-[3/4] w-24 overflow-hidden rounded',
+    image: 'object-cover',
     fallback:
-      'w-full h-full bg-gray-200 flex items-center justify-center text-gray-400 text-sm',
-    size: {
-      vertical: 'aspect-[3/4] w-full mb-3 rounded',
-      compact: 'h-16 w-12 rounded flex-shrink-0',
-      default: 'h-32 w-24 rounded flex-shrink-0',
-    },
+      'flex h-full w-full items-center justify-center bg-gray-200 text-sm text-gray-400',
   },
 
-  title: {
-    base: 'font-bold',
-    size: {
-      compact: 'text-sm font-semibold mb-1 truncate',
-      default: 'text-lg mb-2',
-      detailed: 'text-xl mb-2',
-      verticalDefault: 'text-base',
-      verticalDetailed: 'text-lg',
-    },
+  content: {
+    title: 'mb-2 text-lg font-bold',
+    dateRange: 'text-sm text-gray-600',
+    location: 'text-sm text-gray-600',
+    cast: 'text-sm text-gray-600',
+    price: 'font-semibold text-blue-600',
   },
 
   status: {
-    base: 'inline-block rounded px-2 py-1 mr-2',
-    size: {
-      compact: 'text-xs',
-      default: 'text-sm',
-    },
-    state: {
-      ended: 'bg-gray-100 text-gray-600',
-      ongoing: 'bg-green-100 text-green-700',
-      upcoming: 'bg-blue-100 text-blue-700',
-    },
+    base: 'mr-2 inline-block rounded px-2 py-1 text-sm',
+    ended: 'bg-gray-100 text-gray-600',
+    ongoing: 'bg-green-100 text-green-700',
+    upcoming: 'bg-blue-100 text-blue-700',
   },
 
-  info: {
-    container: 'space-y-1 text-gray-600',
-    size: {
-      compact: 'text-xs',
-      default: 'text-sm',
-    },
-  },
-
-  price: {
-    compact: 'font-medium text-blue-600',
-    default: 'font-semibold text-blue-600',
-  },
-
-  layout: {
-    vertical: {
-      container: 'space-y-2',
-      info: 'space-y-1 text-sm text-gray-600',
-    },
-    horizontal: {
-      compact: {
-        container: 'flex items-center gap-3 pr-10',
-        content: 'min-w-0 flex-1',
-      },
-      default: {
-        container: 'flex gap-4 pr-12',
-        content: 'min-w-0 flex-1',
-      },
-    },
+  likeButton: {
+    base: 'absolute top-3 right-3 z-10 flex h-8 w-8 items-center justify-center rounded-full bg-white/80 transition-colors hover:bg-white',
+    text: 'ml-1',
   },
 } as const;

--- a/src/components/common/PerformanceCard/PerformanceCard.test.tsx
+++ b/src/components/common/PerformanceCard/PerformanceCard.test.tsx
@@ -24,12 +24,11 @@ jest.mock('next/image', () => ({
   ),
 }));
 
-// 현재 진행중인 공연으로 설정 (현재 날짜 포함)
 const today = new Date();
 const yesterday = new Date(today);
 yesterday.setDate(today.getDate() - 1);
 const futureDate = new Date(today);
-futureDate.setMonth(today.getMonth() + 2); // 2개월 후 종료
+futureDate.setMonth(today.getMonth() + 2);
 
 const mockPerformance: Performance = {
   id: '1',

--- a/src/components/common/PerformanceCard/PerformanceCard.test.tsx
+++ b/src/components/common/PerformanceCard/PerformanceCard.test.tsx
@@ -3,8 +3,8 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { Performance } from '@/types/performance';
-import { PerformanceCard } from './PerformanceCard';
-import { PERFORMANCE_CARD_MESSAGES } from './PerformanceCard.messages';
+import * as PerformanceCard from './PerformanceCard';
+import { MESSAGES } from './PerformanceCard.messages';
 
 jest.mock('next/image', () => ({
   __esModule: true,
@@ -43,6 +43,8 @@ const mockPerformance: Performance = {
   state: 'available',
   visit: 'domestic',
   time: ['19:30', '14:00'],
+  groupCount: 0,
+  favoriteCount: 0,
 };
 
 describe('PerformanceCard', () => {
@@ -59,25 +61,21 @@ describe('PerformanceCard', () => {
 
     describe('Messages Integration', () => {
       it('메시지 객체가 export되어 접근 가능하다', () => {
-        expect(PERFORMANCE_CARD_MESSAGES).toBeDefined();
-        expect(PERFORMANCE_CARD_MESSAGES.CONTEXT_ERROR).toBe(
-          PERFORMANCE_CARD_MESSAGES.CONTEXT_ERROR
-        );
+        expect(MESSAGES).toBeDefined();
+        expect(MESSAGES.CONTEXT_ERROR).toBe(MESSAGES.CONTEXT_ERROR);
       });
 
       it('함수형 메시지가 올바르게 동작한다', () => {
         const title = '레미제라블';
-        expect(PERFORMANCE_CARD_MESSAGES.CARD_DETAIL_LABEL(title)).toBe(
+        expect(MESSAGES.CARD_DETAIL_LABEL(title)).toBe(
           `${title} 공연 상세 보기`
         );
-        expect(PERFORMANCE_CARD_MESSAGES.POSTER_ALT(title)).toBe(
-          `${title} 포스터`
-        );
+        expect(MESSAGES.POSTER_ALT(title)).toBe(`${title} 포스터`);
       });
 
       it('메시지를 외부에서 직접 참조할 수 있다', () => {
-        expect(typeof PERFORMANCE_CARD_MESSAGES.LIKE_TEXT).toBe('string');
-        expect(typeof PERFORMANCE_CARD_MESSAGES.UNLIKE_TEXT).toBe('string');
+        expect(typeof MESSAGES.LIKE_TEXT).toBe('string');
+        expect(typeof MESSAGES.UNLIKE_TEXT).toBe('string');
       });
     });
 
@@ -156,6 +154,14 @@ describe('PerformanceCard', () => {
       expect(screen.getByText('공연 중')).toBeInTheDocument();
     });
 
+    it('Status 컴포넌트가 올바른 스타일 클래스를 적용한다', () => {
+      renderWithContext(<PerformanceCard.Status />);
+      const statusElement = screen.getByText('공연 중');
+
+      // 진행중인 공연이므로 ongoing 스타일이 적용되어야 함
+      expect(statusElement).toHaveClass('bg-green-100', 'text-green-700');
+    });
+
     it('DateRange 컴포넌트가 날짜를 렌더링한다', () => {
       renderWithContext(<PerformanceCard.DateRange />);
       const currentYear = new Date().getFullYear();
@@ -180,9 +186,7 @@ describe('PerformanceCard', () => {
 
     it('Image 컴포넌트가 이미지를 렌더링한다', () => {
       renderWithContext(<PerformanceCard.Image />);
-      const image = screen.getByAltText(
-        PERFORMANCE_CARD_MESSAGES.POSTER_ALT('레미제라블')
-      );
+      const image = screen.getByAltText(MESSAGES.POSTER_ALT('레미제라블'));
       expect(image).toBeInTheDocument();
       expect(image.getAttribute('src')).toContain(
         '/images/les-miserables-poster.jpg'
@@ -196,9 +200,7 @@ describe('PerformanceCard', () => {
           <PerformanceCard.Image />
         </PerformanceCard.Root>
       );
-      expect(
-        screen.getByText(PERFORMANCE_CARD_MESSAGES.NO_IMAGE_FALLBACK)
-      ).toBeInTheDocument();
+      expect(screen.getByText(MESSAGES.NO_IMAGE_FALLBACK)).toBeInTheDocument();
     });
 
     it('Image 컴포넌트에 custom fallback을 전달할 수 있다', () => {
@@ -209,6 +211,37 @@ describe('PerformanceCard', () => {
         </PerformanceCard.Root>
       );
       expect(screen.getByText('커스텀 Fallback')).toBeInTheDocument();
+    });
+
+    it('각 컴포넌트에 custom className이 적용된다', () => {
+      renderWithContext(
+        <>
+          <PerformanceCard.Title className='custom-title' />
+          <PerformanceCard.Status className='custom-status' />
+          <PerformanceCard.Image className='custom-image' />
+        </>
+      );
+
+      expect(screen.getByText('레미제라블')).toHaveClass('custom-title');
+      expect(screen.getByText('공연 중')).toHaveClass('custom-status');
+    });
+
+    it('각 컴포넌트에 fallback이 올바르게 동작한다', () => {
+      const performanceWithMissingData = {
+        ...mockPerformance,
+        title: '',
+        location: '',
+      };
+
+      render(
+        <PerformanceCard.Root performance={performanceWithMissingData}>
+          <PerformanceCard.Title fallback='제목 없음' />
+          <PerformanceCard.Location fallback='장소 미정' />
+        </PerformanceCard.Root>
+      );
+
+      expect(screen.getByText('제목 없음')).toBeInTheDocument();
+      expect(screen.getByText('장소 미정')).toBeInTheDocument();
     });
   });
 
@@ -233,7 +266,7 @@ describe('PerformanceCard', () => {
     it('좋아요 버튼이 렌더링된다', () => {
       renderLikeButtonWithContext();
       const likeButton = screen.getByRole('button', {
-        name: PERFORMANCE_CARD_MESSAGES.LIKE_BUTTON_LABEL,
+        name: MESSAGES.LIKE_BUTTON_LABEL,
       });
       expect(likeButton).toBeInTheDocument();
     });
@@ -245,7 +278,7 @@ describe('PerformanceCard', () => {
       });
 
       const likeButton = screen.getByRole('button', {
-        name: PERFORMANCE_CARD_MESSAGES.LIKE_BUTTON_LABEL,
+        name: MESSAGES.LIKE_BUTTON_LABEL,
       });
       await user.click(likeButton);
 
@@ -259,7 +292,7 @@ describe('PerformanceCard', () => {
       });
 
       const likeButton = screen.getByRole('button', {
-        name: PERFORMANCE_CARD_MESSAGES.UNLIKE_BUTTON_LABEL,
+        name: MESSAGES.UNLIKE_BUTTON_LABEL,
       });
       await user.click(likeButton);
 
@@ -282,7 +315,7 @@ describe('PerformanceCard', () => {
       );
 
       const likeButton = screen.getByRole('button', {
-        name: PERFORMANCE_CARD_MESSAGES.LIKE_BUTTON_LABEL,
+        name: MESSAGES.LIKE_BUTTON_LABEL,
       });
       await user.click(likeButton);
 
@@ -302,69 +335,21 @@ describe('PerformanceCard', () => {
 
     it('showText가 true이면 텍스트가 표시된다', () => {
       renderLikeButtonWithContext({ showText: true });
-      expect(
-        screen.getByText(PERFORMANCE_CARD_MESSAGES.LIKE_TEXT)
-      ).toBeInTheDocument();
+      expect(screen.getByText(MESSAGES.LIKE_TEXT)).toBeInTheDocument();
     });
 
     it('커스텀 아이콘을 설정할 수 있다', () => {
       renderLikeButtonWithContext({
-        icon: { liked: '💖', unliked: '🖤' },
+        icon: { liked: '💖', unLiked: '🖤' },
         isLiked: false,
       });
       expect(screen.getByText('🖤')).toBeInTheDocument();
     });
-  });
 
-  describe('Preset Components', () => {
-    it('DefaultCard가 기본 스타일로 렌더링된다', () => {
-      render(
-        <PerformanceCard
-          type='default'
-          performance={mockPerformance}
-          onCardClick={jest.fn()}
-        />
-      );
-
-      expect(screen.getByText('레미제라블')).toBeInTheDocument();
-      expect(screen.getByText('공연 중')).toBeInTheDocument();
-      expect(screen.getByText('블루스퀘어 신한카드홀')).toBeInTheDocument();
-    });
-
-    it('CompactCard가 컴팩트 스타일로 렌더링된다', () => {
-      render(
-        <PerformanceCard
-          type='compact'
-          performance={mockPerformance}
-          onCardClick={jest.fn()}
-        />
-      );
-
-      expect(screen.getByText('레미제라블')).toBeInTheDocument();
-    });
-
-    it('VerticalCard가 세로 스타일로 렌더링된다', () => {
-      render(
-        <PerformanceCard
-          type='vertical'
-          performance={mockPerformance}
-          onCardClick={jest.fn()}
-        />
-      );
-
-      expect(screen.getByText('레미제라블')).toBeInTheDocument();
-    });
-
-    it('DetailedCard가 상세 스타일로 렌더링된다', () => {
-      render(
-        <PerformanceCard
-          type='detailed'
-          performance={mockPerformance}
-          onCardClick={jest.fn()}
-        />
-      );
-
-      expect(screen.getByText('레미제라블')).toBeInTheDocument();
+    it('LikeButton에 custom className이 적용된다', () => {
+      renderLikeButtonWithContext({ className: 'custom-like-btn' });
+      const likeButton = screen.getByRole('button');
+      expect(likeButton).toHaveClass('custom-like-btn');
     });
   });
 
@@ -374,7 +359,15 @@ describe('PerformanceCard', () => {
 
       expect(() => {
         render(<PerformanceCard.Title />);
-      }).toThrow(PERFORMANCE_CARD_MESSAGES.CONTEXT_ERROR);
+      }).toThrow(MESSAGES.CONTEXT_ERROR);
+
+      expect(() => {
+        render(<PerformanceCard.Status />);
+      }).toThrow(MESSAGES.CONTEXT_ERROR);
+
+      expect(() => {
+        render(<PerformanceCard.Image />);
+      }).toThrow(MESSAGES.CONTEXT_ERROR);
 
       consoleSpy.mockRestore();
     });
@@ -394,7 +387,7 @@ describe('PerformanceCard', () => {
       const button = screen.getByRole('button');
       expect(button).toHaveAttribute(
         'aria-label',
-        PERFORMANCE_CARD_MESSAGES.CARD_DETAIL_LABEL('레미제라블')
+        MESSAGES.CARD_DETAIL_LABEL('레미제라블')
       );
     });
 
@@ -411,13 +404,27 @@ describe('PerformanceCard', () => {
       const likeButton = screen.getByRole('button');
       expect(likeButton).toHaveAttribute(
         'aria-label',
-        PERFORMANCE_CARD_MESSAGES.LIKE_BUTTON_LABEL
+        MESSAGES.LIKE_BUTTON_LABEL
       );
+    });
+
+    it('키보드 접근성이 올바르게 동작한다', () => {
+      render(
+        <PerformanceCard.Root
+          performance={mockPerformance}
+          onCardClick={jest.fn()}
+        >
+          <div>Content</div>
+        </PerformanceCard.Root>
+      );
+
+      const button = screen.getByRole('button');
+      expect(button).toHaveAttribute('tabIndex', '0');
     });
   });
 
   describe('Custom Props', () => {
-    it('className이 적절히 적용된다', () => {
+    it('Root에 className이 적절히 적용된다', () => {
       const { container } = render(
         <PerformanceCard.Root
           performance={mockPerformance}
@@ -430,7 +437,7 @@ describe('PerformanceCard', () => {
       expect(container.firstChild).toHaveClass('custom-class');
     });
 
-    it('data-testid 같은 custom props가 전달된다', () => {
+    it('Root에 data-testid 같은 custom props가 전달된다', () => {
       render(
         <PerformanceCard.Root
           performance={mockPerformance}
@@ -441,6 +448,75 @@ describe('PerformanceCard', () => {
       );
 
       expect(screen.getByTestId('performance-card')).toBeInTheDocument();
+    });
+
+    it('Image에 priority prop이 전달된다', () => {
+      render(
+        <PerformanceCard.Root performance={mockPerformance}>
+          <PerformanceCard.Image priority={true} />
+        </PerformanceCard.Root>
+      );
+
+      // Image 컴포넌트가 렌더링되는지 확인
+      const image = screen.getByAltText(MESSAGES.POSTER_ALT('레미제라블'));
+      expect(image).toBeInTheDocument();
+    });
+
+    it('각 컴포넌트에 추가 HTML 속성들이 전달된다', () => {
+      render(
+        <PerformanceCard.Root performance={mockPerformance}>
+          <PerformanceCard.Title data-testid='title-component' />
+          <PerformanceCard.Status data-testid='status-component' />
+          <PerformanceCard.Price data-testid='price-component' />
+        </PerformanceCard.Root>
+      );
+
+      expect(screen.getByTestId('title-component')).toBeInTheDocument();
+      expect(screen.getByTestId('status-component')).toBeInTheDocument();
+      expect(screen.getByTestId('price-component')).toBeInTheDocument();
+    });
+  });
+
+  describe('Performance Status Variants', () => {
+    it('종료된 공연은 올바른 스타일을 적용한다', () => {
+      const pastDate = new Date();
+      pastDate.setMonth(pastDate.getMonth() - 1);
+
+      const endedPerformance = {
+        ...mockPerformance,
+        endDate: pastDate.toISOString(),
+      };
+
+      render(
+        <PerformanceCard.Root performance={endedPerformance}>
+          <PerformanceCard.Status />
+        </PerformanceCard.Root>
+      );
+
+      const statusElement = screen.getByText(/종료|완료/);
+      expect(statusElement).toHaveClass('bg-gray-100', 'text-gray-600');
+    });
+
+    it('예정된 공연은 올바른 스타일을 적용한다', () => {
+      const futureStartDate = new Date();
+      futureStartDate.setDate(futureStartDate.getDate() + 10);
+      const futureEndDate = new Date();
+      futureEndDate.setMonth(futureEndDate.getMonth() + 1);
+
+      const upcomingPerformance = {
+        ...mockPerformance,
+        startDate: futureStartDate.toISOString(),
+        endDate: futureEndDate.toISOString(),
+      };
+
+      render(
+        <PerformanceCard.Root performance={upcomingPerformance}>
+          <PerformanceCard.Status />
+        </PerformanceCard.Root>
+      );
+
+      const statusElement = screen.getByText(/예정|공연 예정/);
+      expect(statusElement).toHaveClass('bg-blue-100', 'text-blue-700');
     });
   });
 });

--- a/src/components/common/PerformanceCard/PerformanceCard.tsx
+++ b/src/components/common/PerformanceCard/PerformanceCard.tsx
@@ -1,11 +1,10 @@
-/* eslint-disable react-refresh/only-export-components */
 import React from 'react';
 import Image from 'next/image';
 import { cn } from '@/lib/utils';
 import { Performance } from '@/types/performance';
 import formatPerformanceData from '@/utils/formatPerformanceData';
-import { PERFORMANCE_CARD_MESSAGES } from './PerformanceCard.messages';
-import { performanceCardStyles as styles } from './PerformanceCard.styles';
+import { MESSAGES } from './PerformanceCard.messages';
+import { STYLES } from './PerformanceCard.styles';
 
 /* Context */
 interface PerformanceCardContextValue {
@@ -21,12 +20,10 @@ const PerformanceCardContext =
 const usePerformanceCardContext = () => {
   const context = React.useContext(PerformanceCardContext);
   if (!context) {
-    throw new Error(PERFORMANCE_CARD_MESSAGES.CONTEXT_ERROR);
+    throw new Error(MESSAGES.CONTEXT_ERROR);
   }
   return context;
 };
-
-/* Headless Component */
 
 // Root
 interface RootProps {
@@ -65,15 +62,13 @@ const Root = ({
   return (
     <PerformanceCardContext.Provider value={contextValue}>
       <div
-        className={className}
+        className={cn(STYLES.root, className)}
         onClick={onCardClick ? handleClick : undefined}
         onKeyDown={onCardClick ? handleKeyDown : undefined}
         role={onCardClick ? 'button' : undefined}
         tabIndex={onCardClick ? 0 : undefined}
         aria-label={
-          onCardClick
-            ? PERFORMANCE_CARD_MESSAGES.CARD_DETAIL_LABEL(data.title)
-            : undefined
+          onCardClick ? MESSAGES.CARD_DETAIL_LABEL(data.title) : undefined
         }
         {...props}
       >
@@ -96,35 +91,30 @@ const ImageComponent = ({
   alt,
   fallback,
   priority = false,
-  ...props
 }: ImageProps & React.HTMLAttributes<HTMLDivElement>) => {
   const { data } = usePerformanceCardContext();
+  const { container, image, fallback: fallbackStyle } = STYLES.image;
 
   return (
-    <div
-      className={cn(styles.image.container, className)}
-      {...props}
-    >
+    <div className={cn(container, className)}>
       {data.mainImage ? (
         <Image
           fill
           src={data.mainImage}
-          alt={alt || PERFORMANCE_CARD_MESSAGES.POSTER_ALT(data.title)}
-          className='object-cover'
+          alt={alt || MESSAGES.POSTER_ALT(data.title)}
+          className={image}
           priority={priority}
         />
       ) : (
         fallback || (
-          <div className={styles.image.fallback}>
-            {PERFORMANCE_CARD_MESSAGES.NO_IMAGE_FALLBACK}
-          </div>
+          <div className={fallbackStyle}>{MESSAGES.NO_IMAGE_FALLBACK}</div>
         )
       )}
     </div>
   );
 };
 
-// Content
+// Content Components
 interface ContentProps {
   className?: string;
   children?: React.ReactNode;
@@ -138,9 +128,11 @@ const Title = ({
   ...props
 }: ContentProps & React.HTMLAttributes<HTMLHeadingElement>) => {
   const { data } = usePerformanceCardContext();
+  const { title } = STYLES.content;
+
   return (
     <h3
-      className={cn(styles.title.base, className)}
+      className={cn(title, className)}
       {...props}
     >
       {children || data.title || fallback}
@@ -155,16 +147,17 @@ const Status = ({
   ...props
 }: ContentProps & React.HTMLAttributes<HTMLSpanElement>) => {
   const { data } = usePerformanceCardContext();
+  const { base, ended, ongoing, upcoming } = STYLES.status;
 
-  const stateClass = data.isEnded
-    ? styles.status.state.ended
+  const statusStyle = data.isEnded
+    ? ended
     : data.isOngoing
-      ? styles.status.state.ongoing
-      : styles.status.state.upcoming;
+      ? ongoing
+      : upcoming;
 
   return (
     <span
-      className={cn(styles.status.base, stateClass, className)}
+      className={cn(base, statusStyle, className)}
       {...props}
     >
       {children || data.status || fallback}
@@ -179,9 +172,11 @@ const DateRange = ({
   ...props
 }: ContentProps & React.HTMLAttributes<HTMLDivElement>) => {
   const { data } = usePerformanceCardContext();
+  const { dateRange } = STYLES.content;
+
   return (
     <div
-      className={className}
+      className={cn(dateRange, className)}
       {...props}
     >
       {children || data.dateRange || fallback}
@@ -196,9 +191,11 @@ const Location = ({
   ...props
 }: ContentProps & React.HTMLAttributes<HTMLDivElement>) => {
   const { data } = usePerformanceCardContext();
+  const { location } = STYLES.content;
+
   return (
     <div
-      className={className}
+      className={cn(location, className)}
       {...props}
     >
       {children || data.location || fallback}
@@ -213,9 +210,11 @@ const Cast = ({
   ...props
 }: ContentProps & React.HTMLAttributes<HTMLDivElement>) => {
   const { data } = usePerformanceCardContext();
+  const { cast } = STYLES.content;
+
   return (
     <div
-      className={className}
+      className={cn(cast, className)}
       {...props}
     >
       {children || data.castSummary || fallback}
@@ -230,9 +229,11 @@ const Price = ({
   ...props
 }: ContentProps & React.HTMLAttributes<HTMLDivElement>) => {
   const { data } = usePerformanceCardContext();
+  const { price } = STYLES.content;
+
   return (
     <div
-      className={className}
+      className={cn(price, className)}
       {...props}
     >
       {children || data.priceRange || fallback}
@@ -248,7 +249,7 @@ interface LikeButtonProps {
   children?: React.ReactNode;
   icon?: {
     liked: React.ReactNode;
-    unliked: React.ReactNode;
+    unLiked: React.ReactNode;
   };
 }
 
@@ -257,11 +258,12 @@ const LikeButton = ({
   showText = false,
   className,
   children,
-  icon = { liked: '❤️', unliked: '🤍' },
+  icon = { liked: '❤️', unLiked: '🤍' },
   ...props
 }: LikeButtonProps
   & Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'onClick'>) => {
   const { performance, onLikeClick } = usePerformanceCardContext();
+  const { base, text } = STYLES.likeButton;
 
   const handleClick = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -273,286 +275,23 @@ const LikeButton = ({
   return (
     <button
       onClick={handleClick}
-      className={cn(styles.likeButton.base, className)}
+      className={cn(base, className)}
       aria-label={
-        isLiked
-          ? PERFORMANCE_CARD_MESSAGES.UNLIKE_BUTTON_LABEL
-          : PERFORMANCE_CARD_MESSAGES.LIKE_BUTTON_LABEL
+        isLiked ? MESSAGES.UNLIKE_BUTTON_LABEL : MESSAGES.LIKE_BUTTON_LABEL
       }
       {...props}
     >
-      <span>{isLiked ? icon.liked : icon.unliked}</span>
+      <span>{isLiked ? icon.liked : icon.unLiked}</span>
       {showText && (
-        <span className='ml-1'>
-          {children
-            || (isLiked
-              ? PERFORMANCE_CARD_MESSAGES.UNLIKE_TEXT
-              : PERFORMANCE_CARD_MESSAGES.LIKE_TEXT)}
+        <span className={text}>
+          {children || (isLiked ? MESSAGES.UNLIKE_TEXT : MESSAGES.LIKE_TEXT)}
         </span>
       )}
     </button>
   );
 };
 
-/* compound */
-
-interface VisibilityProps {
-  showImage?: boolean;
-  showTitle?: boolean;
-  showStatus?: boolean;
-  showDateRange?: boolean;
-  showLocation?: boolean;
-  showCast?: boolean;
-  showPrice?: boolean;
-  showLikeButton?: boolean;
-}
-
-// variants
-const DefaultCard = ({
-  isLiked = false,
-  showImage = true,
-  showTitle = true,
-  showStatus = true,
-  showDateRange = true,
-  showLocation = true,
-  showCast = true,
-  showPrice = true,
-  showLikeButton = true,
-}: { isLiked?: boolean } & VisibilityProps) => (
-  <>
-    {showLikeButton && (
-      <LikeButton
-        isLiked={isLiked}
-        className={cn(
-          styles.likeButton.size,
-          styles.likeButton.position.default
-        )}
-      />
-    )}
-    <div className={styles.layout.horizontal.default.container}>
-      {showImage && <ImageComponent className={styles.image.size.default} />}
-      <div className={styles.layout.horizontal.default.content}>
-        {showTitle && <Title className={styles.title.size.default} />}
-        <div className={cn(styles.info.container, styles.info.size.default)}>
-          {showStatus && <Status className={styles.status.size.default} />}
-          {showDateRange && <DateRange />}
-          {showLocation && <Location />}
-          {showCast && <Cast />}
-          {showPrice && <Price className={styles.price.default} />}
-        </div>
-      </div>
-    </div>
-  </>
-);
-
-const CompactCard = ({
-  isLiked = false,
-  showImage = true,
-  showTitle = true,
-  showStatus = true,
-  showDateRange = true,
-  showLocation = true,
-  showCast = false,
-  showPrice = true,
-  showLikeButton = true,
-}: { isLiked?: boolean } & VisibilityProps) => (
-  <>
-    {showLikeButton && (
-      <LikeButton
-        isLiked={isLiked}
-        className={cn(
-          styles.likeButton.size,
-          styles.likeButton.position.compact
-        )}
-      />
-    )}
-    <div className={styles.layout.horizontal.compact.container}>
-      {showImage && <ImageComponent className={styles.image.size.compact} />}
-      <div className={styles.layout.horizontal.compact.content}>
-        {showTitle && <Title className={styles.title.size.compact} />}
-        <div className={cn(styles.info.container, styles.info.size.compact)}>
-          {showStatus && <Status className={styles.status.size.compact} />}
-          {showDateRange && <DateRange />}
-          {showLocation && <Location />}
-          {showCast && <Cast />}
-          {showPrice && <Price className={styles.price.compact} />}
-        </div>
-      </div>
-    </div>
-  </>
-);
-
-const VerticalCard = ({
-  isLiked = false,
-  showImage = true,
-  showTitle = true,
-  showStatus = true,
-  showDateRange = true,
-  showLocation = true,
-  showCast = true,
-  showPrice = true,
-  showLikeButton = true,
-}: { isLiked?: boolean } & VisibilityProps) => (
-  <>
-    {showLikeButton && (
-      <LikeButton
-        isLiked={isLiked}
-        className={cn(
-          styles.likeButton.size,
-          styles.likeButton.position.default
-        )}
-      />
-    )}
-    {showImage && <ImageComponent className={styles.image.size.vertical} />}
-    <div className={styles.layout.vertical.container}>
-      {showTitle && <Title className={styles.title.size.verticalDefault} />}
-      <div className={styles.layout.vertical.info}>
-        {showStatus && <Status className={styles.status.size.default} />}
-        {showDateRange && <DateRange />}
-        {showLocation && <Location />}
-        {showCast && <Cast />}
-        {showPrice && <Price className={styles.price.default} />}
-      </div>
-    </div>
-  </>
-);
-
-const DetailedCard = ({
-  isLiked = false,
-  showImage = true,
-  showTitle = true,
-  showStatus = true,
-  showDateRange = true,
-  showLocation = true,
-  showCast = true,
-  showPrice = true,
-  showLikeButton = true,
-}: { isLiked?: boolean } & VisibilityProps) => (
-  <>
-    {showLikeButton && (
-      <LikeButton
-        isLiked={isLiked}
-        className={cn(
-          styles.likeButton.size,
-          styles.likeButton.position.default
-        )}
-      />
-    )}
-    <div className={styles.layout.horizontal.default.container}>
-      {showImage && <ImageComponent className={styles.image.size.default} />}
-      <div className={styles.layout.horizontal.default.content}>
-        {showTitle && <Title className={styles.title.size.detailed} />}
-        <div className={cn(styles.info.container, styles.info.size.default)}>
-          {showStatus && <Status className={styles.status.size.default} />}
-          {showDateRange && <DateRange />}
-          {showLocation && <Location />}
-          {showCast && <Cast />}
-          {showPrice && <Price className={styles.price.default} />}
-        </div>
-      </div>
-    </div>
-  </>
-);
-
-/* export */
-type CardType = 'default' | 'compact' | 'vertical' | 'detailed';
-
-interface PerformanceCardProps extends VisibilityProps {
-  performance: Performance;
-  type?: CardType;
-  className?: string;
-  onCardClick?: (performance: Performance) => void;
-  onLikeClick?: (performance: Performance, isLiked: boolean) => void;
-  isLiked?: boolean;
-}
-
-const PerformanceCard = ({
-  performance,
-  type = 'default',
-  className,
-  onCardClick,
-  onLikeClick,
-  isLiked = false,
-  showImage,
-  showTitle,
-  showStatus,
-  showDateRange,
-  showLocation,
-  showCast,
-  showPrice,
-  showLikeButton,
-}: PerformanceCardProps) => {
-  const visibilityProps = {
-    showImage,
-    showTitle,
-    showStatus,
-    showDateRange,
-    showLocation,
-    showCast,
-    showPrice,
-    showLikeButton,
-  };
-
-  const getCardContent = () => {
-    switch (type) {
-      case 'compact':
-        return (
-          <CompactCard
-            isLiked={isLiked}
-            {...visibilityProps}
-          />
-        );
-      case 'vertical':
-        return (
-          <VerticalCard
-            isLiked={isLiked}
-            {...visibilityProps}
-          />
-        );
-      case 'detailed':
-        return (
-          <DetailedCard
-            isLiked={isLiked}
-            {...visibilityProps}
-          />
-        );
-      default:
-        return (
-          <DefaultCard
-            isLiked={isLiked}
-            {...visibilityProps}
-          />
-        );
-    }
-  };
-
-  const getCardVariantClass = () => {
-    switch (type) {
-      case 'compact':
-        return styles.card.variant.compact;
-      case 'detailed':
-        return styles.card.variant.detailed;
-      default:
-        return styles.card.variant.default;
-    }
-  };
-
-  return (
-    <Root
-      performance={performance}
-      onCardClick={onCardClick}
-      onLikeClick={onLikeClick}
-      className={cn(styles.card.base, getCardVariantClass(), className)}
-    >
-      {getCardContent()}
-    </Root>
-  );
-};
-
-export default PerformanceCard;
-
 export {
-  PerformanceCard,
   Root,
   ImageComponent as Image,
   Title,
@@ -562,17 +301,4 @@ export {
   Cast,
   Price,
   LikeButton,
-  usePerformanceCardContext,
-  type VisibilityProps,
 };
-
-PerformanceCard.Root = Root;
-PerformanceCard.Image = ImageComponent;
-PerformanceCard.Title = Title;
-PerformanceCard.Status = Status;
-PerformanceCard.DateRange = DateRange;
-PerformanceCard.Location = Location;
-PerformanceCard.Cast = Cast;
-PerformanceCard.Price = Price;
-PerformanceCard.LikeButton = LikeButton;
-PerformanceCard.useContext = usePerformanceCardContext;

--- a/src/utils/formatPerformanceData.ts
+++ b/src/utils/formatPerformanceData.ts
@@ -60,7 +60,7 @@ const formatPerformanceData = (performance: Performance, locale = ko) => {
     return `${cast.slice(0, CAST_MAX_NUM).join(', ')} 외 ${cast.length - CAST_MAX_NUM}명`;
   })(performance.cast);
 
-  const mainImage = performance.poster || performance.imgs?.[0]?.src;
+  const mainImage = performance.poster || performance.images?.[0]?.src;
 
   return {
     id: performance.id,


### PR DESCRIPTION
### 무엇을 위한 PR인가요?
- 리펙토링: PerformanceCard 컴포넌트의 스타일 분리 및 구조 개선

### 변경사항 및 이유
-  **헤드리스 컴포넌트로의 전화**: 기본 프리셋이 있는 하이브리드 형은 너무복잡함
- **스타일과 로직의 완전한 분리**: 유지보수성 향상과 재사용성 증대를 위해 스타일을 별도 모듈로 분리
- **분해할당 패턴 도입**: 긴 객체 접근 경로를 분해할당으로 단순화하여 가독성 향상 및 depth를 한정함
- **테스트 코드 업데이트**: 변경된 컴포넌트 구조에 맞춰 테스트 케이스 수정 및 추가
- **포괄적인 문서화**: 개발자 친화적인 상세 사용 가이드 및 주의사항 문서 작성


### 작업 내역
- **메인 컴포넌트 리팩토링**: 
  - 스타일 import 및 분해할당 패턴 적용
  - `getStatusStyle` 헬퍼 함수 제거하고 인라인 로직으로 변경
  - Status 컴포넌트의 조건부 스타일 적용 로직 단순화
- **테스트 파일 전면 수정**:
  - 현재 compound component 구조에 맞춰 import 방식 변경
  - Performance 타입의 누락된 필드(groupCount, favoriteCount) 추가
  - 스타일 관련 테스트 케이스 추가
  - 각 컴포넌트별 상세 테스트 확장
- **종합 문서 작성**:
  - 컴포넌트 아키텍처 다이어그램 포함
  - 단계별 사용법 가이드
  - 의존성 주입 방식 상세 설명
  - 실무 체크리스트 및 트러블슈팅 가이드

### 작업 후 기대 동작
- **개발자 경험 향상**: 명확한 문서와 타입 안전성으로 컴포넌트 사용 시 실수 방지
- **유지보수성 개선**: 스타일 변경 시 한 파일만 수정하면 되는 구조
- **코드 품질 향상**: 
  - 더 읽기 쉬운 컴포넌트 코드
  - 포괄적인 테스트 커버리지
  - 일관된 스타일 적용
- **신규 개발자 온보딩**: 상세한 문서로 빠른 컴포넌트 이해 및 활용 가능

### PR 특이 사항
- **Breaking Change 없음**: 기존 API는 그대로 유지하면서 내부 구조만 개선
- **성능 영향 없음**: 런타임 동작은 동일하며, 번들 크기 변화 미미
- **테스트 커버리지 확장**: 
  - 상태별 스타일 적용 검증 테스트 추가
  - 조건부 렌더링 로직 테스트 강화
  - 접근성 관련 테스트 보완
- **문서 우선 접근**: 개발자가 실제로 겪을 수 있는 문제들을 미리 파악하여 문서에 반영

### Issue Number
close: #208 