### PR TITLE
[Fix/issue-279] eslint import 순서 적용 안되는 이슈 해결

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -186,6 +186,7 @@ const eslintConfig = [
               group: 'external',
               position: 'before',
             },
+            { pattern: '@/**', group: 'internal', position: 'before' },
             {
               pattern: './routes/**',
               group: 'internal',


### PR DESCRIPTION
### 무엇을 위한 PR인가요? (: 뒤 설명 추가)

- 버그 수정: eslint import 순서 적용 안되는 이슈 해결

### 변경사항 및 이유 (bullet 으로 구분)

- eslint에 설정해둔 import 순서가 제대로 적용되지 않는 이슈 해결
- `@/**` 형식의 파일을 잘 인식하지 못해 import 순서가 뒤섞임

### 작업 내역 (bullet 으로 구분)

- `eslint.config.mjs` 파일 189번째 줄에 아래 코드 추가해여 해결
```tsx
{ pattern: '@/**', group: 'internal', position: 'before' },
```

### Issue Number

close: #279 