### PR TITLE
[Fix/issue-331] 메인 페이지에서 로그인 무한루프 수정

### DIFF
--- a/src/components/pages/NotificationToast.tsx
+++ b/src/components/pages/NotificationToast.tsx
@@ -2,10 +2,11 @@
 
 import React, { useEffect, useState } from 'react';
 import { useGetNewNotificationsCheck } from '@/hooks/notificationHooks/notificationHooks';
+import { useAuthStore } from '@/providers/AuthStoreProvider';
 import { useSseStore } from '@/providers/SseStoreProvider';
 import Toast from '../common/Toast/Toast';
 
-const NotificationToast = () => {
+const NotificationToastRender = () => {
   const [showToast, setShowToast] = useState(false);
   const notification = useSseStore((state) => state.notification);
   const { refetch } = useGetNewNotificationsCheck();
@@ -27,6 +28,16 @@ const NotificationToast = () => {
       )}
     </>
   );
+};
+
+const NotificationToast = () => {
+  const isLoggedIn = useAuthStore((state) => state.isLoggedin);
+
+  if (!isLoggedIn) {
+    return null;
+  }
+
+  return <NotificationToastRender />;
 };
 
 export default NotificationToast;


### PR DESCRIPTION
### 무엇을 위한 PR인가요? (: 뒤 설명 추가)

- 신규 기능 추가: 
- 버그 수정: 메인 페이지에서 로그인 무한루프 수정
- 리펙토링:
- 문서 업데이트:
- 기타:

### 변경사항 및 이유 (bullet 으로 구분)

- ```<NotificationToast>```에서 ```useGetNewNotificationsCheck```부분이 로그인이 안되었더라도 무조건 실행되어 오류 발생

### 작업 내역 (bullet 으로 구분)

- 로그인이 안되어 있을 경우 렌더링이 안되도록 변경

### ?작업 후 기대 동작(스크린샷)

- 동작

### ?PR 특이 사항

- 특이 사항

### Issue Number

close: #331