### PR TITLE
[Feature/issue-335] 모임 개설 버튼 생성, Toast 컴포넌트 디자인 적용

### DIFF
--- a/src/components/common/Toast/Toast.test.tsx
+++ b/src/components/common/Toast/Toast.test.tsx
@@ -42,15 +42,15 @@ describe('Toast 컴포넌트', () => {
         onClose={jest.fn()}
       />
     );
-    const toast = screen.getByText('기본 메시지');
-    expect(toast).toHaveClass('bg-gray-800');
+    const toast = screen.getByLabelText('toast');
+    expect(toast).toHaveClass('bg-white text-gray-950');
   });
 
   test('타입 props에 따라 올바른 스타일이 적용된다', () => {
     setup({ type: 'error' });
     const toast = screen.getByRole('alert');
 
-    expect(toast).toHaveClass('bg-red-500');
+    expect(toast).toHaveClass('bg-primary-red text-white');
   });
 
   test('초기에는 isVisible = true로 보여진다', () => {
@@ -108,7 +108,7 @@ describe('Toast 컴포넌트', () => {
       />
     );
 
-    const toast = screen.getByText('위치 조정 메시지');
+    const toast = screen.getByLabelText('toast');
     expect(toast.className).toContain('top-10 right-10');
   });
 });

--- a/src/components/common/Toast/Toast.tsx
+++ b/src/components/common/Toast/Toast.tsx
@@ -1,4 +1,6 @@
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import { BellRingIcon, CircleAlertIcon, TriangleAlertIcon } from 'lucide-react';
+import CheckIcon from '@/components/icons/CheckIcon';
 import { cn } from '@/lib/utils';
 import Portal from '../Portal';
 
@@ -11,21 +13,39 @@ export interface ToastProps {
 }
 
 const typeStyles: Record<NonNullable<ToastProps['type']>, string> = {
-  default: 'bg-gray-800',
-  success: 'bg-green-500',
-  warning: 'bg-yellow-400 text-black',
-  error: 'bg-red-500',
-  info: 'bg-blue-500',
+  default: 'bg-white text-gray-950',
+  success: 'bg-white text-gray-950',
+  warning: 'bg-yellow-400 text-gray-950',
+  error: 'bg-primary-red text-white',
+  info: 'bg-white text-gray-950',
+};
+
+const iconStyles: Record<NonNullable<ToastProps['type']>, React.ReactNode> = {
+  default: (
+    <CheckIcon
+      type='filled'
+      className='spect-square h-6 w-6 text-primary-red'
+    />
+  ),
+  success: (
+    <CheckIcon
+      type='filled'
+      className='spect-square h-6 w-6 text-primary-red'
+    />
+  ),
+  warning: <TriangleAlertIcon className='aspect-square h-6 w-6' />,
+  error: <CircleAlertIcon className='aspect-square h-6 w-6' />,
+  info: <BellRingIcon className='aspect-square h-6 w-6' />,
 };
 
 const animationClass = (visible: boolean) =>
-  visible ? 'translate-y-0 opacity-100' : '-translate-y-4 opacity-0';
+  visible ? 'translate-y-0 opacity-100' : 'translate-y-4 opacity-0';
 
 const Toast = ({
   message,
   type = 'default',
   onClose,
-  className = 'top-4 left-1/2 -translate-x-1/2',
+  className,
   blockBackgroundClick = false,
 }: ToastProps) => {
   const [isVisible, setIsVisible] = useState(false);
@@ -48,15 +68,19 @@ const Toast = ({
       )}
       <div
         aria-live='assertive'
+        aria-label='toast'
         role='alert'
         className={cn(
-          'fixed z-50 rounded px-4 py-2 text-white shadow-md transition-all duration-500 ease-in-out',
+          'fixed bottom-4 left-1/2 z-50 flex w-full max-w-[343px] -translate-x-1/2 flex-col items-center justify-center gap-2 rounded-[18px] px-5 py-5 text-gray-950 shadow-[0px_4px_14px_0px_rgba(0,0,0,0.10)] transition-all duration-500 ease-in-out',
           typeStyles[type],
           animationClass(isVisible),
           className
         )}
       >
-        {message}
+        {iconStyles[type]}
+        <span className='text-16_B leading-normal tracking-[-0.4px]'>
+          {message}
+        </span>
       </div>
     </Portal>
   );

