### PR TITLE
[Feature/issue-339] 현재 라우팅 경로에 따른 TabBar 선택적 렌더링 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "jest-fixed-jsdom": "^0.0.9",
         "lucide-react": "^0.511.0",
         "next": "15.3.2",
+        "path-to-regexp": "^8.2.0",
         "pretendard": "^1.3.9",
         "qs": "^6.14.0",
         "react": "^19.0.0",
@@ -10714,7 +10715,6 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
       "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=16"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "jest-fixed-jsdom": "^0.0.9",
     "lucide-react": "^0.511.0",
     "next": "15.3.2",
+    "path-to-regexp": "^8.2.0",
     "pretendard": "^1.3.9",
     "qs": "^6.14.0",
     "react": "^19.0.0",

--- a/src/components/common/TabBar/TabBar.tsx
+++ b/src/components/common/TabBar/TabBar.tsx
@@ -3,13 +3,14 @@
 import React, { ReactNode } from 'react';
 import { useMediaQuery } from 'react-responsive';
 import { CalendarIcon } from 'lucide-react';
+import { usePathname } from 'next/navigation';
+import { match } from 'path-to-regexp';
 import GroupIcon from '@/components/icons/GroupIcon';
 import HomeIcon from '@/components/icons/HomeIcon';
 import LikeIcon from '@/components/icons/LikeIcon';
 import UserIcon from '@/components/icons/UserIcon';
 import { cn } from '@/lib/utils';
 import NavLink from '../NavLink/NavLink';
-
 const NAV_ITEM = [
   { herf: '/', name: '홈', Icon: HomeIcon },
   { herf: '/calendar', name: '캘린더', Icon: CalendarIcon },
@@ -18,12 +19,32 @@ const NAV_ITEM = [
   { herf: '/profiles/me', name: '마이', Icon: UserIcon },
 ];
 
+const INVISIBLE_ROUTE = [
+  '/groups/create',
+  '/proflies/me/edit',
+  '/reviews/managements',
+  '/groups/:groupId/edit',
+  '/groups/:groupId/posts/:postId',
+  '/groups/:groupId/posts/create',
+];
+
+const tabBarHide = (pathname: string) =>
+  INVISIBLE_ROUTE.some((route) =>
+    match(route, { decode: decodeURIComponent })(pathname)
+  );
+
 interface TabBarProps {
   children: ReactNode;
 }
 
 const TabBar = ({ children }: TabBarProps) => {
   const isMobile = useMediaQuery({ maxWidth: 768 });
+  const pathname = usePathname();
+
+  if (tabBarHide(pathname)) {
+    return children;
+  }
+
   return (
     <>
       <div className={cn('overflow-auto', isMobile && 'h-[calc(100dvh-80px)]')}>


### PR DESCRIPTION
### 무엇을 위한 PR인가요? (: 뒤 설명 추가)

- 신규 기능 추가: 현재 라우팅 경로에 따른 TabBar 선택적 렌더링 구현
- 버그 수정:
- 리펙토링:
- 문서 업데이트:
- 기타:

### 변경사항 및 이유 (bullet 으로 구분)

- TabBar가 렌더링 되지 않는 페이지들이 있는데, 해당 페이지마다 라우팅 그룹을 통해 폴더구조를 변경할 경우 폴더구조가 너무 난잡해짐
- 따라서 사용되지 않는 경로를 설정하여 해당 경로일 경우 TabBar가 렌더링되지 않도록 구현

### 작업 내역 (bullet 으로 구분)

- usePathname으로 현재 경로를 가져온 뒤 path-to-regexp라이브러리를 이용하여 해당 경로가 INVISIBLE_ROUTE인지 확인
- 만약 INVISIBLE_ROUTE에 포함될 경우 TabBar를 제외하고 children만 렌더링하도록 변경

### ?작업 후 기대 동작(스크린샷)

- 동작

### ?PR 특이 사항

- 특이 사항

### Issue Number

close: #339