### PR TITLE
[Feature/issue-347] 액세스 토큰 재발급 로직 함수로 분리

### DIFF
--- a/src/components/common/GlobalNavigationBar/GlobalNavigationBar.tsx
+++ b/src/components/common/GlobalNavigationBar/GlobalNavigationBar.tsx
@@ -5,8 +5,8 @@ import { useMediaQuery } from 'react-responsive';
 import { useLogin, useLogout } from '@/hooks/useAuth/useAuth';
 import { useAuthStore } from '@/providers/AuthStoreProvider';
 import NavLink from '../NavLink/NavLink';
+import Notification from '../Notification/Notification';
 import SearchInput from '../SearchInput/SearchInput';
-import Notification from './Notification';
 
 const NAV_ITEM = [
   { herf: '/calendar', name: '캘린더' },

--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -7,7 +7,7 @@ import { useRouter } from 'next/navigation';
 import SearchIcon from '@/components/icons/SearchIcon';
 import { useLogin } from '@/hooks/useAuth/useAuth';
 import { useAuthStore } from '@/providers/AuthStoreProvider';
-import Notification from '../GlobalNavigationBar/Notification';
+import Notification from '../Notification/Notification';
 import SearchInput from '../SearchInput/SearchInput';
 
 interface HeaderProps {

--- a/src/components/common/Notification/Notification.tsx
+++ b/src/components/common/Notification/Notification.tsx
@@ -12,9 +12,19 @@ import {
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { useGetNewNotificationsCheck } from '@/hooks/notificationHooks/notificationHooks';
 
-const Notification = () => {
-  const isDesktop = useMediaQuery({ minWidth: 768 });
+const MobileNotification = () => {
   const router = useRouter();
+  const { data: hasNewNotificationData } = useGetNewNotificationsCheck();
+
+  return (
+    <BellIcon
+      isActive={hasNewNotificationData?.data?.hasUnread}
+      onClick={() => router.push('/notifications')}
+    />
+  );
+};
+
+const DesktopNotification = () => {
   const { data: hasNewNotificationData, refetch } =
     useGetNewNotificationsCheck();
   const pathname = usePathname();
@@ -25,25 +35,28 @@ const Notification = () => {
 
   return (
     <>
-      {isDesktop ? (
-        <Popover>
-          <PopoverTrigger>
-            <BellIcon isActive={hasNewNotificationData?.data?.hasUnread} />
-          </PopoverTrigger>
-          <PopoverContent>
-            <ScrollArea className='h-80'>
-              <NotificationList />
-            </ScrollArea>
-          </PopoverContent>
-        </Popover>
-      ) : (
-        <BellIcon
-          isActive={hasNewNotificationData?.data?.hasUnread}
-          onClick={() => router.push('/notifications')}
-        />
-      )}
+      <Popover>
+        <PopoverTrigger>
+          <BellIcon isActive={hasNewNotificationData?.data?.hasUnread} />
+        </PopoverTrigger>
+        <PopoverContent>
+          <ScrollArea className='h-80'>
+            <NotificationList />
+          </ScrollArea>
+        </PopoverContent>
+      </Popover>
     </>
   );
+};
+
+const Notification = () => {
+  const isDesktop = useMediaQuery({ minWidth: 768 });
+
+  if (isDesktop) {
+    return <DesktopNotification />;
+  }
+
+  return <MobileNotification />;
 };
 
 export default Notification;

--- a/src/components/common/SearchInput/SearchInput.tsx
+++ b/src/components/common/SearchInput/SearchInput.tsx
@@ -1,10 +1,4 @@
-import {
-  FormEvent,
-  InputHTMLAttributes,
-  PropsWithChildren,
-  Ref,
-  useRef,
-} from 'react';
+import { FormEvent, InputHTMLAttributes, PropsWithChildren, Ref } from 'react';
 import SearchIcon from '@/components/icons/SearchIcon';
 
 interface SearchInputProps extends InputHTMLAttributes<HTMLInputElement> {
@@ -17,7 +11,6 @@ const SearchInput = ({
   children,
   ...props
 }: PropsWithChildren<SearchInputProps>) => {
-  const formRef = useRef<HTMLFormElement>(null);
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     onSubmit();
@@ -25,14 +18,12 @@ const SearchInput = ({
 
   return (
     <form
-      ref={formRef}
       onSubmit={handleSubmit}
       className='flex w-full cursor-pointer items-center gap-2 rounded-[100px] bg-gray-25 px-3 py-1.5 focus-within:border focus-within:border-gray-700 focus:border focus:border-gray-700'
     >
-      <SearchIcon
-        className='text-gray-500'
-        onClick={() => formRef.current?.submit()}
-      />
+      <button type='submit'>
+        <SearchIcon className='text-gray-500' />
+      </button>
       <input
         {...props}
         type='search'

--- a/src/utils/getNewAccessToken.ts
+++ b/src/utils/getNewAccessToken.ts
@@ -1,0 +1,31 @@
+import axios from 'axios';
+import { callLogout, callTokenUpdater } from '@/providers/AuthStoreProvider';
+import { TokenRefreshResponse } from '@/types/auth';
+
+export const getNewAccessToken = async (): Promise<string> => {
+  try {
+    const res = await axios.post<TokenRefreshResponse>(
+      `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/v1/auth/token`,
+      {},
+      { withCredentials: true }
+    );
+
+    const newAccessToken = res.data.data?.accessToken;
+
+    if (!newAccessToken) {
+      throw new Error('토큰이 존재하지 않습니다.');
+    }
+
+    callTokenUpdater(newAccessToken);
+    return newAccessToken;
+  } catch (err) {
+    callLogout();
+
+    const REDIRECT_URI = `${process.env.NEXT_PUBLIC_BASE_URL}/login/kakao`;
+    const kakaoAuthUrl = `https://kauth.kakao.com/oauth/authorize?client_id=${process.env.NEXT_PUBLIC_KAKAO_APP_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;
+
+    window.open(kakaoAuthUrl, '_self');
+
+    return Promise.reject(err);
+  }
+};


### PR DESCRIPTION
### 무엇을 위한 PR인가요? (: 뒤 설명 추가)

- 신규 기능 추가: 액세스 토큰 재발급 로직 함수로 분리
- 버그 수정:
- 리펙토링: unread-exists api관련 중복 호출 수정
- 문서 업데이트:
- 기타:

### 변경사항 및 이유 (bullet 으로 구분)

- 액세스 토큰을 재발급 받아 사용하는 로직이 여러곳에서 사용됨
- 해당 로직을 함수로 분리하여 재사용할 수 있도록 변경
- Header는 필요한 페이지마다 새로 렌더링 되기 때문에 unread-exists가 useEffect로 인해 중복 호출되는 오류 발생

### 작업 내역 (bullet 으로 구분)

- 액세스 토큰 재발급 로직을 함수로 분리
- Notification 컴포넌트를 화면 크기에 따라 서로 다른 컴포넌트가 렌더링 되도록 변경
- 데스크톱 환경일때는 GNB에서 사용될것이므로 useEffect로 pathName이 변할때마다 refetch
- 모바일 환경에서는 Header가 필요한 페이지마다 렌더링 될것이므로 useEffect와 refetch를 사용하지 않음

### Issue Number

close: #347