### PR TITLE
[Feature/issue-360] 모임 기본 정보 조회

### DIFF
--- a/src/components/common/Toast/Toast.test.tsx
+++ b/src/components/common/Toast/Toast.test.tsx
@@ -50,7 +50,7 @@ describe('Toast 컴포넌트', () => {
     setup({ type: 'error' });
     const toast = screen.getByRole('alert');
 
-    expect(toast).toHaveClass('bg-primary-red text-white');
+    expect(toast).toHaveClass('bg-white text-gray-950');
   });
 
   test('초기에는 isVisible = true로 보여진다', () => {

--- a/src/components/common/Toast/Toast.tsx
+++ b/src/components/common/Toast/Toast.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
-import { BellRingIcon, CircleAlertIcon, TriangleAlertIcon } from 'lucide-react';
+import BellIcon from '@/components/icons/BellIcon';
 import CheckIcon from '@/components/icons/CheckIcon';
+import WarningIcon from '@/components/icons/WarningIcon';
 import { cn } from '@/lib/utils';
 import Portal from '../Portal';
 
@@ -16,7 +17,7 @@ const typeStyles: Record<NonNullable<ToastProps['type']>, string> = {
   default: 'bg-white text-gray-950',
   success: 'bg-white text-gray-950',
   warning: 'bg-yellow-400 text-gray-950',
-  error: 'bg-primary-red text-white',
+  error: 'bg-white text-gray-950',
   info: 'bg-white text-gray-950',
 };
 
@@ -24,18 +25,18 @@ const iconStyles: Record<NonNullable<ToastProps['type']>, React.ReactNode> = {
   default: (
     <CheckIcon
       type='filled'
-      className='spect-square h-6 w-6 text-primary-red'
+      className='aspect-square h-6 w-6 text-primary-red'
     />
   ),
   success: (
     <CheckIcon
       type='filled'
-      className='spect-square h-6 w-6 text-primary-red'
+      className='aspect-square h-6 w-6 text-primary-red'
     />
   ),
-  warning: <TriangleAlertIcon className='aspect-square h-6 w-6' />,
-  error: <CircleAlertIcon className='aspect-square h-6 w-6' />,
-  info: <BellRingIcon className='aspect-square h-6 w-6' />,
+  warning: <WarningIcon className='aspect-square h-6 w-6' />,
+  error: <WarningIcon className='aspect-square h-6 w-6 text-primary-red' />,
+  info: <BellIcon className='aspect-square h-6 w-6 text-primary-red' />,
 };
 
 const animationClass = (visible: boolean) =>
@@ -71,7 +72,7 @@ const Toast = ({
         aria-label='toast'
         role='alert'
         className={cn(
-          'fixed bottom-4 left-1/2 z-50 flex w-full max-w-[343px] -translate-x-1/2 flex-col items-center justify-center gap-2 rounded-[18px] px-5 py-5 text-gray-950 shadow-[0px_4px_14px_0px_rgba(0,0,0,0.10)] transition-all duration-500 ease-in-out',
+          'fixed bottom-4 left-1/2 z-50 flex w-full max-w-[343px] -translate-x-1/2 flex-col items-center justify-center gap-2.5 rounded-[18px] px-5 py-5.5 text-gray-950 shadow-[0px_4px_14px_0px_rgba(0,0,0,0.10)] transition-all duration-500 ease-in-out',
           typeStyles[type],
           animationClass(isVisible),
           className

--- a/src/components/icons/WarningIcon.tsx
+++ b/src/components/icons/WarningIcon.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+const WarningIcon = ({ className }: { className?: string }) => (
+  <svg
+    className={className}
+    xmlns='http://www.w3.org/2000/svg'
+    width='25'
+    height='25'
+    viewBox='0 0 25 25'
+    fill='none'
+  >
+    <path
+      d='M20.5 2.5H4.5C3.397 2.5 2.5 3.397 2.5 4.5V22.5L6.5 18.5H20.5C21.603 18.5 22.5 17.603 22.5 16.5V4.5C22.5 3.397 21.603 2.5 20.5 2.5ZM13.5 15.5H11.5V13.5H13.5V15.5ZM13.5 11.5H11.5V5.5H13.5V11.5Z'
+      fill='currentColor'
+    />
+  </svg>
+);
+
+export default WarningIcon;

--- a/src/components/pages/groupDetail/GroupInfo.tsx
+++ b/src/components/pages/groupDetail/GroupInfo.tsx
@@ -1,6 +1,62 @@
-const GroupInfo = () => (
-  // TODO: 모임 기본 정보 조회 api 연동
-  <div>모임 기본 정보</div>
-);
+'use client';
+
+import { useState } from 'react';
+import Toast from '@/components/common/Toast/Toast';
+import { useAuthStore } from '@/providers/AuthStoreProvider';
+import { GroupInfo as GroupInfoType } from '@/types/group';
+import { ToastContent } from '@/types/toastContent';
+import GroupInfoCard from './GroupInfoCard/GroupInfoCard';
+import GroupModal from './GroupModal/GroupModal';
+
+interface GroupInfoProps {
+  groupInfo: GroupInfoType;
+}
+
+const GroupInfo = ({ groupInfo }: GroupInfoProps) => {
+  const isLoggedIn = useAuthStore((state) => state.isLoggedin);
+  const [showToast, setShowToast] = useState(false);
+  const [toastContent, setToastContent] = useState<ToastContent>({
+    message: '',
+    type: 'default',
+  });
+  const [isOpen, setIsOpen] = useState(false);
+
+  const onOpenModal = () => {
+    if (!isLoggedIn) {
+      setToastContent({ message: '로그인이 필요합니다!', type: 'error' });
+      setShowToast(true);
+      return;
+    }
+
+    setIsOpen(true);
+  };
+
+  return (
+    <>
+      {showToast && (
+        <Toast
+          message={toastContent.message}
+          type={toastContent.type}
+          onClose={() => setShowToast(false)}
+        />
+      )}
+
+      <GroupInfoCard
+        groupInfo={groupInfo}
+        handleButtonClick={onOpenModal}
+      />
+
+      {/* 모임 신청/탈퇴 모달 */}
+      <GroupModal
+        groupId={groupInfo.id}
+        isMember={groupInfo.isMember}
+        isOpen={isOpen}
+        setIsOpen={setIsOpen}
+        setShowToast={setShowToast}
+        setToastContent={setToastContent}
+      />
+    </>
+  );
+};
 
 export default GroupInfo;

--- a/src/components/pages/groupDetail/GroupInfo.tsx
+++ b/src/components/pages/groupDetail/GroupInfo.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import Toast from '@/components/common/Toast/Toast';
+import { Skeleton } from '@/components/ui/skeleton';
 import { useAuthStore } from '@/providers/AuthStoreProvider';
 import { GroupInfo as GroupInfoType } from '@/types/group';
 import { ToastContent } from '@/types/toastContent';
@@ -9,10 +10,11 @@ import GroupInfoCard from './GroupInfoCard/GroupInfoCard';
 import GroupModal from './GroupModal/GroupModal';
 
 interface GroupInfoProps {
-  groupInfo: GroupInfoType;
+  isPending: boolean;
+  groupInfo?: GroupInfoType;
 }
 
-const GroupInfo = ({ groupInfo }: GroupInfoProps) => {
+const GroupInfo = ({ isPending, groupInfo }: GroupInfoProps) => {
   const isLoggedIn = useAuthStore((state) => state.isLoggedin);
   const [showToast, setShowToast] = useState(false);
   const [toastContent, setToastContent] = useState<ToastContent>({
@@ -30,6 +32,16 @@ const GroupInfo = ({ groupInfo }: GroupInfoProps) => {
 
     setIsOpen(true);
   };
+
+  if (isPending) {
+    return (
+      <div className='px-4'>
+        <Skeleton className='h-[40dvh] w-full rounded-[16px]' />
+      </div>
+    );
+  }
+
+  if (!groupInfo) return null;
 
   return (
     <>

--- a/src/components/pages/groupDetail/GroupInfoCard/GroupInfoCard.tsx
+++ b/src/components/pages/groupDetail/GroupInfoCard/GroupInfoCard.tsx
@@ -1,0 +1,104 @@
+import { format } from 'date-fns';
+import { ko } from 'date-fns/locale';
+import Badge from '@/components/common/Badge/Badge';
+import Button from '@/components/common/Button/Button';
+import HashtagBadgeGroup from '@/components/common/HashtagBadgeGroup/HashtagBadgeGroup';
+import ProfileImage from '@/components/common/ProfileImage/ProfileImage';
+import ProgressBar from '@/components/common/ProgressBar/ProgressBar';
+import StarIcon from '@/components/icons/StarIcon';
+import { GroupInfo } from '@/types/group';
+
+const DATE_FORMAT = 'yy.MM.dd';
+
+interface GroupInfoCardProps {
+  groupInfo: GroupInfo;
+  handleButtonClick?: () => void;
+}
+
+const GroupInfoCard = ({
+  groupInfo,
+  handleButtonClick,
+}: GroupInfoCardProps) => (
+  <div className='px-4'>
+    <div className='flex w-full flex-col items-start justify-center gap-4 rounded-2xl bg-gray-25 p-5'>
+      {/* 카테고리, 날짜 */}
+      <div className='flex w-full items-center justify-between'>
+        <div className='flex gap-0.5'>
+          <Badge
+            label={groupInfo.category}
+            className='flex items-center gap-1 text-14_M text-gray-600'
+          />
+        </div>
+        <span className='text-12_M text-gray-600'>
+          {format(new Date(groupInfo.startDate), DATE_FORMAT, {
+            locale: ko,
+          })}
+          ~
+          {format(new Date(groupInfo.endDate), DATE_FORMAT, {
+            locale: ko,
+          })}
+        </span>
+      </div>
+
+      <div className='flex w-full justify-between gap-4'>
+        <div className='flex flex-1 flex-col justify-between overflow-hidden'>
+          {/* 모임명 */}
+          <h4 className='mb-1.5 truncate text-16_B text-black'>
+            {groupInfo.title}
+          </h4>
+          {/* 모임 정보 */}
+          <div className='mb-2.5 flex items-center gap-2 text-13_M text-gray-700'>
+            <span>{groupInfo.location}</span>
+            <div className='h-2 w-[1px] bg-gray-200' />
+            <span>{groupInfo.gender}</span>
+            <div className='h-2 w-[1px] bg-gray-200' />
+            <span>
+              {groupInfo.startAge}~{groupInfo.endAge}세
+            </span>
+          </div>
+          {/* 방장 정보 */}
+          <div className='flex items-center gap-0.5'>
+            <ProfileImage
+              size='xs'
+              src={groupInfo.host.profileImage}
+              alt={groupInfo.host.name}
+              border={false}
+            />
+            <span className='text-12_M text-gray-700'>
+              {groupInfo.host.name}
+            </span>
+            <span className='flex text-12_M text-gray-700'>
+              (<StarIcon className='h-3 w-3' />
+              {groupInfo.host.rating})
+            </span>
+          </div>
+          {/* 소개글 */}
+          <p className='line-clamp-2 w-full text-14_body_M text-gray-950'>
+            {groupInfo.description}
+          </p>
+        </div>
+      </div>
+
+      {/* 인원 수 프로그레스 바 */}
+      <ProgressBar
+        current={groupInfo.memberCount}
+        total={groupInfo.maxMembers}
+      />
+
+      {/* 해시태그 */}
+      {groupInfo.hashtag && <HashtagBadgeGroup hashtags={groupInfo.hashtag} />}
+
+      <div className='flex w-full gap-2'>
+        <Button
+          variant='primary'
+          color='normal'
+          onClick={handleButtonClick}
+        >
+          {groupInfo.isMember ? '모임 탈퇴' : '참가 신청'}
+        </Button>
+      </div>
+    </div>
+  </div>
+);
+
+export default GroupInfoCard;

--- a/src/components/pages/groupDetail/GroupModal/GroupModal.tsx
+++ b/src/components/pages/groupDetail/GroupModal/GroupModal.tsx
@@ -1,0 +1,196 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import Button from '@/components/common/Button/Button';
+import Portal from '@/components/common/Portal';
+import TextareaInput from '@/components/common/TextareaInput/TextareaInput';
+import { usePostJoinGroup } from '@/hooks/groupHooks/groupHooks';
+import { useLeaveGroup } from '@/hooks/groupsManagementsHooks/groupsManagementsHooks';
+import { ToastContent } from '@/types/toastContent';
+
+interface GroupModalProps {
+  groupId: string;
+  isMember: boolean;
+  isOpen: boolean;
+  setIsOpen: (isOpen: boolean) => void;
+  setShowToast?: (show: boolean) => void;
+  setToastContent?: (value: ToastContent) => void;
+}
+
+const GroupModal = ({
+  groupId,
+  isMember,
+  isOpen,
+  setIsOpen,
+  setShowToast,
+  setToastContent,
+}: GroupModalProps) => {
+  const { mutate: postJoinGroup, status: joinStatus } = usePostJoinGroup();
+  const { mutate: leaveGroup, status: leaveStatus } = useLeaveGroup();
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const [description, setDescription] = useState<string>('');
+
+  const onCloseModal = () => {
+    setDescription('');
+    setIsOpen(false);
+  };
+
+  const applyToGroup = () => {
+    if (groupId && description) {
+      postJoinGroup(
+        { groupId, description },
+        {
+          onSuccess: () => {
+            setToastContent?.({
+              message: '신청 완료되었습니다.',
+              type: 'success',
+            });
+          },
+          onError: (error) => {
+            if (error.code === 400) {
+              setToastContent?.({
+                message: '이미 신청한 모임입니다.',
+                type: 'error',
+              });
+            } else {
+              setToastContent?.({
+                message: '신청 중 오류가 발생했습니다.',
+                type: 'error',
+              });
+            }
+          },
+          onSettled: () => {
+            setShowToast?.(true);
+            onCloseModal();
+          },
+        }
+      );
+    }
+  };
+
+  const leaveFromGroup = () => {
+    if (groupId) {
+      leaveGroup(
+        { groupId },
+        {
+          onSuccess: () => {
+            setToastContent?.({
+              message: '모임에서 탈퇴하였습니다.',
+              type: 'success',
+            });
+          },
+          onError: (error) => {
+            if (error.code === 400) {
+              setToastContent?.({
+                message: '이미 탈퇴한 모임입니다.',
+                type: 'error',
+              });
+            } else {
+              setToastContent?.({
+                message: '탈퇴 중 오류가 발생했습니다.',
+                type: 'error',
+              });
+            }
+          },
+          onSettled: () => {
+            console.log(leaveStatus);
+            setShowToast?.(true);
+            onCloseModal();
+          },
+        }
+      );
+    }
+  };
+
+  const renderApplyContent = () => (
+    <div className='flex flex-col gap-5'>
+      <span className='text-center text-16_B'>신청서 작성</span>
+      <TextareaInput
+        value={description}
+        onChange={setDescription}
+        placeholder='간단한 소개를 작성해주세요.'
+        className='rounded-[16px] border-1 border-gray-100 px-5 py-4 text-[16px] leading-[180%] font-medium tracking-[-0.35px] text-gray-950 shadow-[0px_2px_6px_0px_rgba(0,0,0,0.02)] placeholder:text-gray-500'
+      />
+      <div className='flex gap-2'>
+        <Button
+          variant='secondary'
+          onClick={onCloseModal}
+          disabled={joinStatus === 'pending'}
+        >
+          취소
+        </Button>
+        <Button
+          onClick={applyToGroup}
+          disabled={joinStatus === 'pending'}
+        >
+          {joinStatus === 'pending' ? '신청중...' : '신청'}
+        </Button>
+      </div>
+    </div>
+  );
+
+  const renderLeaveContent = () => (
+    <div className='flex flex-col gap-7.5 pt-5.5'>
+      <p className='flex w-full justify-center text-16_B text-black'>
+        모임을 탈퇴하시겠습니까?
+      </p>
+      <div className='flex gap-2'>
+        <Button
+          variant='secondary'
+          onClick={onCloseModal}
+          disabled={leaveStatus === 'pending'}
+        >
+          취소
+        </Button>
+        <Button
+          onClick={leaveFromGroup}
+          disabled={leaveStatus === 'pending'}
+        >
+          {leaveStatus === 'pending' ? '탈퇴중...' : '탈퇴'}
+        </Button>
+      </div>
+    </div>
+  );
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    if (isOpen && !dialog.open) {
+      dialog.showModal();
+    } else if (!isOpen && dialog.open) {
+      dialog.close();
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    const handleBackdropClick = (event: MouseEvent) => {
+      if (event.target === dialog) {
+        dialog.close();
+      }
+    };
+
+    dialog.addEventListener('click', handleBackdropClick);
+    return () => dialog.removeEventListener('click', handleBackdropClick);
+  }, []);
+
+  if (!isOpen) return null;
+
+  return (
+    <Portal>
+      <dialog
+        ref={dialogRef}
+        onClose={onCloseModal}
+        aria-modal='true'
+        className='fixed top-1/2 left-1/2 w-[calc(100%-32px)] max-w-[480px] -translate-x-1/2 -translate-y-1/2 rounded-[16px] bg-white p-5 backdrop:bg-[rgba(0,0,0,0.5)]'
+      >
+        {isMember ? renderLeaveContent() : renderApplyContent()}
+      </dialog>
+    </Portal>
+  );
+};
+
+export default GroupModal;

--- a/src/components/pages/groupDetail/GroupTabs.tsx
+++ b/src/components/pages/groupDetail/GroupTabs.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from 'react';
 import { Tabs } from '@/components/common';
-import Chat from './Chat/Chat';
 import GroupPosts from './GroupPosts';
 
 const groupTabs = ['게시글', '채팅', '캘린더'];
@@ -19,7 +18,7 @@ const GroupTabs = () => {
       />
       <>
         {selectedTab === '게시글' && <GroupPosts />}
-        {selectedTab === '채팅' && <Chat />}
+        {/* {selectedTab === '채팅' && <Chat />} */}
         {/* {selectedTab === '캘린더' && <캘린더 />} */}
       </>
     </div>

--- a/src/components/pages/groupDetail/GroupWrapper.tsx
+++ b/src/components/pages/groupDetail/GroupWrapper.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useGetGroupInfo } from '@/hooks/groupHooks/groupHooks';
 import { useAuthStore } from '@/providers/AuthStoreProvider';
 import GroupInfo from './GroupInfo';
 import GroupMembers from './GroupMembers';
@@ -11,14 +12,25 @@ interface GroupWrapperProps {
 
 const GroupWrapper = ({ groupId }: GroupWrapperProps) => {
   const isLoggedIn = useAuthStore((state) => state.isLoggedin);
-  console.log(groupId); // TODO: 주석 제거 필요
+  const { data: groupInfo, isPending, isError } = useGetGroupInfo(groupId);
+  const isMember = groupInfo?.data?.isMember;
+
+  if (isError) {
+    return (
+      <div className='flex flex-col items-center justify-center px-4 py-5'>
+        <p className='font-semibold text-gray-500'>존재하지 않는 모임입니다.</p>
+      </div>
+    );
+  }
 
   return (
     <div className='flex flex-col gap-7.5 bg-white'>
-      <GroupInfo />
+      <GroupInfo
+        isPending={isPending}
+        groupInfo={groupInfo?.data}
+      />
 
-      {/* TODO: isLoggedIn && isMember일 경우에만 렌더링 */}
-      {isLoggedIn && (
+      {isLoggedIn && isMember && (
         <>
           <GroupMembers />
           <GroupTabs />

--- a/src/components/pages/performanceDetail/GroupApplyModal.tsx
+++ b/src/components/pages/performanceDetail/GroupApplyModal.tsx
@@ -5,7 +5,7 @@ import Button from '@/components/common/Button/Button';
 import Portal from '@/components/common/Portal';
 import TextareaInput from '@/components/common/TextareaInput/TextareaInput';
 import { usePostJoinGroup } from '@/hooks/groupHooks/groupHooks';
-import { ToastContent } from './PerformanceDetailGroupsList';
+import { ToastContent } from '@/types/toastContent';
 
 interface GroupApplyModalProps {
   groupId: string;

--- a/src/components/pages/performanceDetail/PerformanceDetailGroupsList.tsx
+++ b/src/components/pages/performanceDetail/PerformanceDetailGroupsList.tsx
@@ -6,6 +6,7 @@ import GroupCard from '@/components/common/GroupCard/GroupCard';
 import Toast from '@/components/common/Toast/Toast';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useAuthStore } from '@/providers/AuthStoreProvider';
+import { ToastContent } from '@/types/toastContent';
 import {
   formatPerformanceGroups,
   PerformanceGroupsApiResponse,
@@ -15,11 +16,6 @@ import GroupApplyModal from './GroupApplyModal';
 interface PerformanceDetailGroupsListProps {
   isPending: boolean;
   groups?: PerformanceGroupsApiResponse;
-}
-
-export interface ToastContent {
-  message: string;
-  type: 'default' | 'success' | 'warning' | 'error' | 'info';
 }
 
 const PerformanceDetailGroupsList = ({

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -12,6 +12,7 @@ export const NOTIFICATIONS_QUERY_KEYS = {
 
 export const GROUP_QUERY_KEYS = {
   groups: 'groups',
+  groupInfo: 'groupInfo',
   leaveGroup: 'leaveGroup',
   joinGroup: 'joinGroup',
   groupPosts: 'groupPosts',

--- a/src/hooks/groupHooks/groupHooks.ts
+++ b/src/hooks/groupHooks/groupHooks.ts
@@ -2,7 +2,11 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { GROUP_QUERY_KEYS } from '@/constants/queryKeys';
 import { groupsApi } from '@/services/groupsService';
 import { ApiResponse } from '@/types/api';
-import { GetGroupsParams, PostJoinGroupRequest } from '@/types/group';
+import {
+  GetGroupsParams,
+  GroupInfoResponse,
+  PostJoinGroupRequest,
+} from '@/types/group';
 import { GroupPostsResponse } from '@/types/post';
 import { PerformanceGroupsApiResponse } from '@/utils/formatGroupCardData';
 
@@ -15,6 +19,12 @@ export const useGetGroups = (params: GetGroupsParams) =>
     },
     placeholderData: (previousData: PerformanceGroupsApiResponse | undefined) =>
       previousData,
+  });
+
+export const useGetGroupInfo = (groupId: string) =>
+  useQuery<GroupInfoResponse>({
+    queryKey: [GROUP_QUERY_KEYS.groupInfo],
+    queryFn: async () => await groupsApi.getGroupInfo(groupId),
   });
 
 export const usePostJoinGroup = () => {

--- a/src/hooks/groupHooks/groupHooks.ts
+++ b/src/hooks/groupHooks/groupHooks.ts
@@ -23,7 +23,7 @@ export const useGetGroups = (params: GetGroupsParams) =>
 
 export const useGetGroupInfo = (groupId: string) =>
   useQuery<GroupInfoResponse>({
-    queryKey: [GROUP_QUERY_KEYS.groupInfo],
+    queryKey: [GROUP_QUERY_KEYS.groupInfo, groupId],
     queryFn: async () => await groupsApi.getGroupInfo(groupId),
   });
 

--- a/src/services/groupsService.ts
+++ b/src/services/groupsService.ts
@@ -1,7 +1,11 @@
 import QueryString from 'qs';
 import apiFetcher from '@/lib/apiFetcher';
 import { ApiResponse } from '@/types/api';
-import { GetGroupsParams, PostJoinGroupRequest } from '@/types/group';
+import {
+  GetGroupsParams,
+  GroupInfoResponse,
+  PostJoinGroupRequest,
+} from '@/types/group';
 import { Post } from '@/types/post';
 import { formatPostDate } from '@/utils/date';
 import { PerformanceGroupsApiResponse } from '@/utils/formatGroupCardData';
@@ -20,6 +24,10 @@ export const groupsApi = {
       `/api/v1/performances/${performanceId}/groups?${queryString}`
     );
   },
+
+  getGroupInfo: async (groupId: string) =>
+    (await apiFetcher.get<GroupInfoResponse>(`/api/v1/groups/${groupId}`)).data,
+
   postJoinGroup: async ({ groupId, description }: PostJoinGroupRequest) =>
     (
       await apiFetcher.post<ApiResponse>(`/api/v1/groups/${groupId}/join`, {

--- a/src/types/group.ts
+++ b/src/types/group.ts
@@ -49,6 +49,37 @@ export interface GetGroupsParams {
   gender?: string | null;
 }
 
+export interface GroupInfo {
+  id: string;
+  performance?: {
+    id: string;
+    title?: string;
+    poster?: string;
+  };
+  title: string;
+  category: GroupCategoryType;
+  gender: GenderType;
+  startAge: number;
+  endAge: number;
+  location: string;
+  startDate: string;
+  endDate: string;
+  memberCount: number;
+  maxMembers: number;
+  description?: string;
+  hashtag?: string[];
+  host: {
+    hostId: string;
+    name: string;
+    rating?: number;
+    profileImage?: string;
+  };
+  isMember: boolean;
+  chatRoomId: number;
+}
+
+export type GroupInfoResponse = ApiResponse<GroupInfo>;
+
 export type PostJoinGroupRequest = {
   groupId: string;
   description: string;

--- a/src/types/toastContent.ts
+++ b/src/types/toastContent.ts
@@ -1,0 +1,4 @@
+export type ToastContent = {
+  message: string;
+  type: 'default' | 'success' | 'warning' | 'error' | 'info';
+};


### PR DESCRIPTION
### 무엇을 위한 PR인가요? (: 뒤 설명 추가)

- 신규 기능 추가: 모임 상세 내 모임 기본 정보 섹션 구현

### 변경사항 및 이유 (bullet 으로 구분)

  - 모임 기본 정보 조회 api 연결
  - 모임 기본 정보 섹션 디자인 적용

### 작업 내역 (bullet 으로 구분)

  - 모임 기본 정보 조회 api 연결
    - isError일 경우 '존재하지 않는 모임입니다' 메세지 띄움
  - 모임 기본 정보 섹션 구현
    - `GroupInfoCard`: 모임 기본 정보 컴포넌트 생성
    - `GroupModal`: 모임 신청/탈퇴 모달 컴포넌트 생성
    - Skeleton UI 적용
    - 디자인 적용
  - `ToastContent` 타입: toast 메세지와 toast 타입을 정의하는 타입 선언
  - `Toast` 컴포넌트 type별 아이콘 수정

### 작업 후 기대 동작(스크린샷)

https://github.com/user-attachments/assets/89777921-795b-4deb-aba4-e0089d55fba3

### PR 특이 사항

- 모임 탈퇴 안되는 버그 수정 필요
- 모임 신청 status를 받아오지 않아 신청이 완료된 후 처리(버튼 disabled)를 할 수 없음
- 모임 참가자가 아닌 경우 블러 처리된 모임원 목록, 모임 탭이 보이도록 처리 필요

### Issue Number

close: #360 