--- a/src/components/pages/performanceDetail/CreateGroupButton.tsx
+++ b/src/components/pages/performanceDetail/CreateGroupButton.tsx
@@ -1,0 +1,20 @@
+import Button from '@/components/common/Button/Button';
+import PlusIcon from '@/components/icons/PlusIcon';
+
+interface CreateGroupButtonProps {
+  onClick?: () => void;
+}
+
+const CreateGroupButton = ({ onClick }: CreateGroupButtonProps) => (
+  <Button
+    onClick={onClick}
+    className='fixed right-4 bottom-23 z-2 w-fit min-w-30 gap-1 rounded-[100px] py-2.5 pr-4 pl-2.5'
+  >
+    <PlusIcon className='aspect-square h-6 w-6' />
+    <span className='text-16_B leading-normal tracking-[-0.4px]'>
+      모임 개설
+    </span>
+  </Button>
+);
+
+export default CreateGroupButton;

--- a/src/components/pages/performanceDetail/PerformanceDetailSummary.tsx
+++ b/src/components/pages/performanceDetail/PerformanceDetailSummary.tsx
@@ -59,7 +59,6 @@ const PerformanceDetailSummary = ({
           message='로그인이 필요합니다!'
           type='error'
           onClose={() => setShowToast(false)}
-          className='bottom-4 left-1/2 -translate-x-1/2'
         />
       )}
 

