### PR TITLE
[Fix/issue-257] msw에서 performances/recent-reviews 가 performances/:performanceId로 매칭되는 오류 수정

### DIFF
--- a/src/mocks/server.ts
+++ b/src/mocks/server.ts
@@ -4,11 +4,7 @@ import { performancesHandlers } from './handlers/performancesHandlers';
 import { reviewsHandlers } from './handlers/reviewsHandlers';
 
 export const server = setupServer(
-  
-  ...performancesHandlers,
- 
   ...reviewsHandlers,
-  ...performancesHandlers
-,
+  ...performancesHandlers,
   ...groupsHandlers
 );


### PR DESCRIPTION
### 무엇을 위한 PR인가요? (: 뒤 설명 추가)

- 버그 수정: msw에서 performances/recent-reviews 가 performances/:performanceId로 매칭되는 오류

### 변경사항 및 이유 (bullet 으로 구분)

- 최근 리뷰 목록을 불러오지 못하는 오류 해결

### 작업 내역 (bullet 으로 구분)

- msw를 통해 서버에 등록하는 과정에서 reveiwsHandlers를 performancesHandlers의 상위로 변경

### Issue Number

close: #257