### PR TITLE
[Feature/issue-234] 메인페이지 공연 카드에 순위 추가

### DIFF
--- a/src/components/pages/main/MainPerformanceCard.tsx
+++ b/src/components/pages/main/MainPerformanceCard.tsx
@@ -16,9 +16,13 @@ import { Performance } from '@/types/performance';
 
 interface MainPerformanceCardProps {
   performance: Performance;
+  ranking: number;
 }
 
-const MainPerformanceCard = ({ performance }: MainPerformanceCardProps) => {
+const MainPerformanceCard = ({
+  performance,
+  ranking,
+}: MainPerformanceCardProps) => {
   const isLoggedin = useAuthStore((state) => state.isLoggedin);
   const [showToast, setShowToast] = useState(false);
   const { mutate } = usePatchPerformanceLiked();
@@ -65,7 +69,12 @@ const MainPerformanceCard = ({ performance }: MainPerformanceCardProps) => {
           }}
           className='top-2.5 right-2.5 h-fit w-fit cursor-pointer bg-transparent hover:bg-transparent'
         />
-        <Image className='h-[200px] w-[150px] rounded-[12px]' />
+        <div className='relative'>
+          <Image className='h-[200px] w-[150px] rounded-[12px]' />
+          <span className='absolute bottom-[13px] left-[17px] flex h-[38px] items-center text-32_B text-white'>
+            {ranking}
+          </span>
+        </div>
         <div className='flex flex-col gap-2'>
           <Title className='mb-0 h-[19px] w-[150px] truncate !text-16_B text-gray-950' />
           <Location className='h-[17px] w-[150px] truncate to-gray-600 !text-14_M' />

--- a/src/components/pages/main/PerformanceWrapper.tsx
+++ b/src/components/pages/main/PerformanceWrapper.tsx
@@ -41,12 +41,15 @@ const PerformanceWrapper = ({
   }
 
   if (performances) {
-    content = performances.data?.map((performance) => (
+    content = performances.data?.map((performance, idx) => (
       <CarouselItem
         key={performance.id}
         className='basis-[150px] p-0'
       >
-        <MainPerformanceCard performance={performance} />
+        <MainPerformanceCard
+          ranking={idx + 1}
+          performance={performance}
+        />
       </CarouselItem>
     ));
   }


### PR DESCRIPTION
### 무엇을 위한 PR인가요? (: 뒤 설명 추가)

- 신규 기능 추가: 메인페이지 공연 카드에 순위 추가

### 변경사항 및 이유 (bullet 으로 구분)

- 각 공연들의 해당 카테고리에 대한 순위를 보여주기 위해 추가

### 작업 내역 (bullet 으로 구분)

- 포스터 이미지를 감싸는 ```<div>```를 생성하여 relative속성을 부여한 뒤, 자식으로 absolute속성을 부여하여 이미지 위에 표시

### ?작업 후 기대 동작(스크린샷)

- before
![image](https://github.com/user-attachments/assets/40ce31cf-1a91-41a1-9475-ef3e4ba4f77b)

- after
![image](https://github.com/user-attachments/assets/af34e1cf-b913-41a5-b1d5-442db381489d)

### Issue Number

close: #234 