### PR TITLE
[Feature/issue-372] 댓글 수정 모달 디자인으로 변경

### DIFF
--- a/src/components/common/MessageInput/MessageInput.tsx
+++ b/src/components/common/MessageInput/MessageInput.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { useState } from 'react';
+import Button from '@/components/common/Button/Button';
+import SendIcon from '@/components/icons/SendIcon';
+import { cn } from '@/lib/utils';
+import { hasProfanity } from '@/lib/utils';
+import Toast from '../Toast/Toast';
+
+interface MessageInputProps {
+  disabled?: boolean;
+  sendMessage: (message: string) => void;
+  type: 'comment' | 'chat';
+  maxLength?: number;
+  minLength?: number;
+}
+
+const MessageInput = ({
+  disabled = false,
+  sendMessage,
+  type = 'chat',
+  maxLength = 300,
+  minLength = 1,
+}: MessageInputProps) => {
+  const [message, setMessage] = useState<string>('');
+  const [error, setError] = useState<string>('');
+
+  const validateMessage = (message: string): boolean => {
+    if (message.length > maxLength) {
+      setError(`최대 ${maxLength}자까지 입력 가능합니다.`);
+      return false;
+    }
+    if (hasProfanity(message)) {
+      setError('부적절한 표현이 포함되어 있습니다.');
+      return false;
+    }
+    setError('');
+    return true;
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!validateMessage(message)) {
+      return;
+    }
+
+    sendMessage(message.trim());
+    setMessage('');
+    setError('');
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newMessage = e.target.value;
+
+    if (newMessage.length <= maxLength) {
+      setMessage(newMessage);
+      validateMessage(newMessage);
+    } else {
+      setMessage(newMessage.slice(0, maxLength));
+      setError(`최대 ${maxLength}자까지 입력 가능합니다.`);
+    }
+  };
+
+  const isSubmitDisabled =
+    disabled
+    || message.trim().length < minLength
+    || message.length > maxLength
+    || hasProfanity(message)
+    || !!error;
+
+  return (
+    <div
+      className={cn(
+        'fixed bottom-0 z-1 flex w-full flex-col gap-1',
+        type === 'comment' && 'border-t border-gray-100 bg-white p-4'
+      )}
+    >
+      <form
+        onSubmit={handleSubmit}
+        className={cn(
+          'flex h-11 w-full flex-1 gap-2.5 rounded-[100px] border-1 border-gray-100 bg-white py-1.5 pr-2 pl-3.5',
+          type === 'comment' && 'bg-gray-25',
+          error && 'ring-1 ring-red-500'
+        )}
+      >
+        <input
+          type='text'
+          placeholder={
+            type === 'comment' ? '댓글을 입력하세요' : '메세지를 입력하세요'
+          }
+          disabled={disabled}
+          value={message}
+          onChange={handleInputChange}
+          className='flex w-full items-center text-16_M text-gray-950 placeholder:text-16_M placeholder:leading-normal placeholder:tracking-[-0.35px] placeholder:text-gray-400 focus:outline-none'
+        />
+        <Button
+          type='submit'
+          variant='primary'
+          disabled={isSubmitDisabled}
+          className='flex w-11 shrink-0 items-center justify-center self-stretch rounded-[100px] px-3 py-1.5'
+        >
+          <SendIcon className='aspect-square h-4 w-4 shrink-0' />
+        </Button>
+      </form>
+
+      {error && (
+        <Toast
+          message={error}
+          type='error'
+          onClose={() => {}}
+          className='bottom-5/6 left-1/2'
+        />
+      )}
+    </div>
+  );
+};
+
+export default MessageInput;

