### PR TITLE
[Feature/issue-355] 채팅방 메세지 목록 조회

### DIFF
--- a/src/components/pages/groupDetail/Chat/Chat.tsx
+++ b/src/components/pages/groupDetail/Chat/Chat.tsx
@@ -2,14 +2,18 @@
 
 import { Skeleton } from '@/components/ui/skeleton';
 import { useGetUserId } from '@/hooks/userHooks/userHooks';
+import { GroupInfo } from '@/types/group';
 import PostNotice from '../PostNotice/PostNotice';
 import ChatArea from './ChatArea';
 import ChatInfo from './ChatInfo';
 
 const hasNotice = true;
-const chatRoomId = 1;
 
-const Chat = () => {
+interface ChatProps {
+  groupInfo?: GroupInfo;
+}
+
+const Chat = ({ groupInfo }: ChatProps) => {
   const { data: userId, isPending, isError } = useGetUserId();
 
   if (isPending)
@@ -20,7 +24,7 @@ const Chat = () => {
       </div>
     );
 
-  if (isError || !userId) {
+  if (isError || !userId || !groupInfo?.isMember) {
     return (
       <div className='flex flex-col items-center justify-center px-4 py-5'>
         <p className='font-semibold text-gray-500'>
@@ -37,7 +41,7 @@ const Chat = () => {
         {hasNotice && <PostNotice />}
         <ChatArea
           userId={userId.data?.userId}
-          chatRoomId={chatRoomId}
+          chatRoomId={groupInfo?.chatRoomId}
         />
       </div>
     </div>

--- a/src/components/pages/groupDetail/Chat/Chat.tsx
+++ b/src/components/pages/groupDetail/Chat/Chat.tsx
@@ -35,10 +35,10 @@ const Chat = ({ groupInfo }: ChatProps) => {
   }
 
   return (
-    <div className='px-4'>
+    <div className='px-4 pt-4 pb-6'>
       <div className='flex flex-col rounded-[16px] bg-[#fffcfc] px-4 py-4 shadow-[0px_0px_6px_0px_rgba(0,0,0,0.16)]'>
-        <ChatInfo />
-        {hasNotice && <PostNotice />}
+        <ChatInfo groupInfo={groupInfo} />
+        {hasNotice && <PostNotice className='mt-3.5' />}
         <ChatArea
           userId={userId.data?.userId}
           chatRoomId={groupInfo?.chatRoomId}

--- a/src/components/pages/groupDetail/Chat/ChatArea.tsx
+++ b/src/components/pages/groupDetail/Chat/ChatArea.tsx
@@ -4,7 +4,6 @@ import {
   useChatWebSocket,
   useGetChatHistory,
 } from '@/hooks/chatHooks/chatHooks';
-// import { CHAT_SAMPLE_DATA } from '@/mocks/handlers/chatHandlers';
 import { ChatMessage } from '@/types/chat';
 import ChatMessageInput from './ChatMessageInput';
 import ChatMessageList from './ChatMessageList';
@@ -26,9 +25,10 @@ const ChatArea = ({ userId, chatRoomId }: ChatAreaProps) => {
     data: chatHistory,
     fetchNextPage,
     hasNextPage,
+    isPending,
     isFetchingNextPage,
+    status,
   } = useGetChatHistory(chatRoomId, 20);
-
   if (!isConnected) {
     return (
       <div className='relative flex h-[60dvh] flex-col items-center justify-center gap-2'>
@@ -41,10 +41,35 @@ const ChatArea = ({ userId, chatRoomId }: ChatAreaProps) => {
     );
   }
 
+  if (status === 'error') {
+    return (
+      <div className='relative flex h-[60dvh] flex-col items-center justify-center gap-2'>
+        <p className='font-semibold text-gray-500'>
+          메세지를 불러오지 못했습니다.
+        </p>
+        <ChatMessageInput
+          disabled={true}
+          sendMessage={() => {}}
+        />
+      </div>
+    );
+  }
+
+  if (isPending) {
+    return (
+      <div className='relative flex h-[60dvh] flex-col items-center justify-center gap-2'>
+        <p className='font-semibold text-gray-500'>채팅방 연결 중...</p>
+        <ChatMessageInput
+          disabled={true}
+          sendMessage={() => {}}
+        />
+      </div>
+    );
+  }
+
   const historyMessages: ChatMessage[] = (chatHistory?.pages ?? [])
     .flatMap((page) => page.data ?? [])
     .reverse();
-  // const historyMessages = CHAT_SAMPLE_DATA;
 
   const allMessages = [...historyMessages, ...liveMessages];
 
@@ -57,6 +82,7 @@ const ChatArea = ({ userId, chatRoomId }: ChatAreaProps) => {
             messages={allMessages}
             fetchPrev={fetchNextPage}
             hasPrev={!!hasNextPage && !isFetchingNextPage}
+            isFetchingNextPage={isFetchingNextPage}
           />
           <ChatMessageInput
             disabled={!isConnected}

--- a/src/components/pages/groupDetail/Chat/ChatDateDivider.tsx
+++ b/src/components/pages/groupDetail/Chat/ChatDateDivider.tsx
@@ -8,7 +8,7 @@ interface ChatDateDividerProps {
 const ChatDateDivider = ({ date }: ChatDateDividerProps) => (
   <div className='flex items-center justify-center px-1.5 py-4'>
     <span className='text-13_M leading-normal tracking-[-0.325px] text-gray-800'>
-      {format(parseISO(date), 'yyyy년 MM월 dd일 (eee)', { locale: ko })}
+      {format(parseISO(date), 'yy년 MM월 dd일 (eee)', { locale: ko })}
     </span>
   </div>
 );

--- a/src/components/pages/groupDetail/Chat/ChatDateDivider.tsx
+++ b/src/components/pages/groupDetail/Chat/ChatDateDivider.tsx
@@ -1,0 +1,16 @@
+import { format, parseISO } from 'date-fns';
+import { ko } from 'date-fns/locale';
+
+interface ChatDateDividerProps {
+  date: string;
+}
+
+const ChatDateDivider = ({ date }: ChatDateDividerProps) => (
+  <div className='flex items-center justify-center px-1.5 py-4'>
+    <span className='text-13_M leading-normal tracking-[-0.325px] text-gray-800'>
+      {format(parseISO(date), 'yyyy년 MM월 dd일 (eee)', { locale: ko })}
+    </span>
+  </div>
+);
+
+export default ChatDateDivider;

--- a/src/components/pages/groupDetail/Chat/ChatDateDivider.tsx
+++ b/src/components/pages/groupDetail/Chat/ChatDateDivider.tsx
@@ -6,7 +6,7 @@ interface ChatDateDividerProps {
 }
 
 const ChatDateDivider = ({ date }: ChatDateDividerProps) => (
-  <div className='flex items-center justify-center px-1.5 py-4'>
+  <div className='flex items-center justify-center px-4 py-1.5'>
     <span className='text-13_M leading-normal tracking-[-0.325px] text-gray-800'>
       {format(parseISO(date), 'yy년 MM월 dd일 (eee)', { locale: ko })}
     </span>

--- a/src/components/pages/groupDetail/Chat/ChatInfo.tsx
+++ b/src/components/pages/groupDetail/Chat/ChatInfo.tsx
@@ -7,7 +7,7 @@ interface ChatInfoProps {
 }
 
 const ChatInfo = ({ groupInfo }: ChatInfoProps) => (
-  <div className='flex items-center gap-2.5'>
+  <div className='mb-2.5 flex items-center gap-2.5'>
     <ProfileImage
       size='sm'
       src={groupInfo?.performance?.poster}

--- a/src/components/pages/groupDetail/Chat/ChatInfo.tsx
+++ b/src/components/pages/groupDetail/Chat/ChatInfo.tsx
@@ -1,20 +1,28 @@
-import ProfileIcon from '@/components/icons/ProfileIcon';
+import ProfileImage from '@/components/common/ProfileImage/ProfileImage';
 import UserIcon from '@/components/icons/UserIcon';
+import { GroupInfo } from '@/types/group';
 
-const title = '8/16 공연 같이 가요';
-const memberCount = 8;
+interface ChatInfoProps {
+  groupInfo?: GroupInfo;
+}
 
-const ChatInfo = () => (
-  <div className='mb-3.5 flex items-center gap-2.5'>
-    <ProfileIcon className='aspect-square h-10 w-10 shrink-0' />
+const ChatInfo = ({ groupInfo }: ChatInfoProps) => (
+  <div className='flex items-center gap-2.5'>
+    <ProfileImage
+      size='sm'
+      src={groupInfo?.performance?.poster}
+      alt={groupInfo?.performance?.title}
+      border={false}
+      className='aspect-square shrink-0'
+    />
     <div className='flex flex-col gap-2'>
       <span className='text-14_B leading-normal tracking-[-0.35px] text-gray-950'>
-        {title}
+        {groupInfo?.title}
       </span>
       <div className='flex items-center gap-0.5'>
         <UserIcon className='aspect-square h-4 w-4 text-gray-600' />
         <span className='shrink-0 text-13_M leading-normal tracking-[-0.325px] text-gray-600'>
-          {memberCount}
+          {groupInfo?.memberCount}
         </span>
       </div>
     </div>

--- a/src/components/pages/groupDetail/Chat/ChatMessage.tsx
+++ b/src/components/pages/groupDetail/Chat/ChatMessage.tsx
@@ -14,9 +14,9 @@ const ChatMessage = ({ message, isMine }: ChatMessageProps) => {
         <span className='text-right text-12_M leading-normal tracking-[-0.3px] text-gray-500'>
           {formatToKST(message.createdAt)}
         </span>
-        <div className='rounded-l-[20px] rounded-tr-[2px] rounded-br-[20px] bg-[#ececec] p-3.5'>
+        <div className='rounded-l-[20px] rounded-tr-[2px] rounded-br-[20px] bg-[#ececec] px-4 py-2.5'>
           <span className='text-16_M leading-normal tracking-[-0.4px] text-gray-950'>
-            {message.chatId}: {message.content}
+            {message.content}
           </span>
         </div>
       </div>
@@ -36,9 +36,9 @@ const ChatMessage = ({ message, isMine }: ChatMessageProps) => {
           {message.senderName}
         </span>
         <div className='flex items-end gap-1.5'>
-          <div className='rounded-tl-[2px] rounded-r-[20px] rounded-bl-[20px] bg-[#ececec] p-3.5'>
+          <div className='rounded-tl-[2px] rounded-r-[20px] rounded-bl-[20px] bg-[#ececec] px-4 py-2.5'>
             <span className='text-16_M leading-normal tracking-[-0.4px] text-gray-950'>
-              {message.chatId}: {message.content}
+              {message.content}
             </span>
           </div>
           <span className='text-left text-12_M leading-normal tracking-[-0.3px] text-gray-500'>

--- a/src/components/pages/groupDetail/Chat/ChatMessage.tsx
+++ b/src/components/pages/groupDetail/Chat/ChatMessage.tsx
@@ -1,6 +1,6 @@
-import { format } from 'date-fns';
 import ProfileIcon from '@/components/icons/ProfileIcon';
 import { ChatMessage as ChatMessageType } from '@/types/chat';
+import { formatToKST } from '@/utils/date';
 
 interface ChatMessageProps {
   message: ChatMessageType;
@@ -12,7 +12,7 @@ const ChatMessage = ({ message, isMine }: ChatMessageProps) => {
     return (
       <div className='flex items-end justify-end gap-2'>
         <span className='text-right text-12_M text-gray-500'>
-          {format(message.createdAt, 'yy.MM.dd hh:mm')}
+          {formatToKST(message.createdAt)}
         </span>
         <div className='rounded-l-[20px] rounded-tr-[2px] rounded-br-[20px] bg-[#ececec] p-3.5'>
           <span className='text-16_M leading-normal tracking-[-0.4px] text-gray-950'>
@@ -36,7 +36,7 @@ const ChatMessage = ({ message, isMine }: ChatMessageProps) => {
             </span>
           </div>
           <span className='text-left text-12_M text-gray-500'>
-            {format(message.createdAt, 'yy.MM.dd hh:mm')}
+            {formatToKST(message.createdAt)}
           </span>
         </div>
       </div>

--- a/src/components/pages/groupDetail/Chat/ChatMessage.tsx
+++ b/src/components/pages/groupDetail/Chat/ChatMessage.tsx
@@ -1,4 +1,4 @@
-import ProfileIcon from '@/components/icons/ProfileIcon';
+import ProfileImage from '@/components/common/ProfileImage/ProfileImage';
 import { ChatMessage as ChatMessageType } from '@/types/chat';
 import { formatToKST } from '@/utils/date';
 
@@ -10,13 +10,13 @@ interface ChatMessageProps {
 const ChatMessage = ({ message, isMine }: ChatMessageProps) => {
   if (isMine || message.isMine)
     return (
-      <div className='flex items-end justify-end gap-2'>
-        <span className='text-right text-12_M text-gray-500'>
+      <div className='flex items-end justify-end gap-1.5'>
+        <span className='text-right text-12_M leading-normal tracking-[-0.3px] text-gray-500'>
           {formatToKST(message.createdAt)}
         </span>
         <div className='rounded-l-[20px] rounded-tr-[2px] rounded-br-[20px] bg-[#ececec] p-3.5'>
           <span className='text-16_M leading-normal tracking-[-0.4px] text-gray-950'>
-            {message.content}
+            {message.chatId}: {message.content}
           </span>
         </div>
       </div>
@@ -24,18 +24,24 @@ const ChatMessage = ({ message, isMine }: ChatMessageProps) => {
 
   return (
     <div className='flex justify-start gap-2'>
-      <ProfileIcon className='aspect-square h-10 w-10 shrink-0' />
+      <ProfileImage
+        size='sm'
+        src={message.senderImage?.src}
+        alt={message.senderImage?.alt}
+        border={false}
+        className='aspect-square shrink-0'
+      />
       <div className='flex flex-col gap-2'>
         <span className='text-14_M leading-normal tracking-[-0.35px] text-gray-950'>
           {message.senderName}
         </span>
-        <div className='flex items-end gap-2'>
+        <div className='flex items-end gap-1.5'>
           <div className='rounded-tl-[2px] rounded-r-[20px] rounded-bl-[20px] bg-[#ececec] p-3.5'>
             <span className='text-16_M leading-normal tracking-[-0.4px] text-gray-950'>
-              {message.content}
+              {message.chatId}: {message.content}
             </span>
           </div>
-          <span className='text-left text-12_M text-gray-500'>
+          <span className='text-left text-12_M leading-normal tracking-[-0.3px] text-gray-500'>
             {formatToKST(message.createdAt)}
           </span>
         </div>

--- a/src/components/pages/groupDetail/Chat/ChatMessageList.tsx
+++ b/src/components/pages/groupDetail/Chat/ChatMessageList.tsx
@@ -15,6 +15,7 @@ interface ChatMessageListProps {
   messages: ChatMessageType[];
   fetchPrev: () => void;
   hasPrev: boolean;
+  isFetchingNextPage: boolean;
 }
 
 const ChatMessageList = ({
@@ -22,6 +23,7 @@ const ChatMessageList = ({
   messages,
   fetchPrev,
   hasPrev,
+  isFetchingNextPage,
 }: ChatMessageListProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const topRef = useRef<HTMLDivElement | null>(null);
@@ -108,31 +110,38 @@ const ChatMessageList = ({
   return (
     <div
       ref={containerRef}
-      className='scrollbar-hide flex h-full flex-col gap-5 overflow-y-scroll pt-1 pb-12'
+      className='scrollbar-hide flex h-full flex-col overflow-y-scroll pt-1 pb-15'
     >
       <div ref={topRef} />
-      {messages.map((message: ChatMessageType, index) => {
-        const prevMessage = messages[index - 1];
-        const showDateDivider =
-          !prevMessage
-          || !isSameDay(
-            parseISO(message.createdAt),
-            parseISO(prevMessage.createdAt)
-          );
-
-        return (
-          <div
-            key={message.chatId}
-            className='flex flex-col gap-5'
-          >
-            {showDateDivider && <ChatDateDivider date={message.createdAt} />}
-            <ChatMessage
-              message={message}
-              isMine={message.senderId === userId}
-            />
+      <div className='flex flex-col gap-5'>
+        {isFetchingNextPage && (
+          <div className='mt-5 flex w-full items-center justify-center text-13_M text-gray-400'>
+            메세지 불러오는 중...
           </div>
-        );
-      })}
+        )}
+        {messages.map((message: ChatMessageType, index) => {
+          const prevMessage = messages[index - 1];
+          const showDateDivider =
+            !prevMessage
+            || !isSameDay(
+              parseISO(message.createdAt),
+              parseISO(prevMessage.createdAt)
+            );
+
+          return (
+            <div
+              key={message.chatId}
+              className='flex flex-col gap-5'
+            >
+              {showDateDivider && <ChatDateDivider date={message.createdAt} />}
+              <ChatMessage
+                message={message}
+                isMine={message.senderId === userId}
+              />
+            </div>
+          );
+        })}
+      </div>
       <div ref={bottomRef} />
     </div>
   );

--- a/src/components/pages/groupDetail/Chat/ChatMessageList.tsx
+++ b/src/components/pages/groupDetail/Chat/ChatMessageList.tsx
@@ -121,7 +121,10 @@ const ChatMessageList = ({
           );
 
         return (
-          <div key={message.chatId}>
+          <div
+            key={message.chatId}
+            className='flex flex-col gap-5'
+          >
             {showDateDivider && <ChatDateDivider date={message.createdAt} />}
             <ChatMessage
               message={message}

--- a/src/components/pages/groupDetail/Chat/ChatMessageList.tsx
+++ b/src/components/pages/groupDetail/Chat/ChatMessageList.tsx
@@ -41,8 +41,6 @@ const ChatMessageList = ({
     }
   }, [hasPrev, fetchPrev]);
 
-  console.log('messages', messages);
-
   return (
     <div className='scrollbar-hide flex h-full flex-col gap-5 overflow-y-scroll pt-1 pb-12'>
       {/* <div ref={bottomRef} /> */}

--- a/src/components/pages/groupDetail/Chat/ChatMessageList.tsx
+++ b/src/components/pages/groupDetail/Chat/ChatMessageList.tsx
@@ -1,4 +1,10 @@
-import { useEffect, useRef } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
 import { isSameDay, parseISO } from 'date-fns';
 import { ChatMessage as ChatMessageType } from '@/types/chat';
 import ChatDateDivider from './ChatDateDivider';
@@ -17,33 +23,94 @@ const ChatMessageList = ({
   fetchPrev,
   hasPrev,
 }: ChatMessageListProps) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const topRef = useRef<HTMLDivElement | null>(null);
   const bottomRef = useRef<HTMLDivElement | null>(null);
-  // const topRef = useRef<HTMLDivElement | null>(null);
-  const prevLastMessageIdRef = useRef<number | null>(null);
 
+  const prevLastMessageIdRef = useRef<number | null>(null);
+  const prevHeightRef = useRef<number>(0);
+  const prevScrollTopRef = useRef<number>(0);
+
+  const [initialScrolled, setInitialScrolled] = useState(false);
+
+  // 채팅방 최초 입장 시 맨 아래로 스크롤
+  useEffect(() => {
+    if (
+      !messages.length
+      || userId === undefined
+      || initialScrolled
+      || !bottomRef.current
+    )
+      return;
+
+    bottomRef.current?.scrollIntoView({ behavior: 'auto' });
+    setInitialScrolled(true);
+  }, [messages, userId, initialScrolled]);
+
+  // 내가 채팅 보냈을 때 맨 아래로 스크롤
   useEffect(() => {
     if (!messages.length || userId === undefined) return;
 
     const lastMessage = messages[messages.length - 1];
+    const prevLastId = prevLastMessageIdRef.current;
 
-    if (lastMessage.chatId === prevLastMessageIdRef.current) return;
-
-    prevLastMessageIdRef.current = lastMessage.chatId;
-
-    if (lastMessage.senderId === userId) {
+    if (lastMessage.chatId !== prevLastId && lastMessage.senderId === userId) {
       bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+      prevLastMessageIdRef.current = lastMessage.chatId;
     }
   }, [messages, userId]);
 
+  // 이전 메세지 요청 전 스크롤 상태 저장
+  const handleFetchPrev = useCallback(async () => {
+    if (!containerRef.current) return;
+
+    const container = containerRef.current;
+    prevHeightRef.current = container.scrollHeight;
+    prevScrollTopRef.current = container.scrollTop;
+
+    await fetchPrev();
+  }, [fetchPrev]);
+
+  // fetch 후 스크롤 위치 복구
+  useLayoutEffect(() => {
+    if (!containerRef.current || !prevHeightRef.current) return;
+
+    const container = containerRef.current;
+    const newHeight = container.scrollHeight;
+    const scrollDiff = newHeight - prevHeightRef.current;
+
+    container.scrollTop = prevScrollTopRef.current + scrollDiff;
+
+    prevHeightRef.current = 0;
+    prevScrollTopRef.current = 0;
+  }, [messages]);
+
+  // IntersectionObserver로 현재 메세지 top에 도달하면 이전 메시지 요청
   useEffect(() => {
-    if (hasPrev) {
-      fetchPrev();
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          handleFetchPrev();
+        }
+      },
+      { threshold: 1.0 }
+    );
+
+    if (topRef.current) {
+      observer.observe(topRef.current);
     }
-  }, [hasPrev, fetchPrev]);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [hasPrev, handleFetchPrev]);
 
   return (
-    <div className='scrollbar-hide flex h-full flex-col gap-5 overflow-y-scroll pt-1 pb-12'>
-      {/* <div ref={bottomRef} /> */}
+    <div
+      ref={containerRef}
+      className='scrollbar-hide flex h-full flex-col gap-5 overflow-y-scroll pt-1 pb-12'
+    >
+      <div ref={topRef} />
       {messages.map((message: ChatMessageType, index) => {
         const prevMessage = messages[index - 1];
         const showDateDivider =
@@ -64,7 +131,6 @@ const ChatMessageList = ({
         );
       })}
       <div ref={bottomRef} />
-      {/* {hasPrev && <div ref={topRef} />} */}
     </div>
   );
 };

--- a/src/components/pages/groupDetail/Chat/ChatMessageList.tsx
+++ b/src/components/pages/groupDetail/Chat/ChatMessageList.tsx
@@ -1,21 +1,74 @@
+import { useEffect, useRef } from 'react';
+import { isSameDay, parseISO } from 'date-fns';
 import { ChatMessage as ChatMessageType } from '@/types/chat';
+import ChatDateDivider from './ChatDateDivider';
 import ChatMessage from './ChatMessage';
 
 interface ChatMessageListProps {
   userId?: number;
   messages: ChatMessageType[];
+  fetchPrev: () => void;
+  hasPrev: boolean;
 }
 
-const ChatMessageList = ({ userId, messages }: ChatMessageListProps) => (
-  <div className='scrollbar-hide flex h-full flex-col gap-5 overflow-y-scroll pt-5 pb-17.5'>
-    {messages.map((message: ChatMessageType) => (
-      <ChatMessage
-        key={message.chatId}
-        message={message}
-        isMine={message.senderId === userId}
-      />
-    ))}
-  </div>
-);
+const ChatMessageList = ({
+  userId,
+  messages,
+  fetchPrev,
+  hasPrev,
+}: ChatMessageListProps) => {
+  const bottomRef = useRef<HTMLDivElement | null>(null);
+  // const topRef = useRef<HTMLDivElement | null>(null);
+  const prevLastMessageIdRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!messages.length || userId === undefined) return;
+
+    const lastMessage = messages[messages.length - 1];
+
+    if (lastMessage.chatId === prevLastMessageIdRef.current) return;
+
+    prevLastMessageIdRef.current = lastMessage.chatId;
+
+    if (lastMessage.senderId === userId) {
+      bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [messages, userId]);
+
+  useEffect(() => {
+    if (hasPrev) {
+      fetchPrev();
+    }
+  }, [hasPrev, fetchPrev]);
+
+  console.log('messages', messages);
+
+  return (
+    <div className='scrollbar-hide flex h-full flex-col gap-5 overflow-y-scroll pt-1 pb-12'>
+      {/* <div ref={bottomRef} /> */}
+      {messages.map((message: ChatMessageType, index) => {
+        const prevMessage = messages[index - 1];
+        const showDateDivider =
+          !prevMessage
+          || !isSameDay(
+            parseISO(message.createdAt),
+            parseISO(prevMessage.createdAt)
+          );
+
+        return (
+          <div key={message.chatId}>
+            {showDateDivider && <ChatDateDivider date={message.createdAt} />}
+            <ChatMessage
+              message={message}
+              isMine={message.senderId === userId}
+            />
+          </div>
+        );
+      })}
+      <div ref={bottomRef} />
+      {/* {hasPrev && <div ref={topRef} />} */}
+    </div>
+  );
+};
 
 export default ChatMessageList;

--- a/src/components/pages/groupDetail/Chat/ChatMessageList.tsx
+++ b/src/components/pages/groupDetail/Chat/ChatMessageList.tsx
@@ -115,7 +115,7 @@ const ChatMessageList = ({
       <div ref={topRef} />
       <div className='flex flex-col gap-5'>
         {isFetchingNextPage && (
-          <div className='mt-5 flex w-full items-center justify-center text-13_M text-gray-400'>
+          <div className='flex w-full items-center justify-center pt-5 text-13_M text-gray-400'>
             메세지 불러오는 중...
           </div>
         )}
@@ -124,8 +124,8 @@ const ChatMessageList = ({
           const showDateDivider =
             !prevMessage
             || !isSameDay(
-              parseISO(message.createdAt),
-              parseISO(prevMessage.createdAt)
+              message.createdAt.split('T')[0],
+              parseISO(prevMessage.createdAt.split('T')[0])
             );
 
           return (

--- a/src/components/pages/groupDetail/GroupTabs.tsx
+++ b/src/components/pages/groupDetail/GroupTabs.tsx
@@ -2,11 +2,17 @@
 
 import { useState } from 'react';
 import { Tabs } from '@/components/common';
+import { GroupInfo } from '@/types/group';
+import Chat from './Chat/Chat';
 import GroupPosts from './GroupPosts';
 
 const groupTabs = ['게시글', '채팅', '캘린더'];
 
-const GroupTabs = () => {
+interface GroupTabsProps {
+  groupInfo?: GroupInfo;
+}
+
+const GroupTabs = ({ groupInfo }: GroupTabsProps) => {
   const [selectedTab, setSelectedTab] = useState(groupTabs[0]);
 
   return (
@@ -18,7 +24,7 @@ const GroupTabs = () => {
       />
       <>
         {selectedTab === '게시글' && <GroupPosts />}
-        {/* {selectedTab === '채팅' && <Chat />} */}
+        {selectedTab === '채팅' && <Chat groupInfo={groupInfo} />}
         {/* {selectedTab === '캘린더' && <캘린더 />} */}
       </>
     </div>

--- a/src/components/pages/groupDetail/GroupWrapper.tsx
+++ b/src/components/pages/groupDetail/GroupWrapper.tsx
@@ -33,7 +33,7 @@ const GroupWrapper = ({ groupId }: GroupWrapperProps) => {
       {isLoggedIn && isMember && (
         <>
           <GroupMembers />
-          <GroupTabs />
+          <GroupTabs groupInfo={groupInfo?.data} />
         </>
       )}
     </div>

--- a/src/components/pages/groupDetail/PostNotice/PostNotice.tsx
+++ b/src/components/pages/groupDetail/PostNotice/PostNotice.tsx
@@ -5,21 +5,28 @@ import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import ChevronDownIcon from '@/components/icons/ChevronDownIcon';
 import MegaphoneIcon from '@/components/icons/MegaphoneIcon';
+import { useGetGroupPosts } from '@/hooks/groupHooks/groupHooks';
+import { cn } from '@/lib/utils';
 
-const postId = 'post123';
-const content =
-  '하고 싶은 곡 여기 댓글에 달아주세요~\n(라이브나 공연영상 등 참고 영상 링크 다셔도 좋습니당)\n\n<4월까지 인당 1곡 이상>';
+interface PostNoticeProps {
+  className?: string;
+}
 
-const PostNotice = () => {
+const PostNotice = ({ className }: PostNoticeProps) => {
   const { groupId } = useParams<{ groupId: string }>();
+  const { data: posts } = useGetGroupPosts({ groupId });
   const [isOpen, setIsOpen] = useState(false);
+
+  if (posts?.posts.length === 0 || !posts?.posts[0].isPinned) {
+    return null;
+  }
 
   const toggleNotice = () => {
     setIsOpen((prev) => !prev);
   };
 
   return (
-    <div className='relative mb-11'>
+    <div className={cn('relative mb-11', className)}>
       <div className='absolute top-0 z-1 rounded-[12px] bg-primary-100 px-4.5 py-2.5'>
         <div className='flex items-start justify-between gap-2'>
           <div className='flex w-full flex-1 items-start gap-2 overflow-hidden'>
@@ -31,7 +38,9 @@ const PostNotice = () => {
                   : 'line-clamp-1 overflow-hidden text-ellipsis'
               }`}
             >
-              <Link href={`/groups/${groupId}/posts/${postId}`}>{content}</Link>
+              <Link href={`/groups/${groupId}/posts/${posts?.posts[0].id}`}>
+                {posts?.posts[0].content}
+              </Link>
             </div>
           </div>
 

--- a/src/hooks/chatHooks/chatHooks.ts
+++ b/src/hooks/chatHooks/chatHooks.ts
@@ -16,9 +16,9 @@ import {
 import { getNewAccessToken } from '@/utils/getNewAccessToken';
 
 /**
- * 채팅 웹소켓 연결
+ * [WebSocket] 채팅 웹소켓 구독, 연결, 메세지 전송
  * @param chatRoomId
- * @returns { messages, sendMessage, isConnected }
+ * @returns { messages, sendMessage, isConnected, statusMessage }
  */
 export const useChatWebSocket = (
   userId: number | undefined,
@@ -120,6 +120,12 @@ export const useChatWebSocket = (
   return { messages, sendMessage, isConnected, statusMessage };
 };
 
+/**
+ * [Http] 채팅방 메세지 목록 조회 (무한스크롤)
+ * @param chatRoomId
+ * @param size
+ * @returns
+ */
 export const useGetChatHistory = (
   chatRoomId: GetChatHistoryRequest['chatRoomId'],
   size?: CursorRequest['size']

--- a/src/hooks/chatHooks/chatHooks.ts
+++ b/src/hooks/chatHooks/chatHooks.ts
@@ -2,16 +2,18 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Client } from '@stomp/stompjs';
-// import { InfiniteData, useInfiniteQuery } from '@tanstack/react-query';
-// import { AxiosResponse } from 'axios';
+import { InfiniteData, useInfiniteQuery } from '@tanstack/react-query';
 import SockJS from 'sockjs-client';
+import { CHAT_QUERY_KEY } from '@/constants/queryKeys';
 import { getAccessToken } from '@/lib/apiFetcher';
-import { ChatMessage } from '@/types/chat';
+import { chatServiceApi } from '@/services/chatService';
+import { ApiResponse, CursorRequest } from '@/types/api';
+import {
+  ChatMessage,
+  GetChatHistoryRequest,
+  GetChatHistoryResponse,
+} from '@/types/chat';
 import { getNewAccessToken } from '@/utils/getNewAccessToken';
-// import { CHAT_QUERY_KEY } from '@/constants/queryKeys';
-// import { chatServiceApi } from '@/services/chatService';
-// import { ApiResponse, CursorRequest } from '@/types/api';
-// import { GetChatMessageListResponse } from '@/types/chat';
 
 /**
  * 채팅 웹소켓 연결
@@ -118,42 +120,21 @@ export const useChatWebSocket = (
   return { messages, sendMessage, isConnected, statusMessage };
 };
 
-// export const useGetChatMessageList = (size: CursorRequest['size']) =>
-//   useInfiniteQuery<
-//     AxiosResponse<GetChatMessageListResponse>,
-//     ApiResponse,
-//     InfiniteData<AxiosResponse<GetChatMessageListResponse>>,
-//     string[],
-//     number | undefined
-//   >({
-//     queryKey: [CHAT_QUERY_KEY.chat],
-//     queryFn: ({ pageParam }) =>
-//       chatServiceApi.getChatMessageList({
-//         // chatRoomId,
-//         cursorId: pageParam,
-//         size,
-//       }),
-//     initialPageParam: undefined,
-//     getNextPageParam: (lastPage) =>
-//       lastPage.data.hasNext ? lastPage.data.cursorId : undefined,
-//   });
-
-// export const useGetChatMessageList = (size: CursorRequest['size']) =>
-//   useInfiniteQuery<
-//     AxiosResponse<GetChatMessageListResponse>,
-//     ApiResponse,
-//     InfiniteData<AxiosResponse<GetChatMessageListResponse>>,
-//     string[],
-//     number | undefined
-//   >({
-//     queryKey: [CHAT_QUERY_KEY.chat],
-//     queryFn: ({ pageParam }) =>
-//       chatServiceApi.getChatMessageList({
-//         // chatRoomId,
-//         cursorId: pageParam,
-//         size,
-//       }),
-//     initialPageParam: undefined,
-//     getNextPageParam: (lastPage) =>
-//       lastPage.data.hasNext ? lastPage.data.cursorId : undefined,
-//   });
+export const useGetChatHistory = (
+  chatRoomId: GetChatHistoryRequest['chatRoomId'],
+  size?: CursorRequest['size']
+) =>
+  useInfiniteQuery<
+    GetChatHistoryResponse,
+    ApiResponse,
+    InfiniteData<GetChatHistoryResponse>,
+    string[],
+    number | undefined
+  >({
+    queryKey: [CHAT_QUERY_KEY.chat, chatRoomId.toString()],
+    queryFn: ({ pageParam }) =>
+      chatServiceApi.getChatHistory({ chatRoomId, cursorId: pageParam, size }),
+    getNextPageParam: (lastPage) =>
+      lastPage.hasNext ? lastPage.cursorId : undefined,
+    initialPageParam: undefined,
+  });

--- a/src/mocks/browser.ts
+++ b/src/mocks/browser.ts
@@ -1,4 +1,5 @@
 import { setupWorker } from 'msw/browser';
+// import { chatHandlers } from './handlers/chatHandlers';
 import { groupsHandlers } from './handlers/groupsHandlers';
 import { nicknameHandlers } from './handlers/nicknameHandlers';
 import { notificationHandlers } from './handlers/notificationHandlers';
@@ -17,4 +18,5 @@ export const worker = setupWorker(
   ...usersHandlers,
   ...nicknameHandlers,
   ...reportHandlers
+  // ...chatHandlers
 );

--- a/src/mocks/handlers/chatHandlers.ts
+++ b/src/mocks/handlers/chatHandlers.ts
@@ -1,4 +1,4 @@
-// import { http } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { ChatMessage } from '@/types/chat';
 
 export const CHAT_SAMPLE_DATA: ChatMessage[] = [
@@ -6,11 +6,6 @@ export const CHAT_SAMPLE_DATA: ChatMessage[] = [
     chatId: 1,
     senderId: 1,
     senderName: '토끼',
-    senderImage: {
-      id: 1,
-      src: '/images/rabbit.png',
-      alt: '토끼 프로필',
-    },
     content: '안녕하세요',
     createdAt: '2025-06-12T10:00:00Z',
     isMine: false,
@@ -25,7 +20,7 @@ export const CHAT_SAMPLE_DATA: ChatMessage[] = [
       alt: '문영 프로필',
     },
     content: '네 안녕하세요',
-    createdAt: '2025-06-12T10:01:00Z',
+    createdAt: '2025-06-12T13:01:00Z',
     isMine: true,
   },
   {
@@ -38,20 +33,15 @@ export const CHAT_SAMPLE_DATA: ChatMessage[] = [
       alt: '문영 프로필',
     },
     content: '만나서 반갑습니다',
-    createdAt: '2025-06-12T10:01:30Z',
+    createdAt: '2025-06-12T13:01:30Z',
     isMine: true,
   },
   {
     chatId: 4,
     senderId: 1,
     senderName: '토끼',
-    senderImage: {
-      id: 1,
-      src: '/images/rabbit.png',
-      alt: '토끼 프로필',
-    },
     content: '예. ^^',
-    createdAt: '2025-06-12T10:02:00Z',
+    createdAt: '2025-06-12T17:55:00Z',
     isMine: false,
   },
   {
@@ -65,7 +55,7 @@ export const CHAT_SAMPLE_DATA: ChatMessage[] = [
     },
     content:
       '제 이름은 김수한무 거북이와 두루미 삼천갑자 동방삭 치치카포 사리사리센타 워리워리 세브리깡 무두셀라 구름이 허리케인에 담벼락 담벼락에 서생원 서생원에 고양이 고양이엔 바둑이 바둑이는 돌돌이 입니다',
-    createdAt: '2025-06-12T10:02:30Z',
+    createdAt: '2025-06-12T19:32:30Z',
     isMine: true,
   },
   {
@@ -78,7 +68,7 @@ export const CHAT_SAMPLE_DATA: ChatMessage[] = [
       alt: '문영 프로필',
     },
     content: '조금 길죠?',
-    createdAt: '2025-06-12T10:03:00Z',
+    createdAt: '2025-06-12T19:35:00Z',
     isMine: true,
   },
   {
@@ -87,25 +77,20 @@ export const CHAT_SAMPLE_DATA: ChatMessage[] = [
     senderName: '말하는 감자',
     senderImage: {
       id: 3,
-      src: '/images/potato.png',
+      src: 'http://www.kopis.or.kr/upload/pfmPoster/PF_PF262382_250403_132803.jpg',
       alt: '감자 프로필',
     },
     content:
       'Lorem ipsum dolor sit amet consectetur adipisicing elit. Sint minus asperiores, at a delectus dolores reprehenderit expedita omnis culpa nam autem qui neque quidem similique molestiae magnam alias nostrum maiores?',
-    createdAt: '2025-06-12T10:04:00Z',
+    createdAt: '2025-06-12T20:14:00Z',
     isMine: false,
   },
   {
     chatId: 8,
     senderId: 1,
     senderName: '토끼',
-    senderImage: {
-      id: 1,
-      src: '/images/rabbit.png',
-      alt: '토끼 프로필',
-    },
     content: '네?',
-    createdAt: '2025-06-12T10:04:20Z',
+    createdAt: '2025-06-12T20:14:20Z',
     isMine: false,
   },
   {
@@ -118,7 +103,7 @@ export const CHAT_SAMPLE_DATA: ChatMessage[] = [
       alt: '문영 프로필',
     },
     content: '?',
-    createdAt: '2025-06-12T10:04:40Z',
+    createdAt: '2025-06-12T20:15:40Z',
     isMine: true,
   },
   {
@@ -140,7 +125,7 @@ export const CHAT_SAMPLE_DATA: ChatMessage[] = [
     senderName: '말하는 감자',
     senderImage: {
       id: 3,
-      src: '/images/potato.png',
+      src: 'http://www.kopis.or.kr/upload/pfmPoster/PF_PF262382_250403_132803.jpg',
       alt: '감자 프로필',
     },
     content: '냉장고를 열었더니 잼이 있었어요',
@@ -151,21 +136,385 @@ export const CHAT_SAMPLE_DATA: ChatMessage[] = [
     chatId: 12,
     senderId: 1,
     senderName: '토끼',
-    senderImage: {
-      id: 1,
-      src: '/images/rabbit.png',
-      alt: '토끼 프로필',
-    },
     content: '그만.',
     createdAt: '2025-06-13T22:35:40Z',
     isMine: false,
   },
+  {
+    chatId: 13,
+    senderId: 1,
+    senderName: '토끼',
+    content: '지금 가는 중입니다.',
+    createdAt: '2025-06-13T23:02:00Z',
+    isMine: false,
+  },
+  {
+    chatId: 14,
+    senderId: 3,
+    senderName: '말하는 감자',
+    senderImage: {
+      id: 3,
+      src: 'http://www.kopis.or.kr/upload/pfmPoster/PF_PF262382_250403_132803.jpg',
+      alt: '감자 프로필',
+    },
+    content: '하하하 웃기네요',
+    createdAt: '2025-06-13T23:04:00Z',
+    isMine: false,
+  },
+  {
+    chatId: 15,
+    senderId: 4,
+    senderName: '문영',
+    senderImage: {
+      id: 2,
+      src: '/images/moonyoung.png',
+      alt: '문영 프로필',
+    },
+    content: '조심해서 오세요!',
+    createdAt: '2025-06-13T23:06:00Z',
+    isMine: true,
+  },
+  {
+    chatId: 16,
+    senderId: 1,
+    senderName: '토끼',
+    content: '넵넵',
+    createdAt: '2025-06-14T09:01:00Z',
+    isMine: false,
+  },
+  {
+    chatId: 17,
+    senderId: 3,
+    senderName: '말하는 감자',
+    senderImage: {
+      id: 3,
+      src: 'http://www.kopis.or.kr/upload/pfmPoster/PF_PF262382_250403_132803.jpg',
+      alt: '감자 프로필',
+    },
+    content: '오늘 날씨 좋네요',
+    createdAt: '2025-06-14T10:20:00Z',
+    isMine: false,
+  },
+  {
+    chatId: 18,
+    senderId: 4,
+    senderName: '문영',
+    senderImage: {
+      id: 2,
+      src: '/images/moonyoung.png',
+      alt: '문영 프로필',
+    },
+    content: '산책 가기 딱이네요',
+    createdAt: '2025-06-14T10:21:00Z',
+    isMine: true,
+  },
+  {
+    chatId: 19,
+    senderId: 1,
+    senderName: '토끼',
+    content: '전 실내파입니다',
+    createdAt: '2025-06-14T11:00:00Z',
+    isMine: false,
+  },
+  {
+    chatId: 20,
+    senderId: 4,
+    senderName: '문영',
+    senderImage: {
+      id: 2,
+      src: '/images/moonyoung.png',
+      alt: '문영 프로필',
+    },
+    content: '그럴 줄 알았어요',
+    createdAt: '2025-06-14T11:01:00Z',
+    isMine: true,
+  },
+  {
+    chatId: 21,
+    senderId: 3,
+    senderName: '말하는 감자',
+    senderImage: {
+      id: 3,
+      src: 'http://www.kopis.or.kr/upload/pfmPoster/PF_PF262382_250403_132803.jpg',
+      alt: '감자 프로필',
+    },
+    content: '게임 할 사람~',
+    createdAt: '2025-06-14T12:00:00Z',
+    isMine: false,
+  },
+  {
+    chatId: 22,
+    senderId: 1,
+    senderName: '토끼',
+    content: '접속 중...',
+    createdAt: '2025-06-14T12:02:00Z',
+    isMine: false,
+  },
+  {
+    chatId: 23,
+    senderId: 4,
+    senderName: '문영',
+    senderImage: {
+      id: 2,
+      src: '/images/moonyoung.png',
+      alt: '문영 프로필',
+    },
+    content: '저도 들어가요!',
+    createdAt: '2025-06-14T12:03:00Z',
+    isMine: true,
+  },
+  {
+    chatId: 24,
+    senderId: 3,
+    senderName: '말하는 감자',
+    senderImage: {
+      id: 3,
+      src: 'http://www.kopis.or.kr/upload/pfmPoster/PF_PF262382_250403_132803.jpg',
+      alt: '감자 프로필',
+    },
+    content: '오늘도 평화롭다',
+    createdAt: '2025-06-15T08:00:00Z',
+    isMine: false,
+  },
+  {
+    chatId: 25,
+    senderId: 1,
+    senderName: '토끼',
+    content: '좋은 하루~',
+    createdAt: '2025-06-15T08:30:00Z',
+    isMine: false,
+  },
+  {
+    chatId: 26,
+    senderId: 4,
+    senderName: '문영',
+    senderImage: {
+      id: 2,
+      src: '/images/moonyoung.png',
+      alt: '문영 프로필',
+    },
+    content: '모두 힘내세요!',
+    createdAt: '2025-06-15T08:45:00Z',
+    isMine: true,
+  },
+  {
+    chatId: 27,
+    senderId: 3,
+    senderName: '말하는 감자',
+    senderImage: {
+      id: 3,
+      src: 'http://www.kopis.or.kr/upload/pfmPoster/PF_PF262382_250403_132803.jpg',
+      alt: '감자 프로필',
+    },
+    content: '화이팅!!',
+    createdAt: '2025-06-15T09:00:00Z',
+    isMine: false,
+  },
+  {
+    chatId: 28,
+    senderId: 1,
+    senderName: '토끼',
+    content: '으랏차!',
+    createdAt: '2025-06-15T09:02:00Z',
+    isMine: false,
+  },
+  {
+    chatId: 29,
+    senderId: 4,
+    senderName: '문영',
+    senderImage: {
+      id: 2,
+      src: '/images/moonyoung.png',
+      alt: '문영 프로필',
+    },
+    content: '오늘 점심은 뭘 먹지?',
+    createdAt: '2025-06-17T11:30:00Z',
+    isMine: true,
+  },
+  {
+    chatId: 30,
+    senderId: 1,
+    senderName: '토끼',
+    content: '비빔면이요',
+    createdAt: '2025-06-17T11:31:00Z',
+    isMine: false,
+  },
+  {
+    chatId: 31,
+    senderId: 3,
+    senderName: '말하는 감자',
+    senderImage: {
+      id: 3,
+      src: 'http://www.kopis.or.kr/upload/pfmPoster/PF_PF262382_250403_132803.jpg',
+      alt: '감자 프로필',
+    },
+    content: '나는 감자볶음밥!',
+    createdAt: '2025-06-17T15:32:00Z',
+    isMine: false,
+  },
+  {
+    chatId: 32,
+    senderId: 4,
+    senderName: '문영',
+    senderImage: {
+      id: 2,
+      src: '/images/moonyoung.png',
+      alt: '문영 프로필',
+    },
+    content: '오늘도 다들 고생 많았어요 :)',
+    createdAt: '2025-06-17T23:58:00Z',
+    isMine: true,
+  },
+  {
+    chatId: 33,
+    senderId: 3,
+    senderName: '말하는 감자',
+    senderImage: {
+      id: 3,
+      src: 'http://www.kopis.or.kr/upload/pfmPoster/PF_PF262382_250403_132803.jpg',
+      alt: '감자 프로필',
+    },
+    content: '진짜 다들 수고 많았어요~',
+    createdAt: '2025-06-18T00:00:00Z',
+    isMine: false,
+  },
+  {
+    chatId: 34,
+    senderId: 1,
+    senderName: '토끼',
+    content: '내일도 화이팅이에요!',
+    createdAt: '2025-06-18T00:01:00Z',
+    isMine: false,
+  },
+  {
+    chatId: 35,
+    senderId: 4,
+    senderName: '문영',
+    senderImage: {
+      id: 2,
+      src: '/images/moonyoung.png',
+      alt: '문영 프로필',
+    },
+    content: '응응~ 다들 잘자요 😴',
+    createdAt: '2025-06-18T00:02:00Z',
+    isMine: true,
+  },
+  {
+    chatId: 36,
+    senderId: 3,
+    senderName: '말하는 감자',
+    senderImage: {
+      id: 3,
+      src: 'http://www.kopis.or.kr/upload/pfmPoster/PF_PF262382_250403_132803.jpg',
+      alt: '감자 프로필',
+    },
+    content: '감자는 꿈나라로...',
+    createdAt: '2025-06-18T00:03:30Z',
+    isMine: false,
+  },
+  {
+    chatId: 37,
+    senderId: 1,
+    senderName: '토끼',
+    content: 'ㅋㅋㅋㅋㅋㅋ',
+    createdAt: '2025-06-18T00:04:00Z',
+    isMine: false,
+  },
+  {
+    chatId: 38,
+    senderId: 4,
+    senderName: '문영',
+    senderImage: {
+      id: 2,
+      src: '/images/moonyoung.png',
+      alt: '문영 프로필',
+    },
+    content: '자 그럼 진짜 잘 자요~~',
+    createdAt: '2025-06-18T00:05:00Z',
+    isMine: true,
+  },
+  {
+    chatId: 39,
+    senderId: 1,
+    senderName: '토끼',
+    content: '굿밤 🌙',
+    createdAt: '2025-06-18T00:06:00Z',
+    isMine: false,
+  },
+  {
+    chatId: 40,
+    senderId: 3,
+    senderName: '말하는 감자',
+    senderImage: {
+      id: 3,
+      src: 'http://www.kopis.or.kr/upload/pfmPoster/PF_PF262382_250403_132803.jpg',
+      alt: '감자 프로필',
+    },
+    content: '감자 out 💤',
+    createdAt: '2025-06-18T00:07:10Z',
+    isMine: false,
+  },
+  {
+    chatId: 41,
+    senderId: 4,
+    senderName: '문영',
+    senderImage: {
+      id: 2,
+      src: '/images/moonyoung.png',
+      alt: '문영 프로필',
+    },
+    content: 'ㅋㅋㅋㅋㅋ 귀엽다 진짜',
+    createdAt: '2025-06-18T00:08:20Z',
+    isMine: true,
+  },
+  {
+    chatId: 42,
+    senderId: 1,
+    senderName: '토끼',
+    content: '좋은 꿈 꾸세요 다들~',
+    createdAt: '2025-06-18T00:09:00Z',
+    isMine: false,
+  },
 ];
 
-// export const chatHandlers = [
-//   http.get(`http://localhost:3000/api/v1/chat/list`, async ({ request }) => {
-//     const url = new URL(request.url);
-//     const cursorId = Number(url.searchParams.get('cursorId')) || 1000;
-//     const size = Number(url.searchParams.get('size')) || 20;
-//   }),
-// ];
+export const chatHandlers = [
+  http.get(`http://localhost:3000/api/v1/chat/list`, async ({ request }) => {
+    const url = new URL(request.url);
+    const chatRoomId = url.searchParams.get('chatRoomId');
+    const cursorId = Number(url.searchParams.get('cursorId'));
+    const size = Number(url.searchParams.get('size')) || 20;
+
+    if (chatRoomId === '1' || chatRoomId === '2') {
+      const sortedData = [...CHAT_SAMPLE_DATA].sort(
+        (a, b) => b.chatId - a.chatId
+      );
+
+      const filteredData = cursorId
+        ? sortedData.filter((message) => message.chatId < Number(cursorId))
+        : sortedData;
+
+      const slicedData = filteredData.slice(0, size);
+
+      const newCursorId =
+        slicedData.length > 0 ? slicedData[slicedData.length - 1].chatId : null;
+
+      const hasNext = filteredData.length > size;
+
+      return HttpResponse.json(
+        {
+          code: 200,
+          message: '메시지 목록 조회 성공',
+          data: slicedData,
+          cursorId: newCursorId,
+          hasNext,
+        },
+        { status: 200 }
+      );
+    }
+
+    return HttpResponse.json(
+      { code: '404', message: '채팅방을 찾을 수 없습니다.', data: [] },
+      { status: 404 }
+    );
+  }),
+];

--- a/src/mocks/handlers/chatHandlers.ts
+++ b/src/mocks/handlers/chatHandlers.ts
@@ -121,6 +121,45 @@ export const CHAT_SAMPLE_DATA: ChatMessage[] = [
     createdAt: '2025-06-12T10:04:40Z',
     isMine: true,
   },
+  {
+    chatId: 10,
+    senderId: 4,
+    senderName: '문영',
+    senderImage: {
+      id: 2,
+      src: '/images/moonyoung.png',
+      alt: '문영 프로필',
+    },
+    content: '재밌는 얘기 해주세요',
+    createdAt: '2025-06-13T21:04:40Z',
+    isMine: true,
+  },
+  {
+    chatId: 11,
+    senderId: 3,
+    senderName: '말하는 감자',
+    senderImage: {
+      id: 3,
+      src: '/images/potato.png',
+      alt: '감자 프로필',
+    },
+    content: '냉장고를 열었더니 잼이 있었어요',
+    createdAt: '2025-06-13T22:34:40Z',
+    isMine: false,
+  },
+  {
+    chatId: 12,
+    senderId: 1,
+    senderName: '토끼',
+    senderImage: {
+      id: 1,
+      src: '/images/rabbit.png',
+      alt: '토끼 프로필',
+    },
+    content: '그만.',
+    createdAt: '2025-06-13T22:35:40Z',
+    isMine: false,
+  },
 ];
 
 // export const chatHandlers = [

--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -1,18 +1,15 @@
 import apiFetcher from '@/lib/apiFetcher';
-import {
-  GetChatMessageListRequest,
-  GetChatMessageListResponse,
-} from '@/types/chat';
+import { GetChatHistoryRequest, GetChatHistoryResponse } from '@/types/chat';
 
 export const chatServiceApi = {
-  getChatMessageList: async ({
-    // chatRoomId,
+  getChatHistory: async ({
+    chatRoomId,
     cursorId,
     size = 20,
-  }: GetChatMessageListRequest) => {
-    await apiFetcher.get<GetChatMessageListResponse>(`/api/v1/chat/list`, {
-      params: { cursorId, size },
-      // params: { chatRoomId, cursorId, size },
-    });
-  },
+  }: GetChatHistoryRequest) =>
+    (
+      await apiFetcher.get<GetChatHistoryResponse>(`/api/v1/chat/list`, {
+        params: { chatRoomId, cursorId, size },
+      })
+    ).data,
 };

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -5,9 +5,9 @@ export interface ChatMessage {
   senderId: number;
   senderName: string;
   senderImage?: {
-    id: number;
-    src: string;
-    alt: string;
+    id?: number;
+    src?: string;
+    alt?: string;
   };
   content: string;
   createdAt: string;
@@ -18,5 +18,7 @@ export type GetChatHistoryRequest = {
   chatRoomId: number;
 } & CursorRequest;
 
-export type GetChatHistoryResponse = ApiResponse<ChatMessage[]>
-  & CursorResponse;
+export type GetChatHistoryResponse = {
+  data: ChatMessage[];
+} & CursorResponse
+  & ApiResponse;

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -14,15 +14,9 @@ export interface ChatMessage {
   isMine?: boolean;
 }
 
-export interface ChatMessageRequest {
-  chatRoomId: string;
-  cursorId?: number;
-  size?: number;
-}
-
-export type GetChatMessageListRequest = {
+export type GetChatHistoryRequest = {
   chatRoomId: number;
 } & CursorRequest;
 
-export type GetChatMessageListResponse = ApiResponse<ChatMessage[]>
+export type GetChatHistoryResponse = ApiResponse<ChatMessage[]>
   & CursorResponse;

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -45,10 +45,11 @@ export const formatPostDate = (dateStr: string): string => {
 };
 
 export const formatToKST = (isoString: string) => {
-  const timeStr = isoString.split('T')[1].slice(0, 5);
-  const hour = Number(timeStr.split(':')[0]);
+  const timeString = isoString.split('T')[1].slice(0, 5);
+  const hour = Number(timeString.split(':')[0]);
   const meridiem = hour < 12 ? '오전' : '오후';
   const hour12 = hour % 12 === 0 ? 12 : hour % 12;
-  const minute = timeStr.split(':')[1];
-  return `${meridiem} ${hour12}:${minute}`;
+  const paddedHour = hour12.toString().padStart(2, '0');
+  const minute = timeString.split(':')[1];
+  return `${meridiem} ${paddedHour}:${minute}`;
 };

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -43,3 +43,12 @@ export const formatPostDate = (dateStr: string): string => {
     return dateStr;
   }
 };
+
+export const formatToKST = (isoString: string) => {
+  const timeStr = isoString.split('T')[1].slice(0, 5);
+  const hour = Number(timeStr.split(':')[0]);
+  const meridiem = hour < 12 ? '오전' : '오후';
+  const hour12 = hour % 12 === 0 ? 12 : hour % 12;
+  const minute = timeStr.split(':')[1];
+  return `${meridiem} ${hour12}:${minute}`;
+};


### PR DESCRIPTION
### 무엇을 위한 PR인가요? (: 뒤 설명 추가)

- 신규 기능 추가: 채팅방 메세지 목록 조회 

### 변경사항 및 이유 (bullet 으로 구분)

- 채팅방 메세지 목록 조회 api
- 채팅창에 모임 기본 정보, 고정된 게시글 api 연결
- 채팅창 디자인 일부 수정
- 로딩 ui, 에러 핸들링

### 작업 내역 (bullet 으로 구분)

- 채팅방 메세지 목록 조회 api
  - 무한 스크롤
  - 내가 채팅 보냈을 때 맨 아래로 스크롤되도록 설정
  - 추후 Suspensive 라이브러리로 리팩토링 필요
  - msw handler 설정
- 채팅창에 모임 기본 정보, 고정된 게시글 api 연결
- 채팅창 디자인 일부 수정
- `formatToKST` 유틸 함수 추가
  - 한국 시간(2025-06-18T15:00:43Z)을 `오전/오후 hh:mm` 형식으로 포맷하는 함수
- 로딩 ui, 에러 핸들링
  - 채팅 연결 시 로딩, 무한 스크롤 시 로딩 ui 적용

### 작업 후 기대 동작(스크린샷)

https://github.com/user-attachments/assets/67bf27d8-5b2f-4445-9f60-30002be3fef0

<img width="378" alt="스크린샷 2025-06-18 오후 3 24 13" src="https://github.com/user-attachments/assets/24e0ce51-09c8-4b87-a3fd-aaa4580b734b" />

### PR 특이 사항

- Suspensive 라이브러리 사용하여 무한스크롤 리팩토링 필요

### Issue Number

close: #355 