### PR TITLE
[Feature/issue-185] 모임 관리 페이지 신청목록, 참가목록 구현

### DIFF
--- a/src/app/(hasGNB)/(isLogin)/groups/managements/page.tsx
+++ b/src/app/(hasGNB)/(isLogin)/groups/managements/page.tsx
@@ -1,3 +1,5 @@
-const GroupsManagementsPage = () => <div>나의 모임 페이지</div>;
+import GroupsManagementsTabs from '@/components/pages/groupsManagement/GroupsManagementsTabs';
+
+const GroupsManagementsPage = () => <GroupsManagementsTabs />;
 
 export default GroupsManagementsPage;

--- a/src/components/pages/groupsManagement/ApplicationCard/ApplicationCard.tsx
+++ b/src/components/pages/groupsManagement/ApplicationCard/ApplicationCard.tsx
@@ -149,12 +149,14 @@ const ApplicationCard = ({
         {secondaryButtonText && (
           <Button
             variant='secondary'
+            color='normal'
             onClick={handleSecondaryClick}
           >
             {secondaryButtonText}
           </Button>
         )}
         <Button
+          variant='primary'
           color={applicationData.status === 'REJECTED' ? 'disable' : 'normal'}
           disabled={applicationData.status === 'REJECTED'}
           onClick={handlePrimaryClick}

--- a/src/components/pages/groupsManagement/Applications.tsx
+++ b/src/components/pages/groupsManagement/Applications.tsx
@@ -1,0 +1,4 @@
+import React from 'react';
+
+const Applications = () => <div>받은 신청서 목록</div>;
+export default Applications;

--- a/src/components/pages/groupsManagement/AppliedGroups.tsx
+++ b/src/components/pages/groupsManagement/AppliedGroups.tsx
@@ -1,5 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { useInView } from 'react-intersection-observer';
+import React, { useRef, useState } from 'react';
 import { InfiniteData, useInfiniteQuery } from '@tanstack/react-query';
 import { AxiosResponse } from 'axios';
 import Button from '@/components/common/Button/Button';
@@ -14,6 +13,7 @@ import {
   useCancelApplication,
   useConfirmApplication,
 } from '@/hooks/groupsManagementsHooks/groupsManagementsHooks';
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll/useInfiniteScroll';
 import { groupsManagementsApi } from '@/services/groupsManagementsService';
 import { ApiResponse } from '@/types/api';
 import { ApplicationStatus } from '@/types/enums';
@@ -26,8 +26,9 @@ import ApplicationCard from './ApplicationCard/ApplicationCard';
 const size = 20;
 
 const AppliedGroups = () => {
-  const { ref, inView } = useInView();
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const { mutate: cancelApplication } = useCancelApplication();
+  const { mutate: confirmApplication } = useConfirmApplication();
   const [showToast, setShowToast] = useState(false);
   const [selectedApplicationId, setSelectedApplicationId] =
     useState<string>('');
@@ -48,14 +49,11 @@ const AppliedGroups = () => {
       initialPageParam: undefined,
     });
 
-  const { mutate: cancelApplication } = useCancelApplication();
-  const { mutate: confirmApplication } = useConfirmApplication();
-
-  useEffect(() => {
-    if (inView && hasNextPage && !isFetchingNextPage) {
-      fetchNextPage();
-    }
-  }, [inView, hasNextPage, isFetchingNextPage, fetchNextPage]);
+  const bottomRef = useInfiniteScroll<HTMLDivElement>(
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage
+  );
 
   const handlePrimaryClick = (applicationId: string, status: string) => {
     if (status === ApplicationStatus.ACCEPTED) {
@@ -104,7 +102,7 @@ const AppliedGroups = () => {
       )}
       {hasNextPage && (
         <div
-          ref={ref}
+          ref={bottomRef}
           className='h-10'
         />
       )}

--- a/src/components/pages/groupsManagement/AppliedGroups.tsx
+++ b/src/components/pages/groupsManagement/AppliedGroups.tsx
@@ -1,0 +1,141 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { useInView } from 'react-intersection-observer';
+import { InfiniteData, useInfiniteQuery } from '@tanstack/react-query';
+import { AxiosResponse } from 'axios';
+import Button from '@/components/common/Button/Button';
+import Modal from '@/components/common/Modal/Modal';
+import ModalAction from '@/components/common/Modal/ModalAction';
+import ModalCancel from '@/components/common/Modal/ModalCancel';
+import ModalContent from '@/components/common/Modal/ModalContent';
+import ModalTrigger from '@/components/common/Modal/ModalTrigger';
+import Toast from '@/components/common/Toast/Toast';
+import { GROUPS_MANAGEMENTS_QUERY_KEYS } from '@/constants/queryKeys';
+import {
+  useCancelApplication,
+  useConfirmApplication,
+} from '@/hooks/groupsManagementsHooks/groupsManagementsHooks';
+import { groupsManagementsApi } from '@/services/groupsManagementsService';
+import { ApiResponse } from '@/types/api';
+import { ApplicationStatus } from '@/types/enums';
+import {
+  AppliedGroupsApiResponse,
+  formatAppliedGroups,
+} from '@/utils/formatApplicationCardData';
+import ApplicationCard from './ApplicationCard/ApplicationCard';
+
+const size = 20;
+
+const AppliedGroups = () => {
+  const { ref, inView } = useInView();
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const [showToast, setShowToast] = useState(false);
+  const [selectedApplicationId, setSelectedApplicationId] =
+    useState<string>('');
+
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useInfiniteQuery<
+      AxiosResponse<AppliedGroupsApiResponse>,
+      ApiResponse,
+      InfiniteData<AxiosResponse<AppliedGroupsApiResponse>>,
+      string[],
+      number | undefined
+    >({
+      queryKey: [GROUPS_MANAGEMENTS_QUERY_KEYS.appliedGroups],
+      queryFn: ({ pageParam }) =>
+        groupsManagementsApi.getAppliedGroups({ cursorId: pageParam, size }),
+      getNextPageParam: (lastPage) =>
+        lastPage.data?.hasNext ? lastPage.data?.cursorId : undefined,
+      initialPageParam: undefined,
+    });
+
+  const { mutate: cancelApplication } = useCancelApplication();
+  const { mutate: confirmApplication } = useConfirmApplication();
+
+  useEffect(() => {
+    if (inView && hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, [inView, hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  const handlePrimaryClick = (applicationId: string, status: string) => {
+    if (status === ApplicationStatus.ACCEPTED) {
+      confirmApplication({ applicationId });
+      setShowToast(true);
+    } else {
+      setSelectedApplicationId(applicationId);
+      triggerRef.current?.click();
+    }
+  };
+
+  const handleSecondaryClick = (applicationId: string) => {
+    setSelectedApplicationId(applicationId);
+    triggerRef.current?.click();
+  };
+
+  const handleModalConfirm = () => {
+    if (selectedApplicationId) {
+      cancelApplication({ applicationId: selectedApplicationId });
+    }
+  };
+
+  type ApplicationStatus =
+    (typeof ApplicationStatus)[keyof typeof ApplicationStatus];
+
+  const primaryText = (status: ApplicationStatus) =>
+    status === ApplicationStatus.ACCEPTED ? '참가 확정' : '신청 취소';
+
+  return (
+    <div className='flex flex-col items-center gap-5 px-4'>
+      {data?.pages.flatMap((page) =>
+        formatAppliedGroups(page.data).map((group) => (
+          <ApplicationCard
+            key={group.applicationId}
+            applicationData={group}
+            primaryButtonText={primaryText(group.status)}
+            onPrimaryClick={() =>
+              handlePrimaryClick(group.applicationId, group.status)
+            }
+            {...(group.status === ApplicationStatus.ACCEPTED && {
+              secondaryButtonText: '신청 취소',
+              onSecondaryClick: () => handleSecondaryClick(group.applicationId),
+            })}
+          />
+        ))
+      )}
+      {hasNextPage && (
+        <div
+          ref={ref}
+          className='h-10'
+        />
+      )}
+      <Modal>
+        <ModalTrigger>
+          <button ref={triggerRef}></button>
+        </ModalTrigger>
+        <ModalContent className='flex w-[343px] flex-col rounded-2xl bg-white p-5 pt-11'>
+          <p className='mb-[30px] flex w-full justify-center text-16_B text-black'>
+            신청을 취소하시겠습니까?
+          </p>
+          <div className='flex w-full justify-between gap-2.5'>
+            <ModalCancel className='w-1/2'>
+              <Button variant='secondary'>아니요</Button>
+            </ModalCancel>
+            <ModalAction className='w-1/2'>
+              <Button onClick={handleModalConfirm}>네</Button>
+            </ModalAction>
+          </div>
+        </ModalContent>
+      </Modal>
+
+      {showToast && (
+        <Toast
+          message='참가 확정되었습니다'
+          onClose={() => setShowToast(false)}
+          className='bottom-4 left-1/2 -translate-x-1/2'
+        />
+      )}
+    </div>
+  );
+};
+
+export default AppliedGroups;

--- a/src/components/pages/groupsManagement/GroupsManagementsTabs.tsx
+++ b/src/components/pages/groupsManagement/GroupsManagementsTabs.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import React, { useState } from 'react';
+import Tabs from '@/components/common/Tabs/Tabs';
+import Applications from './Applications';
+import AppliedGroups from './AppliedGroups';
+import JoinedGroups from './JoinedGroups';
+
+const tabs = ['신청한 모임', '참가 중인 모임', '받은 신청서'];
+
+const GroupsManagementsTabs = () => {
+  const [selectedTab, setSelectedTab] = useState(tabs[0]);
+  return (
+    <>
+      <div className='mb-5'>
+        <Tabs
+          tabs={tabs}
+          activeTab={selectedTab}
+          onTabChange={setSelectedTab}
+        />
+      </div>
+      <div className='mb-9'>
+        {selectedTab === '신청한 모임' && <AppliedGroups />}
+        {selectedTab === '참가 중인 모임' && <JoinedGroups />}
+        {selectedTab === '받은 신청서' && <Applications />}
+      </div>
+    </>
+  );
+};
+
+export default GroupsManagementsTabs;

--- a/src/components/pages/groupsManagement/JoinedGroups.tsx
+++ b/src/components/pages/groupsManagement/JoinedGroups.tsx
@@ -1,5 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { useInView } from 'react-intersection-observer';
+import React, { useRef, useState } from 'react';
 import { InfiniteData, useInfiniteQuery } from '@tanstack/react-query';
 import { AxiosResponse } from 'axios';
 import Button from '@/components/common/Button/Button';
@@ -11,6 +10,7 @@ import ModalContent from '@/components/common/Modal/ModalContent';
 import ModalTrigger from '@/components/common/Modal/ModalTrigger';
 import { GROUPS_MANAGEMENTS_QUERY_KEYS } from '@/constants/queryKeys';
 import { useLeaveGroup } from '@/hooks/groupsManagementsHooks/groupsManagementsHooks';
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll/useInfiniteScroll';
 import { groupsManagementsApi } from '@/services/groupsManagementsService';
 import { ApiResponse } from '@/types/api';
 import {
@@ -21,9 +21,9 @@ import {
 const size = 20;
 
 const JoinedGroups = () => {
-  const { ref, inView } = useInView();
   const triggerRef = useRef<HTMLButtonElement>(null);
-  const [selectedGroupId, setSelectedGroupId] = useState<string>('');
+  const { mutate: leaveGroup } = useLeaveGroup();
+  const [selectedGroupId, setSelectedGroupId] = useState('');
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useInfiniteQuery<
@@ -41,13 +41,11 @@ const JoinedGroups = () => {
       initialPageParam: undefined,
     });
 
-  const { mutate: leaveGroup } = useLeaveGroup();
-
-  useEffect(() => {
-    if (inView && hasNextPage && !isFetchingNextPage) {
-      fetchNextPage();
-    }
-  }, [inView, hasNextPage, isFetchingNextPage, fetchNextPage]);
+  const bottomRef = useInfiniteScroll<HTMLDivElement>(
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage
+  );
 
   const handleButtonClick = (
     groupId: string,
@@ -95,7 +93,7 @@ const JoinedGroups = () => {
       )}
       {hasNextPage && (
         <div
-          ref={ref}
+          ref={bottomRef}
           className='h-10'
         />
       )}

--- a/src/components/pages/groupsManagement/JoinedGroups.tsx
+++ b/src/components/pages/groupsManagement/JoinedGroups.tsx
@@ -1,0 +1,124 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { useInView } from 'react-intersection-observer';
+import { InfiniteData, useInfiniteQuery } from '@tanstack/react-query';
+import { AxiosResponse } from 'axios';
+import Button from '@/components/common/Button/Button';
+import GroupCard from '@/components/common/GroupCard/GroupCard';
+import Modal from '@/components/common/Modal/Modal';
+import ModalAction from '@/components/common/Modal/ModalAction';
+import ModalCancel from '@/components/common/Modal/ModalCancel';
+import ModalContent from '@/components/common/Modal/ModalContent';
+import ModalTrigger from '@/components/common/Modal/ModalTrigger';
+import { GROUPS_MANAGEMENTS_QUERY_KEYS } from '@/constants/queryKeys';
+import { useLeaveGroup } from '@/hooks/groupsManagementsHooks/groupsManagementsHooks';
+import { groupsManagementsApi } from '@/services/groupsManagementsService';
+import { ApiResponse } from '@/types/api';
+import {
+  formatJoinedGroups,
+  JoinedGroupsApiResponse,
+} from '@/utils/formatGroupCardData';
+
+const size = 20;
+
+const JoinedGroups = () => {
+  const { ref, inView } = useInView();
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const [selectedGroupId, setSelectedGroupId] = useState<string>('');
+
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useInfiniteQuery<
+      AxiosResponse<JoinedGroupsApiResponse>,
+      ApiResponse,
+      InfiniteData<AxiosResponse<JoinedGroupsApiResponse>>,
+      string[],
+      number | undefined
+    >({
+      queryKey: [GROUPS_MANAGEMENTS_QUERY_KEYS.joinedGroups],
+      queryFn: ({ pageParam }) =>
+        groupsManagementsApi.getJoinedGroups({ cursorId: pageParam, size }),
+      getNextPageParam: (lastPage) =>
+        lastPage.data?.hasNext ? lastPage.data?.cursorId : undefined,
+      initialPageParam: undefined,
+    });
+
+  const { mutate: leaveGroup } = useLeaveGroup();
+
+  useEffect(() => {
+    if (inView && hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, [inView, hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  const handleButtonClick = (
+    groupId: string,
+    title: string,
+    isHost: boolean,
+    memberCount: number
+  ) => {
+    if (!isHost || memberCount === 1) {
+      setSelectedGroupId(groupId);
+      triggerRef.current?.click();
+    }
+  };
+  const handleModalConfirm = () => {
+    console.log('탈퇴 요청 groupId:', selectedGroupId);
+
+    if (selectedGroupId) {
+      leaveGroup({ groupId: selectedGroupId });
+    }
+  };
+
+  return (
+    <div className='flex flex-col items-center gap-5 px-4'>
+      {data?.pages.flatMap((page) =>
+        formatJoinedGroups(page.data).map((group) => (
+          <GroupCard
+            key={group.id}
+            groupData={group}
+            buttonText='모임 탈퇴'
+            {...(group.isHost
+              && group.memberCount > 1 && {
+                buttonColor: 'disable',
+                buttonDisabled: true,
+              })}
+            onCardClick={() => alert('상세페이지로 이동')}
+            onButtonClick={() =>
+              handleButtonClick(
+                group.id,
+                group.title,
+                group.isHost,
+                group.memberCount
+              )
+            }
+          />
+        ))
+      )}
+      {hasNextPage && (
+        <div
+          ref={ref}
+          className='h-10'
+        />
+      )}
+
+      <Modal>
+        <ModalTrigger>
+          <button ref={triggerRef}></button>
+        </ModalTrigger>
+        <ModalContent className='flex w-[343px] flex-col rounded-2xl bg-white p-5 pt-11'>
+          <p className='mb-[30px] flex w-full justify-center text-16_B text-black'>
+            모임을 탈퇴하시겠습니까?
+          </p>
+          <div className='flex w-full justify-between gap-2.5'>
+            <ModalCancel className='w-1/2'>
+              <Button variant='secondary'>아니요</Button>
+            </ModalCancel>
+            <ModalAction className='w-1/2'>
+              <Button onClick={handleModalConfirm}>네</Button>
+            </ModalAction>
+          </div>
+        </ModalContent>
+      </Modal>
+    </div>
+  );
+};
+export default JoinedGroups;

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -12,6 +12,7 @@ export const NOTIFICATIONS_QUERY_KEYS = {
 
 export const GROUP_QUERY_KEYS = {
   groups: 'groups',
+  leaveGroup: 'leaveGroup',
 };
 
 export const REVIEWS_QUERY_KEYS = {
@@ -23,4 +24,10 @@ export const REVIEWS_QUERY_KEYS = {
 export const USERS_QUERY_KEYS = {
   users: 'users',
   favoriteUsers: 'favoriteUsers',
+};
+
+export const GROUPS_MANAGEMENTS_QUERY_KEYS = {
+  appliedGroups: 'appliedGroups',
+  joinedGroups: 'joinedGroups',
+  applications: 'applications',
 };

--- a/src/hooks/groupsManagementsHooks/groupsManagementsHooks.ts
+++ b/src/hooks/groupsManagementsHooks/groupsManagementsHooks.ts
@@ -1,0 +1,52 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { GROUPS_MANAGEMENTS_QUERY_KEYS } from '@/constants/queryKeys';
+import { groupsManagementsApi } from '@/services/groupsManagementsService';
+import { ApiResponse } from '@/types/api';
+
+// 신청 취소
+export const useCancelApplication = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<ApiResponse, ApiResponse, { applicationId: string }>({
+    mutationFn: ({ applicationId }) =>
+      groupsManagementsApi.deleteAppliedGroup(applicationId),
+
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [GROUPS_MANAGEMENTS_QUERY_KEYS.appliedGroups],
+      });
+    },
+  });
+};
+
+// 참가 확정
+export const useConfirmApplication = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<ApiResponse, ApiResponse, { applicationId: string }>({
+    mutationFn: ({ applicationId }) =>
+      groupsManagementsApi.patchConfirmJoin(applicationId),
+
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [GROUPS_MANAGEMENTS_QUERY_KEYS.appliedGroups],
+      });
+    },
+  });
+};
+
+// 모임 탈퇴
+export const useLeaveGroup = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<ApiResponse, ApiResponse, { groupId: string }>({
+    mutationFn: ({ groupId }) =>
+      groupsManagementsApi.deleteJoinedGroup(groupId),
+
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [GROUPS_MANAGEMENTS_QUERY_KEYS.joinedGroups],
+      });
+    },
+  });
+};

--- a/src/hooks/useInfiniteScroll/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll/useInfiniteScroll.ts
@@ -2,15 +2,16 @@ import { useEffect, useRef } from 'react';
 
 export const useInfiniteScroll = <T extends HTMLElement>(
   fetchNextPage: () => void,
-  hasNextPage: boolean
+  hasNextPage: boolean,
+  isFetchingNextPage?: boolean
 ) => {
   const bottomRef = useRef<T | null>(null);
 
   useEffect(() => {
-    if (!bottomRef.current || !hasNextPage) return;
+    if (!bottomRef.current || !hasNextPage || isFetchingNextPage) return;
 
     const observer = new IntersectionObserver(([entry]) => {
-      if (entry.isIntersecting && hasNextPage) {
+      if (entry.isIntersecting) {
         fetchNextPage();
       }
     });
@@ -18,7 +19,7 @@ export const useInfiniteScroll = <T extends HTMLElement>(
     observer.observe(bottomRef.current);
 
     return () => observer.disconnect();
-  }, [hasNextPage, fetchNextPage]);
+  }, [hasNextPage, fetchNextPage, isFetchingNextPage]);
 
   return bottomRef;
 };

--- a/src/services/groupsManagementsService.ts
+++ b/src/services/groupsManagementsService.ts
@@ -1,0 +1,61 @@
+import apiFetcher from '@/lib/apiFetcher';
+import { ApiResponse, CursorRequest } from '@/types/api';
+import { ApplicationStatus } from '@/types/enums';
+import { AppliedGroupsApiResponse } from '@/utils/formatApplicationCardData';
+import { JoinedGroupsApiResponse } from '@/utils/formatGroupCardData';
+
+export const groupsManagementsApi = {
+  // 신청한 모임 목록
+  getAppliedGroups: async ({ cursorId, size = 20 }: CursorRequest) =>
+    await apiFetcher.get<AppliedGroupsApiResponse>(
+      `/api/v1/managements/applied`,
+      {
+        params: {
+          cursorId,
+          size,
+        },
+      }
+    ),
+
+  // 신청 취소
+  deleteAppliedGroup: async (applicationId: string) => {
+    const response = await apiFetcher.delete<ApiResponse>(
+      `/api/v1/managements/applied/${applicationId}`
+    );
+
+    return response.data;
+  },
+
+  // 참가 확정
+  patchConfirmJoin: async (applicationId: string) => {
+    const response = await apiFetcher.patch<ApiResponse>(
+      `/api/v1/managements/applied/${applicationId}`,
+      {
+        status: ApplicationStatus.CONFIRMED,
+      }
+    );
+
+    return response.data;
+  },
+
+  // 참가 중 모임 목록
+  getJoinedGroups: async ({ cursorId, size = 20 }: CursorRequest) =>
+    await apiFetcher.get<JoinedGroupsApiResponse>(
+      `/api/v1/managements/joined`,
+      {
+        params: {
+          cursorId,
+          size,
+        },
+      }
+    ),
+
+  // 모임 탈퇴
+  deleteJoinedGroup: async (groupId: string) => {
+    const response = await apiFetcher.delete<ApiResponse>(
+      `/api/v1/groups/${groupId}/leave`
+    );
+
+    return response.data;
+  },
+};


### PR DESCRIPTION
### 무엇을 위한 PR인가요? (: 뒤 설명 추가)

- 신규 기능 추가: 모임 참가중/신청한 모임 관리 기능 구현

### 변경사항 및 이유 (bullet 으로 구분)

- 신청한 모임, 참가 중인 모임, 받은 신청서 목록을 탭 형태로 구분하여 볼 수 있도록 기능을 추가하였습니다.

- 신청 취소 및 참가 확정 처리 기능을 구현하였고, 모임 탈퇴 기능도 추가되었습니다.

- API 요청에 따라 관련 쿼리를 invalidate하여 최신 데이터를 반영합니다.

### 작업 내역 (bullet 으로 구분)

- GroupsManagementsTabs.tsx : 탭 구조 구현

- AppliedGroups.tsx : 신청한 모임 목록 조회, 신청 취소/참가 확정 처리 기능 구현

- JoinedGroups.tsx : 참가 중인 모임 목록 조회, 탈퇴 기능 및 버튼 상태 분기 처리

- Applications.tsx : 받은 신청서 목록 구현 (기존 컴포넌트 사용)

- groupsManagementsHooks.ts : useCancelApplication, useConfirmApplication, useLeaveGroup 훅 구현

- groupsManagementsService.ts : 관련 API 요청 함수 정의

### 작업 후 기대 동작(스크린샷)

https://github.com/user-attachments/assets/8650ad21-e329-4dfa-b95b-49d3f3bd50d2


### PR 특이 사항

- 탭  sticky 미적용 상태

- 현재 로딩 중 스켈레톤 UI가 미적용

- 방장이 아닌 모임 탈퇴 기능 백엔드 수정 필요

- 신청서 목록은 디자이너와 상의 후 수정 예정

- 훅으로 분리하기
```useEffect(() => {
    if (inView && hasNextPage && !isFetchingNextPage) {
      fetchNextPage();
    }
  }, [inView, hasNextPage, isFetchingNextPage, fetchNextPage]); 
