### PR TITLE
[Feature/issue-212] 메인 페이지 데이터 스켈레톤 적용 및 찜 낙관적 업데이트 구현

### DIFF
--- a/src/components/common/Toast/Toast.tsx
+++ b/src/components/common/Toast/Toast.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useState } from 'react';
 import { cn } from '@/lib/utils';
+import Portal from '../Portal';
 
 export interface ToastProps {
   message: string;
   type?: 'default' | 'success' | 'warning' | 'error' | 'info';
   onClose: () => void;
   className?: string;
+  blockBackgroundClick?: boolean;
 }
 
 const typeStyles: Record<NonNullable<ToastProps['type']>, string> = {
@@ -24,6 +26,7 @@ const Toast = ({
   type = 'default',
   onClose,
   className = 'top-4 left-1/2 -translate-x-1/2',
+  blockBackgroundClick = false,
 }: ToastProps) => {
   const [isVisible, setIsVisible] = useState(false);
 
@@ -39,8 +42,10 @@ const Toast = ({
   }, [onClose]);
 
   return (
-    <>
-      <div className='fixed inset-0 z-40 select-none' />
+    <Portal>
+      {blockBackgroundClick && (
+        <div className='fixed inset-0 z-40 select-none' />
+      )}
       <div
         aria-live='assertive'
         role='alert'
@@ -53,7 +58,7 @@ const Toast = ({
       >
         {message}
       </div>
-    </>
+    </Portal>
   );
 };
 

--- a/src/components/pages/main/MainPerformanceCard.tsx
+++ b/src/components/pages/main/MainPerformanceCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useState } from 'react';
 import {
   Image,
   LikeButton,
@@ -8,8 +8,10 @@ import {
   Root,
   Title,
 } from '@/components/common/PerformanceCard/PerformanceCard';
+import Toast from '@/components/common/Toast/Toast';
 import LikeIcon from '@/components/icons/LikeIcon';
 import { usePatchPerformanceLiked } from '@/hooks/performanceHooks/performanceHooks';
+import { useAuthStore } from '@/providers/AuthStoreProvider';
 import { Performance } from '@/types/performance';
 
 interface MainPerformanceCardProps {
@@ -17,14 +19,28 @@ interface MainPerformanceCardProps {
 }
 
 const MainPerformanceCard = ({ performance }: MainPerformanceCardProps) => {
+  const isLoggedin = useAuthStore((state) => state.isLoggedin);
+  const [showToast, setShowToast] = useState(false);
   const { mutate } = usePatchPerformanceLiked();
 
   const toggleLike = () => {
+    if (!isLoggedin) {
+      setShowToast(true);
+      return;
+    }
     mutate({ performanceId: performance.id, isLiked: !performance.isLiked });
   };
 
   return (
     <>
+      {showToast && (
+        <Toast
+          message='로그인이 필요합니다!'
+          type='error'
+          onClose={() => setShowToast(false)}
+          className='bottom-4 left-1/2 -translate-x-1/2'
+        />
+      )}
       <Root
         onCardClick={() => {}}
         onLikeClick={toggleLike}

--- a/src/components/pages/main/MainPerformanceCard.tsx
+++ b/src/components/pages/main/MainPerformanceCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React from 'react';
 import {
   Image,
   LikeButton,
@@ -9,6 +9,7 @@ import {
   Title,
 } from '@/components/common/PerformanceCard/PerformanceCard';
 import LikeIcon from '@/components/icons/LikeIcon';
+import { usePatchPerformanceLiked } from '@/hooks/performanceHooks/performanceHooks';
 import { Performance } from '@/types/performance';
 
 interface MainPerformanceCardProps {
@@ -16,20 +17,22 @@ interface MainPerformanceCardProps {
 }
 
 const MainPerformanceCard = ({ performance }: MainPerformanceCardProps) => {
-  const [isLike, setIsLike] = useState(performance.isLiked);
+  const { mutate } = usePatchPerformanceLiked();
+
+  const toggleLike = () => {
+    mutate({ performanceId: performance.id, isLiked: !performance.isLiked });
+  };
+
   return (
     <>
       <Root
         onCardClick={() => {}}
-        onLikeClick={(p, l) => {
-          console.log(p, l);
-          setIsLike((pre) => !pre);
-        }}
+        onLikeClick={toggleLike}
         performance={performance}
         className='relative flex w-[150px] flex-col gap-3 border-0'
       >
         <LikeButton
-          isLiked={isLike}
+          isLiked={performance.isLiked}
           icon={{
             liked: (
               <LikeIcon

--- a/src/components/pages/main/MainPerformanceCard.tsx
+++ b/src/components/pages/main/MainPerformanceCard.tsx
@@ -34,17 +34,17 @@ const MainPerformanceCard = ({ performance }: MainPerformanceCardProps) => {
             liked: (
               <LikeIcon
                 type='active'
-                className='h-[30px] w-[30px]'
+                className='h-[30px] w-[30px] hover:opacity-80'
               />
             ),
             unLiked: (
               <LikeIcon
                 type='emptyWhite'
-                className='h-[30px] w-[30px]'
+                className='h-[30px] w-[30px] hover:opacity-80'
               />
             ),
           }}
-          className='top-2.5 right-2.5 h-fit w-fit bg-transparent'
+          className='top-2.5 right-2.5 h-fit w-fit cursor-pointer bg-transparent hover:bg-transparent'
         />
         <Image className='h-[200px] w-[150px] rounded-[12px]' />
         <div className='flex flex-col gap-2'>

--- a/src/components/pages/main/MainTopFavoritesPerformances.tsx
+++ b/src/components/pages/main/MainTopFavoritesPerformances.tsx
@@ -1,19 +1,19 @@
+'use client';
+
 import React from 'react';
-import { nextFetcher } from '@/lib/nextFetcher';
-import { PerformancesResponse } from '@/types/performance';
+import { useGetTopFavoritesPerformances } from '@/hooks/performanceHooks/performanceHooks';
 import PerformanceWrapper from './PerformanceWrapper';
 
-const MainTopFavoritesPerformances = async () => {
-  const topFavoritesPerformances = await nextFetcher<PerformancesResponse>(
-    `/api/v1/performances/top-favorites`,
-    { method: 'GET', revalidate: 21600 }
-  );
+const MainTopFavoritesPerformances = () => {
+  const { data: topFavoritesPerformances, isPending } =
+    useGetTopFavoritesPerformances();
 
   return (
     <PerformanceWrapper
       href=''
       title='지금 핫한 공연'
-      performances={topFavoritesPerformances}
+      isPending={isPending}
+      performances={topFavoritesPerformances?.data}
     />
   );
 };

--- a/src/components/pages/main/MainTopGroupsPerformances.tsx
+++ b/src/components/pages/main/MainTopGroupsPerformances.tsx
@@ -1,18 +1,18 @@
+'use client';
 import React from 'react';
-import { nextFetcher } from '@/lib/nextFetcher';
-import { PerformancesResponse } from '@/types/performance';
+import { useGetTopByGroupCountPerformances } from '@/hooks/performanceHooks/performanceHooks';
 import PerformanceWrapper from './PerformanceWrapper';
 
-const MainTopGroupsPerformances = async () => {
-  const topFavoritesPerformances = await nextFetcher<PerformancesResponse>(
-    `/api/v1/performances/top-groups`,
-    { method: 'GET', revalidate: 21600 }
-  );
+const MainTopGroupsPerformances = () => {
+  const { data: topByGroupCountPerformances, isPending } =
+    useGetTopByGroupCountPerformances();
+
   return (
     <PerformanceWrapper
       href=''
       title='모임 많은 공연'
-      performances={topFavoritesPerformances}
+      isPending={isPending}
+      performances={topByGroupCountPerformances?.data}
     />
   );
 };

--- a/src/components/pages/main/PerformanceWrapper.tsx
+++ b/src/components/pages/main/PerformanceWrapper.tsx
@@ -4,51 +4,77 @@ import {
   CarouselContent,
   CarouselItem,
 } from '@/components/ui/carousel';
+import { Skeleton } from '@/components/ui/skeleton';
 import { PerformancesResponse } from '@/types/performance';
 import MainPerformanceCard from './MainPerformanceCard';
 
 interface PerformanceWrapperProps {
   title: string;
   href: string;
-  performances: PerformancesResponse;
+  isPending: boolean;
+  performances?: PerformancesResponse;
 }
 
 const PerformanceWrapper = ({
   title,
   href,
+  isPending,
   performances,
-}: PerformanceWrapperProps) => (
-  <div className='flex flex-col gap-5 bg-white px-4 pt-5 pb-[30px]'>
-    <div className='flex items-center justify-between'>
-      <h2 className='flex h-[19px] items-center text-16_B text-gray-950'>
-        {title}
-      </h2>
-      <Link
-        href={href}
-        className='flex h-[17px] items-center text-14_M text-gray-500 underline'
-      >
-        더보기
-      </Link>
-    </div>
+}: PerformanceWrapperProps) => {
+  let content;
 
-    <Carousel
-      opts={{
-        align: 'start',
-      }}
-      className='w-full'
-    >
-      <CarouselContent className='z-10 m-0 gap-5'>
-        {performances.data?.map((performance) => (
-          <CarouselItem
-            key={performance.id}
-            className='basis-[150px] p-0'
-          >
-            <MainPerformanceCard performance={performance} />
-          </CarouselItem>
-        ))}
-      </CarouselContent>
-    </Carousel>
-  </div>
-);
+  if (isPending) {
+    content = Array.from({ length: 5 }).map((_, index) => (
+      <CarouselItem
+        key={index}
+        className='basis-[150px] p-0'
+      >
+        <div className='flex w-[150px] flex-col gap-3'>
+          <Skeleton className='h-[200px] w-[150px] rounded-[12px]' />
+          <div className='flex flex-col gap-2'>
+            <Skeleton className='h-[19px] w-[150px]' />
+            <Skeleton className='h-[17px] w-[150px]' />
+          </div>
+        </div>
+      </CarouselItem>
+    ));
+  }
+
+  if (performances) {
+    content = performances.data?.map((performance) => (
+      <CarouselItem
+        key={performance.id}
+        className='basis-[150px] p-0'
+      >
+        <MainPerformanceCard performance={performance} />
+      </CarouselItem>
+    ));
+  }
+
+  return (
+    <div className='flex flex-col gap-5 bg-white px-4 pt-5 pb-[30px]'>
+      <div className='flex items-center justify-between'>
+        <h2 className='flex h-[19px] items-center text-16_B text-gray-950'>
+          {title}
+        </h2>
+        <Link
+          href={href}
+          className='flex h-[17px] items-center text-14_M text-gray-500 underline'
+        >
+          더보기
+        </Link>
+      </div>
+
+      <Carousel
+        opts={{
+          align: 'start',
+        }}
+        className='w-full'
+      >
+        <CarouselContent className='z-10 m-0 gap-5'>{content}</CarouselContent>
+      </Carousel>
+    </div>
+  );
+};
 
 export default PerformanceWrapper;

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,16 @@
+import { cn } from '@/lib/utils';
+
+const Skeleton = function ({
+  className,
+  ...props
+}: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot='skeleton'
+      className={cn('animate-pulse rounded-md bg-accent', className)}
+      {...props}
+    />
+  );
+};
+
+export { Skeleton };

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -1,0 +1,5 @@
+export const PERFORMANCES_QUERY_KEYS = {
+  performances: 'performances',
+  topFavorites: 'topFavorites',
+  topByGroupCount: 'topByGroupCount',
+};

--- a/src/hooks/performanceHooks/performanceHooks.ts
+++ b/src/hooks/performanceHooks/performanceHooks.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query';
+import { PERFORMANCES_QUERY_KEYS } from '@/constants/queryKeys';
+import { performancesApi } from '@/services/performancesService';
+
+export const useGetTopFavoritesPerformances = () =>
+  useQuery({
+    queryKey: [
+      PERFORMANCES_QUERY_KEYS.performances,
+      PERFORMANCES_QUERY_KEYS.topFavorites,
+    ],
+    queryFn: performancesApi.getTopFavorites,
+  });
+
+export const useGetTopByGroupCountPerformances = () =>
+  useQuery({
+    queryKey: [
+      PERFORMANCES_QUERY_KEYS.performances,
+      PERFORMANCES_QUERY_KEYS.topByGroupCount,
+    ],
+    queryFn: performancesApi.getTopByGroupCount,
+  });

--- a/src/mocks/handlers/performancesHandlers.ts
+++ b/src/mocks/handlers/performancesHandlers.ts
@@ -1,5 +1,8 @@
 import { http, HttpResponse, delay } from 'msw';
-import { PerformancesResponse } from '@/types/performance';
+import {
+  PerformanceIsLikedData,
+  PerformancesResponse,
+} from '@/types/performance';
 
 const TOP_FAVORITES_SAMPLE_DATA: PerformancesResponse = {
   code: 200,
@@ -46,32 +49,32 @@ const TOP_FAVORITES_SAMPLE_DATA: PerformancesResponse = {
     },
     {
       id: 'pf-20251001',
-      title: '고객 중심 차별화 전략',
-      startDate: '2025-07-01T18:00:00Z',
-      endDate: '2025-07-03T22:00:00Z',
-      location: '경기도 김정현동 748-24',
-      cast: ['이은우', '오승희', '박은우'],
-      crew: ['이한결', '박승민'],
-      runtime: '180분',
-      age: '만 7세 이상',
-      productionCompany: ['윤주 (주)'],
-      agency: ['이서준 (주)'],
-      host: ['정지윤 (유)'],
-      organizer: ['오주원 (유)'],
-      price: ['일반석 97907원', 'VIP석 148307원'],
+      title: 'Tempore Culpa 페스티벌',
+      startDate: '2025-06-07T10:26:44',
+      endDate: '2025-06-09T12:26:44',
+      location: '인천광역시 성북구 봉은사로 (도윤김김마을)',
+      cast: ['김재호', '김은서', '김지원'],
+      crew: ['이민지', '이미숙'],
+      runtime: '90분',
+      age: '만 12세 이상',
+      productionCompany: ['김홍'],
+      agency: ['송서'],
+      host: ['박우'],
+      organizer: ['이최'],
+      price: ['일반석 66049원', 'VIP석 124628원'],
       poster: 'https://picsum.photos/seed/perf1/400/600',
-      state: '공연중',
+      state: '예정',
       visit: '국내',
       images: [
         {
           id: 'img-11',
           src: 'https://picsum.photos/seed/perf11/800/600',
-          alt: '대한민국 불구하고 나타났다.',
+          alt: 'Nulla similique neque provident.',
         },
         {
           id: 'img-12',
           src: 'https://picsum.photos/seed/perf12/800/600',
-          alt: '예를 들어 강력한 의무가',
+          alt: 'Ut.',
         },
       ],
       time: [
@@ -79,12 +82,12 @@ const TOP_FAVORITES_SAMPLE_DATA: PerformancesResponse = {
         '토요일(16:00,19:00)',
         '일요일(15:00,18:00)',
       ],
-      groupCount: 18,
-      favoriteCount: 7160,
+      groupCount: 26,
+      favoriteCount: 9935,
       isLiked: true,
     },
     {
-      id: 'pf-20251002',
+      id: 'pf-20251012',
       title: '마케팅 구조 역량',
       startDate: '2025-07-01T18:00:00Z',
       endDate: '2025-07-03T22:00:00Z',
@@ -123,7 +126,7 @@ const TOP_FAVORITES_SAMPLE_DATA: PerformancesResponse = {
       isLiked: false,
     },
     {
-      id: 'pf-20251003',
+      id: 'pf-20251103',
       title: '혁신적 브랜드 정체성',
       startDate: '2025-07-01T18:00:00Z',
       endDate: '2025-07-03T22:00:00Z',
@@ -162,7 +165,7 @@ const TOP_FAVORITES_SAMPLE_DATA: PerformancesResponse = {
       isLiked: false,
     },
     {
-      id: 'pf-20251004',
+      id: 'pf-20251104',
       title: '글로벌 고객 확보 전략',
       startDate: '2025-07-01T18:00:00Z',
       endDate: '2025-07-03T22:00:00Z',
@@ -413,8 +416,49 @@ export const performancesHandlers = [
       return HttpResponse.json(TOP_FAVORITES_SAMPLE_DATA);
     }
   ),
+
   http.get('http://localhost:3000/api/v1/performances/top-groups', async () => {
     await delay(3000);
     return HttpResponse.json(TOP_GROUPS_SAMPLE_DATA);
   }),
+
+  http.patch(
+    'http://localhost:3000/api/v1/performances/:performanceId/favorites',
+    async ({ request, params }) => {
+      const { performanceId } = params;
+      const { isLiked } = (await request.json()) as PerformanceIsLikedData;
+      await delay(2000);
+      // return HttpResponse.json(
+      //   {
+      //     code: 404,
+      //     message: '존재하지 않는 공연입니다.',
+      //   },
+      //   { status: 404 }
+      // );
+      const target = TOP_FAVORITES_SAMPLE_DATA.data
+        ?.concat(TOP_GROUPS_SAMPLE_DATA.data ?? [])
+        .find((item) => item.id === performanceId);
+
+      if (!target) {
+        return HttpResponse.json(
+          {
+            code: 404,
+            message: '존재하지 않는 공연입니다.',
+          },
+          { status: 404 }
+        );
+      }
+
+      target.isLiked = isLiked;
+
+      return HttpResponse.json(
+        {
+          code: 200,
+          message: isLiked ? '공연을 찜했습니다.' : '공연을 찜 취소했습니다.',
+          data: { performanceId, isLiked },
+        },
+        { status: 200 }
+      );
+    }
+  ),
 ];

--- a/src/mocks/handlers/performancesHandlers.ts
+++ b/src/mocks/handlers/performancesHandlers.ts
@@ -1,4 +1,4 @@
-import { http, HttpResponse } from 'msw';
+import { http, HttpResponse, delay } from 'msw';
 import { PerformancesResponse } from '@/types/performance';
 
 const TOP_FAVORITES_SAMPLE_DATA: PerformancesResponse = {
@@ -406,10 +406,15 @@ const TOP_GROUPS_SAMPLE_DATA: PerformancesResponse = {
 };
 
 export const performancesHandlers = [
-  http.get('http://localhost:3000/api/v1/performances/top-favorites', () =>
-    HttpResponse.json(TOP_FAVORITES_SAMPLE_DATA)
+  http.get(
+    'http://localhost:3000/api/v1/performances/top-favorites',
+    async () => {
+      await delay(3000);
+      return HttpResponse.json(TOP_FAVORITES_SAMPLE_DATA);
+    }
   ),
-  http.get('http://localhost:3000/api/v1/performances/top-groups', () =>
-    HttpResponse.json(TOP_GROUPS_SAMPLE_DATA)
-  ),
+  http.get('http://localhost:3000/api/v1/performances/top-groups', async () => {
+    await delay(3000);
+    return HttpResponse.json(TOP_GROUPS_SAMPLE_DATA);
+  }),
 ];

--- a/src/services/performancesService.ts
+++ b/src/services/performancesService.ts
@@ -1,13 +1,24 @@
 import apiFetcher from '@/lib/apiFetcher';
-import { PerformancesResponse } from '@/types/performance';
+import {
+  PerformanceIsLikedData,
+  PerformanceIsLikedResponse,
+  PerformancesResponse,
+} from '@/types/performance';
 
 export const performancesApi = {
   getTopFavorites: async () =>
     await apiFetcher.get<PerformancesResponse>(
       '/api/v1/performances/top-favorites'
     ),
+
   getTopByGroupCount: async () =>
     await apiFetcher.get<PerformancesResponse>(
       '/api/v1/performances/top-groups'
+    ),
+
+  patchLiked: async ({ performanceId, isLiked }: PerformanceIsLikedData) =>
+    await apiFetcher.patch<PerformanceIsLikedResponse>(
+      `/api/v1/performances/${performanceId}/favorites`,
+      { isLiked }
     ),
 };

--- a/src/types/performance.ts
+++ b/src/types/performance.ts
@@ -27,3 +27,10 @@ export interface Performance {
 }
 
 export type PerformancesResponse = ApiResponse<Performance[]>;
+
+export interface PerformanceIsLikedData {
+  performanceId: string;
+  isLiked: boolean;
+}
+
+export type PerformanceIsLikedResponse = ApiResponse<PerformanceIsLikedData>;


### PR DESCRIPTION
### 무엇을 위한 PR인가요? (: 뒤 설명 추가)

- 신규 기능 추가: 메인 페이지 데이터 스켈레톤 적용 및 찜 낙관적 업데이트 구현

### 변경사항 및 이유 (bullet 으로 구분)

- 공연 목록이 서버에서 불러와질 동안 스켈레톤 컴포넌트 렌더링
- 찜 요청 시 낙관적 업데이트 수행

### 작업 내역 (bullet 으로 구분)

- tanstack-query를 통해 공연 목록을 불러올 때 isPending상태일 경우 공연 목록 카드와 동일한 크기의 스켈레톤 컴포넌트를 렌더링 하도록 변경
- tanstack-query를 사용하여 공연을 찜 했을때 실제 적용까지 오래 걸리더라도 낙관적으로 업데이트를 수행

### ?작업 후 기대 동작(스크린샷)

https://github.com/user-attachments/assets/dd9796cf-6496-4c18-a102-e5c452010fba

https://github.com/user-attachments/assets/e94c8298-fa8b-4dbf-9f86-e1e24227d1a6

https://github.com/user-attachments/assets/b7b43255-1bea-4810-ba67-b9050cf27407


### ?PR 특이 사항

- 향후 배너 클릭 시 공연 상세 이동 기능 추가 예정
- 공연 카드 클릭시 라우팅 적용 예정
- 현재는 모바일 크기(가로 375px)에 맞춰진 상태로 추후 반응형 스타일링 예정

### Issue Number

close: #212 