### PR TITLE
[Refactor/issue-265] PerformanceListContainer 리펙토링

### DIFF
--- a/src/components/pages/performances/PerformancesListContainer.tsx
+++ b/src/components/pages/performances/PerformancesListContainer.tsx
@@ -1,12 +1,9 @@
 'use client';
-import React, { useMemo } from 'react';
+import React from 'react';
 import QueryPagination from '@/components/common/QueryPagination/QueryPagination';
 import { PerformanceList } from '@/components/pages/performances';
 import { useGetPerformances } from '@/hooks/performanceHooks/performanceHooks';
 import useQueryParam from '@/hooks/useQueryParam/useQueryParam';
-
-const DEFAULT_PAGE = '1';
-const DEFAULT_SIZE = '20';
 
 const LoadingFallback = () => (
   <div className='flex items-center justify-center py-8'>
@@ -21,31 +18,8 @@ const errorFallback = (error: Error) => (
 );
 
 const PerformanceListContainer = () => {
-  const { getQueryParam } = useQueryParam();
-
-  const queryString = useMemo(() => {
-    const params = new URLSearchParams();
-    const queryParams = {
-      keyword: getQueryParam('keyword'),
-      category: getQueryParam('category'),
-      startDate: getQueryParam('startDate'),
-      endDate: getQueryParam('endDate'),
-      location: getQueryParam('location'),
-      sort: getQueryParam('sort'),
-      page: getQueryParam('page') || DEFAULT_PAGE,
-      size: getQueryParam('size') || DEFAULT_SIZE,
-    };
-
-    return Object.entries(queryParams)
-      .filter(([, value]) => Boolean(value?.toString().trim()))
-      .reduce((params, [key, value]) => {
-        if (value) {
-          params.set(key, value.toString());
-        }
-        return params;
-      }, params)
-      .toString();
-  }, [getQueryParam]);
+  const { getQueryParam, getPerformanceQueryString } = useQueryParam();
+  const queryString = getPerformanceQueryString();
 
   const {
     data: searchResult,
@@ -54,9 +28,7 @@ const PerformanceListContainer = () => {
   } = useGetPerformances(queryString);
 
   if (error) return errorFallback(error);
-
   if (isPending) return <LoadingFallback />;
-
   if (!searchResult?.data)
     return (
       <div>
@@ -65,7 +37,7 @@ const PerformanceListContainer = () => {
     );
 
   const { totalPages = 0, totalElements: totalItems = 0 } = searchResult;
-  const currentPage = parseInt(getQueryParam('page') || DEFAULT_PAGE, 10);
+  const currentPage = parseInt(getQueryParam('page') || '1', 10);
 
   return (
     <div>

--- a/src/components/pages/performances/PerformancesListContainer.tsx
+++ b/src/components/pages/performances/PerformancesListContainer.tsx
@@ -3,11 +3,22 @@ import React, { useMemo, Suspense } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import QueryPagination from '@/components/common/QueryPagination/QueryPagination';
 import { PerformanceList } from '@/components/pages/performances';
+import { useGetPerformances } from '@/hooks/performanceHooks/performanceHooks';
 import useQueryParam from '@/hooks/useQueryParam/useQueryParam';
-import { nextFetcher } from '@/lib/nextFetcher';
-import { PerformancesResponsePagination } from '@/types/performance';
 
-const usePerformanceQuery = () => {
+const LoadingFallback = () => (
+  <div className='flex items-center justify-center py-8'>
+    <span>로딩 중...</span>
+  </div>
+);
+
+const errorFallback = (error: Error) => (
+  <div className='flex items-center justify-center py-8'>
+    <span className='text-red-500'>{error.message}</span>
+  </div>
+);
+
+const PerformanceListContainer = () => {
   const { getQueryParam, setQueryParam } = useQueryParam();
   const queryString = useMemo(() => {
     const params = new URLSearchParams();
@@ -33,7 +44,6 @@ const usePerformanceQuery = () => {
 
   const {
     data: searchResult,
-    isLoading,
     error,
   } = useQuery<PerformancesResponsePagination>({
     queryKey: ['performances', queryString],
@@ -64,6 +74,8 @@ const PerformanceListContainer = () => {
 
   if (error) return errorFallback(error);
 
+  if (isPending) return <LoadingFallback />;
+
   if (!searchResult || !searchResult.data)
     return (
       <div>
@@ -81,9 +93,7 @@ const PerformanceListContainer = () => {
         총 {totalItems}개의 공연이 있습니다. (페이지 {currentPage} /{' '}
         {totalPages})
       </div>
-      <Suspense fallback={<LoadingFallback />}>
-        <PerformanceList performances={searchResult.data} />
-      </Suspense>
+      <PerformanceList performances={searchResult.data} />
       {totalPages > 1 && (
         <QueryPagination
           totalPages={totalPages}

--- a/src/hooks/performanceHooks/performanceHooks.ts
+++ b/src/hooks/performanceHooks/performanceHooks.ts
@@ -7,6 +7,7 @@ import {
   PerformanceIsLikedData,
   PerformanceIsLikedResponse,
   PerformancesResponse,
+  PerformancesResponsePagination,
 } from '@/types/performance';
 
 export const useGetTopFavoritesPerformances = () =>
@@ -107,5 +108,17 @@ export const useGetPerformanceDetail = (performanceId: string) =>
     queryFn: async () => {
       const res = await performancesApi.getPerformanceDetail(performanceId);
       return res.data;
+    },
+  });
+
+export const useGetPerformances = (queryString: string) =>
+  useQuery<PerformancesResponsePagination>({
+    queryKey: [PERFORMANCES_QUERY_KEYS.performances, queryString],
+    queryFn: async () => {
+      const response = await fetch(`/api/v1/performances?${queryString}`);
+      if (!response.ok) {
+        throw new Error('공연 목록을 불러오는데 실패했습니다.');
+      }
+      return response.json();
     },
   });


### PR DESCRIPTION
### 무엇을 위한 PR인가요? (: 뒤 설명 추가)

- 리펙토링: fetching 부분을 서버로 분리 및 관심사 분리

### 변경사항 및 이유 (bullet 으로 구분)

- 이유 
  - next/fetcher가 클라이언트 사이드에서 호출되고 있어서 의미가 없음
  - suspense가 제대로 동작하지 않음  

### 작업 내역 (bullet 으로 구분)

- `useGetPerformance` 훅으로 분리하여 클라이언트 사이트에서  `next/fetcher`의 호출을 방지
- 쿼리스트링을 처리하던 부분은 `useQueryParam`안에 `getPerformanceQueryString`으로 분리하여 관심사를 나눴음
- `QueryPagination` 적용

### Issue Number

close: #265 