--- a/src/components/pages/performanceDetail/PerformanceDetailWrapper.tsx
+++ b/src/components/pages/performanceDetail/PerformanceDetailWrapper.tsx
@@ -38,7 +38,7 @@ const PerformanceDetailWrapper = ({
 
   if (isError)
     return (
-      <div className='flex h-[80dvh] flex-col items-center justify-center gap-2 px-4 py-5 md:h-[100dvh]'>
+      <div className='flex h-[80dvh] flex-col items-center justify-center gap-2 px-4 py-5'>
         <p className='font-semibold text-gray-500'>존재하지 않는 공연입니다.</p>
       </div>
     );

--- a/src/components/pages/performanceDetail/PerformanceDetailWrapper.tsx
+++ b/src/components/pages/performanceDetail/PerformanceDetailWrapper.tsx
@@ -50,7 +50,6 @@ const PerformanceDetailWrapper = ({
           message='로그인이 필요합니다!'
           type='error'
           onClose={() => setShowToast(false)}
-          className='bottom-4 left-1/2 -translate-x-1/2'
         />
       )}
 

--- a/src/components/pages/performanceDetail/PerformanceDetailWrapper.tsx
+++ b/src/components/pages/performanceDetail/PerformanceDetailWrapper.tsx
@@ -1,7 +1,13 @@
 'use client';
 
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Button from '@/components/common/Button/Button';
+import Toast from '@/components/common/Toast/Toast';
+import PlusIcon from '@/components/icons/PlusIcon';
 import { Summary, Tabs } from '@/components/pages/performanceDetail';
 import { useGetPerformanceDetail } from '@/hooks/performanceHooks/performanceHooks';
+import { useAuthStore } from '@/providers/AuthStoreProvider';
 
 type PerformanceDetailWrapperProps = {
   performanceId: string;
@@ -10,10 +16,27 @@ type PerformanceDetailWrapperProps = {
 const PerformanceDetailWrapper = ({
   performanceId,
 }: PerformanceDetailWrapperProps) => {
-  const { data: performanceDetail, isPending } =
-    useGetPerformanceDetail(performanceId);
+  const router = useRouter();
+  const isLoggedIn = useAuthStore((state) => state.isLoggedin);
+  const [showToast, setShowToast] = useState(false);
+  const {
+    data: performanceDetail,
+    isPending,
+    isError,
+  } = useGetPerformanceDetail(performanceId);
 
-  if (!isPending && !performanceDetail?.data)
+  const routeToCreateGroupPage = () => {
+    if (!isLoggedIn) {
+      setShowToast(true);
+      return;
+    }
+
+    if (!isError && performanceDetail?.data) {
+      router.push(`performances/${performanceDetail?.data?.id}/createGroup`);
+    }
+  };
+
+  if (isError)
     return (
       <div className='flex h-[80dvh] flex-col items-center justify-center gap-2 px-4 py-5 md:h-[100dvh]'>
         <p className='font-semibold text-gray-500'>존재하지 않는 공연입니다.</p>
@@ -21,17 +44,38 @@ const PerformanceDetailWrapper = ({
     );
 
   return (
-    <div className='flex flex-col gap-3 bg-gray-25'>
-      <Summary
-        isPending={isPending}
-        performanceDetail={performanceDetail?.data}
-      />
+    <>
+      {showToast && (
+        <Toast
+          message='로그인이 필요합니다!'
+          type='error'
+          onClose={() => setShowToast(false)}
+          className='bottom-4 left-1/2 -translate-x-1/2'
+        />
+      )}
 
-      <Tabs
-        isPending={isPending}
-        performanceDetail={performanceDetail?.data}
-      />
-    </div>
+      <div className='flex flex-col gap-3 bg-gray-25'>
+        <Summary
+          isPending={isPending}
+          performanceDetail={performanceDetail?.data}
+        />
+
+        <Tabs
+          isPending={isPending}
+          performanceDetail={performanceDetail?.data}
+        />
+
+        <Button
+          onClick={routeToCreateGroupPage}
+          className='fixed right-4 bottom-23 z-2 w-fit min-w-30 gap-1 rounded-[100px] py-2.5 pr-4 pl-2.5'
+        >
+          <PlusIcon className='aspect-square h-6 w-6' />
+          <span className='text-16_B leading-normal tracking-[-0.4px]'>
+            모임 개설
+          </span>
+        </Button>
+      </div>
+    </>
   );
 };
 

--- a/src/components/pages/performanceDetail/PerformanceDetailWrapper.tsx
+++ b/src/components/pages/performanceDetail/PerformanceDetailWrapper.tsx
@@ -38,7 +38,7 @@ const PerformanceDetailWrapper = ({
 
   if (isError)
     return (
-      <div className='flex h-[80dvh] flex-col items-center justify-center gap-2 px-4 py-5'>
+      <div className='flex h-full flex-col items-center justify-center px-4 py-5'>
         <p className='font-semibold text-gray-500'>존재하지 않는 공연입니다.</p>
       </div>
     );

--- a/src/components/pages/performanceDetail/PerformanceDetailWrapper.tsx
+++ b/src/components/pages/performanceDetail/PerformanceDetailWrapper.tsx
@@ -2,12 +2,11 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import Button from '@/components/common/Button/Button';
 import Toast from '@/components/common/Toast/Toast';
-import PlusIcon from '@/components/icons/PlusIcon';
 import { Summary, Tabs } from '@/components/pages/performanceDetail';
 import { useGetPerformanceDetail } from '@/hooks/performanceHooks/performanceHooks';
 import { useAuthStore } from '@/providers/AuthStoreProvider';
+import CreateGroupButton from './CreateGroupButton';
 
 type PerformanceDetailWrapperProps = {
   performanceId: string;
@@ -64,15 +63,7 @@ const PerformanceDetailWrapper = ({
           performanceDetail={performanceDetail?.data}
         />
 
-        <Button
-          onClick={routeToCreateGroupPage}
-          className='fixed right-4 bottom-23 z-2 w-fit min-w-30 gap-1 rounded-[100px] py-2.5 pr-4 pl-2.5'
-        >
-          <PlusIcon className='aspect-square h-6 w-6' />
-          <span className='text-16_B leading-normal tracking-[-0.4px]'>
-            모임 개설
-          </span>
-        </Button>
+        <CreateGroupButton onClick={routeToCreateGroupPage} />
       </div>
     </>
   );

--- a/src/mocks/handlers/performancesHandlers.ts
+++ b/src/mocks/handlers/performancesHandlers.ts
@@ -892,10 +892,13 @@ export const performancesHandlers = [
           data,
         });
       } else {
-        return HttpResponse.json({
-          code: 404,
-          message: '존재하지 않는 공연입니다.',
-        });
+        return HttpResponse.json(
+          {
+            code: 404,
+            message: '존재하지 않는 공연입니다.',
+          },
+          { status: 404 }
+        );
       }
     }
   ),


### PR DESCRIPTION
### 무엇을 위한 PR인가요? (: 뒤 설명 추가)

- 신규 기능 추가: 모임 개설 버튼 생성
- 기타: Toast 컴포넌트 디자인 적용

### 변경사항 및 이유 (bullet 으로 구분)

- 공연 상세 페이지에 모임 개설 버튼 생성
- Toast 컴포넌트 type별 디자인 적용

### 작업 내역 (bullet 으로 구분)

- 모임 개설 버튼 (`CreateGroupButton`)
  - 모임 개설 페이지로 라우팅되는 버튼 컴포넌트 생성
  - 공연 상세 조회 요청이 성공했을 경우에만 동작하도록 설정
- `Toast` 컴포넌트
  - 디자인 적용
  - 토스트 type별 아이콘 추가
  - 테스트 코드 수정

### 작업 후 기대 동작(스크린샷)

https://github.com/user-attachments/assets/981d596c-b4d2-4ff2-8515-0ffebabd0194

### PR 특이 사항

- Toast 아이콘 추후 변경 필요

### Issue Number

close: #335 