### PR TITLE
[Refactor/issue-196] 모임 내 채팅 에러 핸들링

### DIFF
--- a/src/components/pages/groupDetail/Chat/Chat.tsx
+++ b/src/components/pages/groupDetail/Chat/Chat.tsx
@@ -1,17 +1,47 @@
+'use client';
+
+import { Skeleton } from '@/components/ui/skeleton';
+import { useGetUserId } from '@/hooks/userHooks/userHooks';
 import PostNotice from '../PostNotice/PostNotice';
 import ChatArea from './ChatArea';
 import ChatInfo from './ChatInfo';
 
 const hasNotice = true;
+const chatRoomId = 1;
 
-const Chat = () => (
-  <div className='px-4'>
-    <div className='flex flex-col rounded-[16px] bg-[#fffcfc] px-4 py-4 shadow-[0px_0px_6px_0px_rgba(0,0,0,0.16)]'>
-      <ChatInfo />
-      {hasNotice && <PostNotice />}
-      <ChatArea />
+const Chat = () => {
+  const { data: userId, isPending, isError } = useGetUserId();
+
+  if (isPending)
+    return (
+      <div className='flex flex-col gap-3.5 px-4'>
+        <Skeleton className='h-[10vh]' />
+        <Skeleton className='h-[50dvh]' />
+      </div>
+    );
+
+  if (isError || !userId) {
+    return (
+      <div className='flex flex-col items-center justify-center px-4 py-5'>
+        <p className='font-semibold text-gray-500'>
+          채팅 접근 권한이 없습니다.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className='px-4'>
+      <div className='flex flex-col rounded-[16px] bg-[#fffcfc] px-4 py-4 shadow-[0px_0px_6px_0px_rgba(0,0,0,0.16)]'>
+        <ChatInfo />
+        {hasNotice && <PostNotice />}
+        <ChatArea
+          userId={userId.data?.userId}
+          chatRoomId={chatRoomId}
+        />
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default Chat;

--- a/src/components/pages/groupDetail/Chat/ChatArea.tsx
+++ b/src/components/pages/groupDetail/Chat/ChatArea.tsx
@@ -1,27 +1,22 @@
 'use client';
 
 import { useChatWebSocket } from '@/hooks/chatHooks/chatHooks';
-import { useGetUserId } from '@/hooks/userHooks/userHooks';
 // import { CHAT_SAMPLE_DATA } from '@/mocks/handlers/chatHandlers';
 import ChatMessageInput from './ChatMessageInput';
 import ChatMessageList from './ChatMessageList';
 
-const chatRoomId = 1;
+interface ChatAreaProps {
+  userId: number | undefined;
+  chatRoomId: number | undefined;
+}
 
-const ChatArea = () => {
-  const { data: userId, isPending } = useGetUserId();
-  const { messages, sendMessage } = useChatWebSocket(
-    userId?.data?.userId,
-    chatRoomId
-  );
-
-  if (isPending) return <div>loading...</div>;
-  if (!isPending && !userId) return <div>접근 권한이 없습니다.</div>;
+const ChatArea = ({ userId, chatRoomId }: ChatAreaProps) => {
+  const { messages, sendMessage } = useChatWebSocket(userId, chatRoomId);
 
   return (
     <div className='relative flex h-[60dvh] flex-col gap-2'>
       <ChatMessageList
-        userId={userId?.data?.userId}
+        userId={userId}
         messages={messages}
         // messages={CHAT_SAMPLE_DATA}
       />

--- a/src/components/pages/groupDetail/Chat/ChatArea.tsx
+++ b/src/components/pages/groupDetail/Chat/ChatArea.tsx
@@ -11,16 +11,36 @@ interface ChatAreaProps {
 }
 
 const ChatArea = ({ userId, chatRoomId }: ChatAreaProps) => {
-  const { messages, sendMessage } = useChatWebSocket(userId, chatRoomId);
+  const { messages, sendMessage, statusMessage, isConnected } =
+    useChatWebSocket(userId, chatRoomId);
+
+  if (!isConnected) {
+    return (
+      <div className='relative flex h-[60dvh] flex-col items-center justify-center gap-2'>
+        <p className='font-semibold text-gray-500'>{statusMessage}</p>
+        <ChatMessageInput
+          disabled={true}
+          sendMessage={() => {}}
+        />
+      </div>
+    );
+  }
 
   return (
     <div className='relative flex h-[60dvh] flex-col gap-2'>
-      <ChatMessageList
-        userId={userId}
-        messages={messages}
-        // messages={CHAT_SAMPLE_DATA}
-      />
-      <ChatMessageInput sendMessage={sendMessage} />
+      {isConnected && (
+        <>
+          <ChatMessageList
+            userId={userId}
+            messages={messages}
+            // messages={CHAT_SAMPLE_DATA}
+          />
+          <ChatMessageInput
+            disabled={!isConnected}
+            sendMessage={sendMessage}
+          />
+        </>
+      )}
     </div>
   );
 };

--- a/src/components/pages/groupDetail/Chat/ChatMessageInput.tsx
+++ b/src/components/pages/groupDetail/Chat/ChatMessageInput.tsx
@@ -5,10 +5,14 @@ import Button from '@/components/common/Button/Button';
 import SendIcon from '@/components/icons/SendIcon';
 
 interface ChatMessageInputProps {
+  disabled?: boolean;
   sendMessage: (message: string) => void;
 }
 
-const ChatMessageInput = ({ sendMessage }: ChatMessageInputProps) => {
+const ChatMessageInput = ({
+  disabled = false,
+  sendMessage,
+}: ChatMessageInputProps) => {
   const [message, setMessage] = useState<string>('');
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -25,6 +29,7 @@ const ChatMessageInput = ({ sendMessage }: ChatMessageInputProps) => {
       <input
         type='text'
         placeholder='메세지를 입력하세요'
+        disabled={disabled}
         value={message}
         onChange={(e) => setMessage(e.target.value)}
         className='flex w-full items-center text-16_M text-gray-950 placeholder:text-16_M placeholder:leading-normal placeholder:tracking-[-0.35px] placeholder:text-gray-400 focus:outline-none'

--- a/src/hooks/chatHooks/chatHooks.ts
+++ b/src/hooks/chatHooks/chatHooks.ts
@@ -44,9 +44,9 @@ export const useChatWebSocket = (
           Authorization: `Bearer ${token}`,
         },
 
-        debug: (debugMessage: string) => {
-          console.log(`debug: ${debugMessage}`);
-        },
+        // debug: (debugMessage: string) => {
+        //   console.log(`debug: ${debugMessage}`);
+        // },
 
         reconnectDelay: 0,
 

--- a/src/hooks/chatHooks/chatHooks.ts
+++ b/src/hooks/chatHooks/chatHooks.ts
@@ -4,13 +4,48 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { Client } from '@stomp/stompjs';
 // import { InfiniteData, useInfiniteQuery } from '@tanstack/react-query';
 // import { AxiosResponse } from 'axios';
+import axios from 'axios';
 import SockJS from 'sockjs-client';
 import { getAccessToken } from '@/lib/apiFetcher';
+import { callLogout, callTokenUpdater } from '@/providers/AuthStoreProvider';
+import { TokenRefreshResponse } from '@/types/auth';
 import { ChatMessage } from '@/types/chat';
 // import { CHAT_QUERY_KEY } from '@/constants/queryKeys';
 // import { chatServiceApi } from '@/services/chatService';
 // import { ApiResponse, CursorRequest } from '@/types/api';
 // import { GetChatMessageListResponse } from '@/types/chat';
+
+/**
+ * 리프레시 토큰으로 액세스 토큰 재발급하는 함수
+ * @returns Promise<newAccessToken:string | null>
+ */
+const refreshAccessToken = async (): Promise<string> => {
+  try {
+    const res = await axios.post<TokenRefreshResponse>(
+      `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/v1/auth/token`,
+      {},
+      { withCredentials: true }
+    );
+
+    const newAccessToken = res.data.data?.accessToken;
+
+    if (!newAccessToken) {
+      throw new Error('토큰이 존재하지 않습니다.');
+    }
+
+    callTokenUpdater(newAccessToken);
+    return newAccessToken;
+  } catch (err) {
+    callLogout();
+
+    const REDIRECT_URI = `${process.env.NEXT_PUBLIC_BASE_URL}/login/kakao`;
+    const kakaoAuthUrl = `https://kauth.kakao.com/oauth/authorize?client_id=${process.env.NEXT_PUBLIC_KAKAO_APP_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;
+
+    window.open(kakaoAuthUrl, '_self');
+
+    return Promise.reject(err);
+  }
+};
 
 /**
  * 채팅 웹소켓 연결
@@ -24,15 +59,13 @@ export const useChatWebSocket = (
   const clientRef = useRef<Client | null>(null);
   const [isConnected, setIsConnected] = useState<boolean>(false);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
 
   useEffect(() => {
-    const connectWebSocket = async () => {
-      const accessToken = getAccessToken();
+    if (!userId || !chatRoomId) return;
 
-      // 액세스 토큰이 만료되면 자동으로 서버에서 401 error가 날아옴
-      // 401 error 시 리프레시 토큰으로 액세스 토큰을 재발급 해야 함
-
-      if (!accessToken || !userId || !chatRoomId) return;
+    const connectWebSocket = async (token: string) => {
+      setStatusMessage('채팅방 연결중...');
 
       const socket = new SockJS(
         `${process.env.NEXT_PUBLIC_WEBSOCKET_URL}/chat`
@@ -42,11 +75,18 @@ export const useChatWebSocket = (
         webSocketFactory: () => socket,
 
         connectHeaders: {
-          Authorization: `Bearer ${accessToken}`,
+          Authorization: `Bearer ${token}`,
         },
+
+        debug: (debugMessage: string) => {
+          console.log(`debug: ${debugMessage}`);
+        },
+
+        reconnectDelay: 0,
 
         onConnect: () => {
           setIsConnected(true);
+          setStatusMessage(null);
           stompClient.subscribe(`/sub/chat/${chatRoomId}`, (message) => {
             const body = JSON.parse(message.body);
             setMessages((prev) => [...prev, body]);
@@ -57,26 +97,30 @@ export const useChatWebSocket = (
           setIsConnected(false);
         },
 
-        // debug: (debugMessage: string) => {
-        //   console.log(`debug: ${debugMessage}`);
-        // },
-
-        onStompError: (error) => {
-          console.log(`stomp error: ${error}`);
+        onStompError: async () => {
+          const newToken = await refreshAccessToken();
+          if (newToken) {
+            stompClient.deactivate();
+            connectWebSocket(newToken);
+          } else {
+            setStatusMessage('서버 연결 중 오류가 발생했습니다.');
+          }
         },
 
         onWebSocketError: (error) => {
           console.log(`web socket error: ${error}`);
+          setStatusMessage('서버 연결 중 오류가 발생했습니다.');
         },
-
-        reconnectDelay: 3000,
       });
 
       clientRef.current = stompClient;
       stompClient.activate();
     };
 
-    connectWebSocket();
+    const accessToken = getAccessToken();
+    if (accessToken) {
+      connectWebSocket(accessToken);
+    }
 
     return () => {
       clientRef.current?.deactivate();
@@ -98,13 +142,14 @@ export const useChatWebSocket = (
           body: requestBody,
         });
       } catch (error) {
+        setStatusMessage('메세지 전송에 실패했습니다.');
         console.log('error: ', error);
       }
     },
     [isConnected, userId, chatRoomId]
   );
 
-  return { messages, sendMessage, isConnected };
+  return { messages, sendMessage, isConnected, statusMessage };
 };
 
 // export const useGetChatMessageList = (size: CursorRequest['size']) =>

--- a/src/mocks/handlers/usersHandlers.ts
+++ b/src/mocks/handlers/usersHandlers.ts
@@ -105,11 +105,20 @@ export const usersHandlers = [
     });
   }),
 
-  http.get('http://localhost:3000/api/v1/users/id', () =>
-    HttpResponse.json({
-      code: 200,
-      message: '회원 ID 조회 성공',
-      data: USER_ID_SAMPLE_DATA,
-    })
+  http.get(
+    'http://localhost:3000/api/v1/users/id',
+    () =>
+      HttpResponse.json({
+        code: 200,
+        message: '사용자 ID 조회 성공',
+        data: USER_ID_SAMPLE_DATA,
+      })
+    // HttpResponse.json(
+    //   {
+    //     code: 401,
+    //     message: '인증 실패',
+    //   },
+    //   { status: 401 }
+    // )
   ),
 ];


### PR DESCRIPTION
### 무엇을 위한 PR인가요? (: 뒤 설명 추가)

- 리팩토링: 모임 내 채팅 에러 핸들링 추가

### 변경사항 및 이유 (bullet 으로 구분)

- userId 조회 시 에러 핸들링 추가
- 채팅 탭 Skeleton UI 적용
- 채팅방 에러 핸들링

### 작업 내역 (bullet 으로 구분)

- userId 조회
  - isPending 일 경우 Skeleton UI가 나타나도록 설정
  - isError이거나 userId가 없는 경우 접근 권한 오류 메세지 띄움
- 채팅방 에러 핸들링
  - 채팅방 입장(웹소켓 연결) 시 액세스 토큰 확인 (유틸 함수 사용)
  - 새 액세스 토큰으로 재시도 후에도 에러 시 에러 메세지 띄움
- 채팅 탭 Skeleton UI 적용
  - userId 조회 시 스켈레톤 ui 적용
  - 채팅방 연결중인 경우 연결중 메세지 띄움

### 스크린샷

- 액세스 토큰 만료됐을 경우 재발급 후 재시도
https://github.com/user-attachments/assets/9ba59357-6ca6-4b52-9d47-7ebedc7df3a4

- 액세스 토큰, 재발급한 액세스 토큰 모두 오류가 있을 때
https://github.com/user-attachments/assets/eb96ac3a-ae94-4a94-a3f7-dca409b75a35

### Issue Number

close: #196 