### PR TITLE
[Fix/issue-257] msw에서 performances/recent-reviews 가 performances/:performanceId로 매칭되는 오류 수정

### DIFF
--- a/src/mocks/server.ts
+++ b/src/mocks/server.ts
@@ -4,11 +4,7 @@ import { performancesHandlers } from './handlers/performancesHandlers';
 import { reviewsHandlers } from './handlers/reviewsHandlers';
 
 export const server = setupServer(
-  
-  ...performancesHandlers,
- 
   ...reviewsHandlers,
-  ...performancesHandlers
-,
+  ...performancesHandlers,
   ...groupsHandlers
 );


### PR DESCRIPTION
### Issue Number

close: #257 