--- a/src/components/common/TextareaInput/TextareaInput.tsx
+++ b/src/components/common/TextareaInput/TextareaInput.tsx
@@ -45,7 +45,7 @@ const TextareaInput = ({
   const finalClass = cn(baseClass, borderClass, scrollbarClass, className);
 
   return (
-    <div className='flex h-full w-full flex-col gap-1'>
+    <div className='flex h-full w-full flex-col gap-2.5'>
       <textarea
         className={finalClass}
         value={value}

--- a/src/components/pages/groupDetail/CommentItem/CommentItem.tsx
+++ b/src/components/pages/groupDetail/CommentItem/CommentItem.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useRef } from 'react';
+import React, { useRef, useState } from 'react';
 import { useParams } from 'next/navigation';
 import Button from '@/components/common/Button/Button';
 import Modal from '@/components/common/Modal/Modal';
@@ -10,45 +10,92 @@ import ModalContent from '@/components/common/Modal/ModalContent';
 import ModalTrigger from '@/components/common/Modal/ModalTrigger';
 import MoreDropdown from '@/components/common/MoreDropdown/MoreDropdown';
 import ProfileImage from '@/components/common/ProfileImage/ProfileImage';
-import { useDeleteComment } from '@/hooks/postHooks/postHook';
-import { cn } from '@/lib/utils';
+import TextareaInput from '@/components/common/TextareaInput/TextareaInput';
+import { useDeleteComment, useUpdateComment } from '@/hooks/postHooks/postHook';
+import { cn, hasProfanity } from '@/lib/utils';
 import { Comment } from '@/types/comment';
 import { formatRelativeDate } from '@/utils/date';
 
 interface CommentItemProps {
   comment: Comment;
   className?: string;
-  setMessage: (message: string) => void;
-  setEditCommentId: (id: string) => void;
-  setOriginalMessage: (message: string) => void;
 }
 
-const CommentItem = ({
-  comment,
-  className,
-  setMessage,
-  setEditCommentId,
-  setOriginalMessage,
-}: CommentItemProps) => {
+type ModalType = 'delete' | 'edit' | null;
+
+const CommentItem = ({ comment, className }: CommentItemProps) => {
   const { author, content, createdAt, isMine } = comment;
   const { profileImage: profileImageUrl, name } = author ?? {};
   const { mutate: deleteComment } = useDeleteComment();
+  const { mutate: updateComment } = useUpdateComment();
   const params = useParams();
   const groupId = params?.groupId as string;
   const postId = params?.postId as string;
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const [modalType, setModalType] = useState<ModalType>(null);
+  const [editMessage, setEditMessage] = useState(content);
+  const [originalEditMessage, setOriginalEditMessage] = useState(content);
+
+  const openModal = (type: ModalType) => {
+    setModalType(type);
+
+    if (type === 'edit') {
+      setEditMessage(content);
+      setOriginalEditMessage(content);
+    }
+
+    triggerRef.current?.click();
+  };
 
   const handleDeleteComment = () => {
-    if (isMine) {
-      deleteComment({ groupId, postId, commentId: comment.id });
-    }
+    if (!isMine) return;
+
+    deleteComment({ groupId, postId, commentId: comment.id });
+    setModalType(null);
   };
 
-  const handleUpdateComment = () => {
-    setEditCommentId(comment.id);
-    setMessage(comment.content);
-    setOriginalMessage(comment.content);
+  const handleEditSubmit = () => {
+    if (!isEditable) return;
+
+    updateComment({
+      groupId,
+      postId,
+      commentId: comment.id,
+      content: editMessage,
+    });
+    setModalType(null);
   };
+
+  const handleCancelEdit = () => {
+    setEditMessage(originalEditMessage);
+    setModalType(null);
+  };
+
+  const closeModal = () => {
+    setModalType(null);
+  };
+
+  const dropdownItems = isMine
+    ? [
+        {
+          label: '수정하기',
+          onClick: () => openModal('edit'),
+        },
+        {
+          label: '삭제하기',
+          onClick: () => openModal('delete'),
+        },
+      ]
+    : [
+        {
+          label: '신고하기',
+          onClick: () => console.log('신고하기 클릭'),
+        },
+      ];
+
+  const isEditable =
+    editMessage !== originalEditMessage && !hasProfanity(editMessage);
+
   return (
     <div className={cn('flex w-full items-center py-3.5', className)}>
       <div className='flex w-full items-start justify-center gap-2.5'>
@@ -65,48 +112,51 @@ const CommentItem = ({
           </span>
           <span className='text-14_M text-black'>{content}</span>
         </div>
-        <MoreDropdown
-          items={[
-            ...(isMine
-              ? [
-                  {
-                    label: '수정하기',
-                    onClick: () => handleUpdateComment(),
-                  },
-                  {
-                    label: '삭제하기',
-                    onClick: () => triggerRef.current?.click(),
-                  },
-                ]
-              : [
-                  {
-                    label: '신고하기',
-                    onClick: () => console.log('신고하기 클릭'),
-                  },
-                ]),
-          ]}
-        />
+        <MoreDropdown items={dropdownItems} />
       </div>
 
+      {/* 통합 모달 */}
       <Modal>
         <ModalTrigger>
           <button ref={triggerRef}></button>
         </ModalTrigger>
-        <ModalContent className='flex w-[343px] flex-col rounded-2xl bg-white p-5 pt-11'>
-          <p className='mb-[30px] flex w-full justify-center text-16_B text-black'>
-            댓글을 삭제하시겠습니까?
-          </p>
+        <ModalContent className='flex w-[343px] flex-col rounded-2xl bg-white px-5 pb-5 text-center'>
+          {modalType === 'delete' ? (
+            <p className='mb-[30px] flex w-full justify-center pt-11 text-16_B text-black'>
+              댓글을 삭제하시겠습니까?
+            </p>
+          ) : modalType === 'edit' ? (
+            <div className='mb-5 flex flex-col gap-5 pt-5'>
+              <span className='text-16_B text-black'>댓글 수정</span>
+              <TextareaInput
+                value={editMessage}
+                onChange={setEditMessage}
+                className='border-1 border-gray-100 text-16_body_M leading-[180%] tracking-[-0.4px] text-gray-500 shadow-none focus:ring-0 focus:outline-none'
+              />
+            </div>
+          ) : null}
           <div className='flex w-full justify-between gap-2.5'>
             <ModalCancel className='w-1/2'>
-              <Button variant='secondary'>아니요</Button>
+              <Button
+                variant='secondary'
+                onClick={modalType === 'edit' ? handleCancelEdit : closeModal}
+              >
+                {modalType === 'delete' ? '아니요' : '취소'}
+              </Button>
             </ModalCancel>
             <ModalAction className='w-1/2'>
               <Button
-                onClick={() => {
-                  handleDeleteComment();
-                }}
+                onClick={
+                  modalType === 'delete'
+                    ? handleDeleteComment
+                    : handleEditSubmit
+                }
+                disabled={modalType === 'edit' && !isEditable}
+                color={
+                  modalType === 'edit' && !isEditable ? 'disable' : 'normal'
+                }
               >
-                네
+                {modalType === 'delete' ? '네' : '수정'}
               </Button>
             </ModalAction>
           </div>

--- a/src/components/pages/groupDetail/CommentList/CommentList.tsx
+++ b/src/components/pages/groupDetail/CommentList/CommentList.tsx
@@ -4,15 +4,7 @@ import { useGetComments } from '@/hooks/postHooks/postHook';
 import { cn } from '@/lib/utils';
 import CommentItem from '../CommentItem/CommentItem';
 
-const CommentList = ({
-  setMessage,
-  setEditCommentId,
-  setOriginalMessage,
-}: {
-  setMessage: (message: string) => void;
-  setEditCommentId: (id: string) => void;
-  setOriginalMessage: (message: string) => void;
-}) => {
+const CommentList = () => {
   const params = useParams();
   const groupId = params?.groupId as string;
   const postId = params?.postId as string;
@@ -24,9 +16,6 @@ const CommentList = ({
         <CommentItem
           key={comment.id}
           comment={comment}
-          setMessage={setMessage}
-          setEditCommentId={setEditCommentId}
-          setOriginalMessage={setOriginalMessage}
           className={cn(
             index === 0 && 'pt-0',
             index === (comments.data?.length ?? 0) - 1 && 'pb-0'

--- a/src/components/pages/groupDetail/PostDetailWrapper.tsx
+++ b/src/components/pages/groupDetail/PostDetailWrapper.tsx
@@ -1,16 +1,13 @@
 'use client';
 
-import { useState } from 'react';
 import { useParams } from 'next/navigation';
-import Button from '@/components/common/Button/Button';
-import SendIcon from '@/components/icons/SendIcon';
+import Header from '@/components/common/Header/Header';
+import MessageInput from '@/components/common/MessageInput/MessageInput';
 import {
   useCreateComment,
   useGetPost,
   useReactionPost,
-  useUpdateComment,
 } from '@/hooks/postHooks/postHook';
-import { hasProfanity } from '@/lib/utils';
 import CommentList from './CommentList/CommentList';
 import PostCard from './PostCard/PostCard';
 import { CheckButton, CommentButton } from '.';
@@ -19,19 +16,13 @@ const PostDetailWrapper = () => {
   const params = useParams();
   const groupId = params?.groupId as string;
   const postId = params?.postId as string;
-  const [message, setMessage] = useState('');
-  const [editCommentId, setEditCommentId] = useState<string | null>(null);
-  const [isValidText, setIsValidText] = useState(true);
-  const [originalMessage, setOriginalMessage] = useState('');
   const { data: post, isLoading, error } = useGetPost({ groupId, postId });
   const { mutate: reactionPost } = useReactionPost();
   const { mutate: createComment } = useCreateComment();
-  const { mutate: updateComment } = useUpdateComment();
-  const placeholder = '댓글을 입력해 보세요';
+
   if (isLoading) return <div>로딩 중...</div>;
   if (error) return <div>오류 발생: {error.message}</div>;
   if (!post) return <div>데이터 없음</div>;
-  const isEditDisabled = message === originalMessage;
 
   const handleReaction = () => {
     reactionPost({
@@ -41,53 +32,18 @@ const PostDetailWrapper = () => {
     });
   };
 
-  const handleCancelEdit = () => {
-    setEditCommentId(null);
-    setMessage('');
-    setOriginalMessage('');
-    setIsValidText(true);
-  };
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setMessage(e.target.value);
-    setIsValidText(!hasProfanity(e.target.value));
-  };
-
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    if (hasProfanity(message)) {
-      setIsValidText(false);
-      return;
-    }
-
+  const handleSubmit = (message: string) => {
     createComment({ groupId, postId, content: message });
-    setMessage('');
-    setIsValidText(true);
-  };
-
-  const handleUpdateComment = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    if (isEditDisabled) {
-      return;
-    } else if (hasProfanity(message)) {
-      setIsValidText(false);
-      return;
-    }
-
-    updateComment({
-      groupId,
-      postId,
-      commentId: editCommentId as string,
-      content: message,
-    });
-    setEditCommentId(null);
-    setMessage('');
-    setOriginalMessage('');
   };
 
   return (
     <>
-      <div className='flex w-full flex-col px-4 pb-4'>
+      <Header
+        title='게시글 상세'
+        hasNotification={false}
+        hasSearch={false}
+      />
+      <div className='mb-[89px] flex w-full flex-col px-4'>
         <PostCard
           post={post}
           type='detail'
@@ -98,50 +54,13 @@ const PostDetailWrapper = () => {
           />
           <CommentButton commentCount={post.commentCount} />
         </PostCard>
-        <CommentList
-          setMessage={setMessage}
-          setEditCommentId={setEditCommentId}
-          setOriginalMessage={setOriginalMessage}
-        />
+        <CommentList />
       </div>
-      <div className='flex flex-col gap-2.5 border-t border-gray-100 p-4'>
-        <div className='flex gap-2.5'>
-          {editCommentId && (
-            <Button
-              className='inline-block'
-              size='sm'
-              onClick={handleCancelEdit}
-            >
-              수정 취소
-            </Button>
-          )}
-          {/* TODO: 서경님 메시지 입력 컴포넌트 수정해서 가져오기 */}
-          <form
-            onSubmit={editCommentId ? handleUpdateComment : handleSubmit}
-            className='flex h-11 w-full flex-1 gap-2.5 rounded-[100px] border-1 border-gray-100 bg-gray-25 py-1.5 pr-2 pl-3.5'
-          >
-            <input
-              type='text'
-              value={message}
-              onChange={handleChange}
-              placeholder={placeholder}
-              className='flex w-full items-center text-16_M text-gray-950 placeholder:text-16_M placeholder:leading-normal placeholder:tracking-[-0.35px] placeholder:text-gray-400 focus:outline-none'
-            />
-            <Button
-              type='submit'
-              variant='primary'
-              className='flex w-11 shrink-0 items-center justify-center self-stretch rounded-[100px] px-3 py-1.5'
-            >
-              <SendIcon className='aspect-square h-4 w-4 shrink-0' />
-            </Button>
-          </form>
-        </div>
-        {!isValidText && (
-          <p className='pl-2 text-12_M text-red-500'>
-            부적절한 단어가 포함되어 있습니다
-          </p>
-        )}
-      </div>
+      <MessageInput
+        type='comment'
+        sendMessage={handleSubmit}
+        maxLength={150}
+      />
     </>
   );
 };


### PR DESCRIPTION
### 무엇을 위한 PR인가요? (: 뒤 설명 추가)

- 리팩토링: 기존 채팅 메시지 인풋 컴포넌트의 재사용성을 높이고, 댓글 수정 기능을 개선했습니다.


### 변경사항 및 이유 (bullet 으로 구분)

- 기존 채팅 메시지 인풋 컴포넌트 재사용 컴포넌트로 분리: 여러 페이지에서 사용되는 채팅 메시지 입력 필드를 재사용 가능한 컴포넌트로 분리하여 코드 중복을 줄이고 유지보수성을 높였습니다.

- 페이지 내 댓글 수정 기능 모달로 변경: 기존 댓글 수정 방식이 사용자 경험을 저해하는 부분이 있어, 모달(Modal) 형태로 변경하여 더욱 직관적이고 편리하게 댓글을 수정할 수 있도록 개선했습니다.

### 작업 내역 (bullet 으로 구분)

- 채팅 메시지 입력 관련 UI 및 로직을 [MessageInput]으로 분리.

- 댓글 수정 시 [기존 방식 설명] 대신 모달을 띄우는 로직 구현.

- 모달 내에서 댓글 내용을 입력하고 수정할 수 있는 UI 구현.

- 댓글 수정 완료 시 모달이 닫히고 변경된 내용이 즉시 반영되도록 구현.

### ?작업 후 기대 동작(스크린샷)

https://github.com/user-attachments/assets/780abc04-5d30-4c6b-8b00-744eee44a9c3

### ?PR 특이 사항

- 기존 채팅에서 사용하던 메시지인풋을 'MessageInput'으로 추가생성해 욕설방지와 토스트 기능 추가한 새로운 컴포넌트를 생성하였으니 적용하면 좋을 듯 합니다.