### PR TITLE
[Feature/issue-232] Toast컴포넌트 테스트코드 실패 오류 해결

### DIFF
--- a/src/components/common/Toast/Toast.test.tsx
+++ b/src/components/common/Toast/Toast.test.tsx
@@ -4,6 +4,19 @@ import Toast, { ToastProps } from './Toast';
 jest.useFakeTimers();
 
 describe('Toast 컴포넌트', () => {
+  beforeAll(() => {
+    const portal = document.createElement('div');
+    portal.setAttribute('id', 'portal');
+    document.body.appendChild(portal);
+  });
+
+  afterAll(() => {
+    const portal = document.getElementById('portal');
+    if (portal) {
+      document.body.removeChild(portal);
+    }
+  });
+
   const setup = (props: Partial<ToastProps> = {}) => {
     const onClose = jest.fn();
     render(


### PR DESCRIPTION
### 무엇을 위한 PR인가요? (: 뒤 설명 추가)

- 버그 수정: Toast컴포넌트 테스트코드 실패 오류 해결

### 변경사항 및 이유 (bullet 으로 구분)

- ```<Toast>```컴포넌트를 ```<Portal>```로 감싸면서 생긴 테스트코드 오류 해결

### 작업 내역 (bullet 으로 구분)

- 테스트코드에서 beforeAll을 통해 portal의 id에 해당하는 ```<div>```를 document.body에 appendChild를 통해 삽입

### ?작업 후 기대 동작(스크린샷)

- 테스트 정상 작동
- 
### Issue Number

close: #232 