### PR TITLE
[Feature/issue-383] 모임원 목록 조회, 역할 변경, 퇴출

### DIFF
--- a/src/components/pages/groupDetail/Chat/ChatArea.tsx
+++ b/src/components/pages/groupDetail/Chat/ChatArea.tsx
@@ -26,31 +26,14 @@ const ChatArea = ({ userId, chatRoomId }: ChatAreaProps) => {
     fetchNextPage,
     hasNextPage,
     isPending,
+    isError,
     isFetchingNextPage,
-    status,
   } = useGetChatHistory(chatRoomId, 20);
+
   if (!isConnected) {
     return (
       <div className='relative flex h-[60dvh] flex-col items-center justify-center gap-2'>
         <p className='font-semibold text-gray-500'>{statusMessage}</p>
-        <ChatMessageInput
-          disabled={true}
-          sendMessage={() => {}}
-        />
-      </div>
-    );
-  }
-
-  if (status === 'error') {
-    return (
-      <div className='relative flex h-[60dvh] flex-col items-center justify-center gap-2'>
-        <p className='font-semibold text-gray-500'>
-          메세지를 불러오지 못했습니다.
-        </p>
-        <ChatMessageInput
-          disabled={true}
-          sendMessage={() => {}}
-        />
       </div>
     );
   }
@@ -58,11 +41,21 @@ const ChatArea = ({ userId, chatRoomId }: ChatAreaProps) => {
   if (isPending) {
     return (
       <div className='relative flex h-[60dvh] flex-col items-center justify-center gap-2'>
-        <p className='font-semibold text-gray-500'>채팅방 연결 중...</p>
+        <p className='font-semibold text-gray-500'>메세지 불러오는 중...</p>
         <ChatMessageInput
           disabled={true}
           sendMessage={() => {}}
         />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className='relative flex h-[60dvh] flex-col items-center justify-center gap-2'>
+        <p className='font-semibold text-gray-500'>
+          예상치 못한 오류가 발생하였습니다.
+        </p>
       </div>
     );
   }
@@ -72,6 +65,7 @@ const ChatArea = ({ userId, chatRoomId }: ChatAreaProps) => {
     .reverse();
 
   const allMessages = [...historyMessages, ...liveMessages];
+  console.log(historyMessages);
 
   return (
     <div className='relative flex h-[60dvh] flex-col gap-2'>

--- a/src/components/pages/groupDetail/Chat/ChatArea.tsx
+++ b/src/components/pages/groupDetail/Chat/ChatArea.tsx
@@ -65,7 +65,6 @@ const ChatArea = ({ userId, chatRoomId }: ChatAreaProps) => {
     .reverse();
 
   const allMessages = [...historyMessages, ...liveMessages];
-  console.log(historyMessages);
 
   return (
     <div className='relative flex h-[60dvh] flex-col gap-2'>

--- a/src/components/pages/groupDetail/GroupMembers.tsx
+++ b/src/components/pages/groupDetail/GroupMembers.tsx
@@ -1,3 +1,4 @@
+import { useGetGroupMembers } from '@/hooks/groupHooks/groupHooks';
 import MembersHeader from './Members/MembersHeader';
 import MembersList from './Members/MembersList';
 
@@ -5,11 +6,27 @@ interface GroupMembersProps {
   groupId: string;
 }
 
-const GroupMembers = ({ groupId }: GroupMembersProps) => (
-  <div className='flex flex-col gap-5 px-4'>
-    <MembersHeader groupId={groupId} />
-    <MembersList groupId={groupId} />
-  </div>
-);
+const GroupMembers = ({ groupId }: GroupMembersProps) => {
+  const {
+    data: groupMembers,
+    isPending,
+    isError,
+  } = useGetGroupMembers(groupId, 5);
+
+  return (
+    <div className='flex flex-col gap-5 px-4'>
+      <MembersHeader
+        groupId={groupId}
+        memberCount={groupMembers?.data.memberCount}
+        isHost={groupMembers?.data.isHost}
+      />
+      <MembersList
+        members={groupMembers?.data.members}
+        isPending={isPending}
+        isError={isError}
+      />
+    </div>
+  );
+};
 
 export default GroupMembers;

--- a/src/components/pages/groupDetail/GroupMembers.tsx
+++ b/src/components/pages/groupDetail/GroupMembers.tsx
@@ -1,6 +1,15 @@
-const GroupMembers = () => (
-  // TODO: 모임원 목록 조회 api 연동
-  <div>모임원 목록</div>
+import MembersHeader from './Members/MembersHeader';
+import MembersList from './Members/MembersList';
+
+interface GroupMembersProps {
+  groupId: string;
+}
+
+const GroupMembers = ({ groupId }: GroupMembersProps) => (
+  <div className='flex flex-col gap-5 px-4'>
+    <MembersHeader groupId={groupId} />
+    <MembersList groupId={groupId} />
+  </div>
 );
 
 export default GroupMembers;

--- a/src/components/pages/groupDetail/GroupMembers.tsx
+++ b/src/components/pages/groupDetail/GroupMembers.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import { useGetGroupMembers } from '@/hooks/groupHooks/groupHooks';
 import MembersHeader from './Members/MembersHeader';
 import MembersList from './Members/MembersList';
@@ -7,6 +8,7 @@ interface GroupMembersProps {
 }
 
 const GroupMembers = ({ groupId }: GroupMembersProps) => {
+  const modalTriggerRef = useRef<HTMLButtonElement>(null);
   const {
     data: groupMembers,
     isPending,
@@ -19,11 +21,14 @@ const GroupMembers = ({ groupId }: GroupMembersProps) => {
         groupId={groupId}
         memberCount={groupMembers?.data.memberCount}
         isHost={groupMembers?.data.isHost}
+        modalTriggerRef={modalTriggerRef}
       />
       <MembersList
         members={groupMembers?.data.members}
+        memberCount={groupMembers?.data.memberCount}
         isPending={isPending}
         isError={isError}
+        modalTriggerRef={modalTriggerRef}
       />
     </div>
   );

--- a/src/components/pages/groupDetail/GroupWrapper.tsx
+++ b/src/components/pages/groupDetail/GroupWrapper.tsx
@@ -32,7 +32,7 @@ const GroupWrapper = ({ groupId }: GroupWrapperProps) => {
 
       {isLoggedIn && isMember && (
         <>
-          <GroupMembers />
+          <GroupMembers groupId={groupId} />
           <GroupTabs groupInfo={groupInfo?.data} />
         </>
       )}

--- a/src/components/pages/groupDetail/Members/MemberCard.tsx
+++ b/src/components/pages/groupDetail/Members/MemberCard.tsx
@@ -1,4 +1,5 @@
 import { CrownIcon } from 'lucide-react';
+import Link from 'next/link';
 import ProfileImage from '@/components/common/ProfileImage/ProfileImage';
 import { RoleLabels } from '@/constants/roleLabels';
 import { useAuthStore } from '@/providers/AuthStoreProvider';
@@ -20,14 +21,16 @@ const MemberCard = ({ member, isHost }: MemberCardProps) => {
       key={member.memberId}
       className='flex items-center justify-between rounded-[16px] border-1 border-gray-100 bg-white p-3.5'
     >
-      <div className='flex items-center justify-center gap-3'>
-        <ProfileImage
-          size='md'
-          src={member.profileImage}
-          alt={member.name}
-          border={false}
-          className='aspect-square shrink-0'
-        />
+      <div className='flex items-center justify-start gap-3'>
+        <Link href={`/profiles/${member.memberId}`}>
+          <ProfileImage
+            size='md'
+            src={member.profileImage}
+            alt={member.name}
+            border={false}
+            className='aspect-square shrink-0'
+          />
+        </Link>
         <div className='flex flex-col justify-center gap-0.5'>
           <span className='ml-[0.5px] flex items-center text-center text-12_M tracking-[-0.35px] text-gray-500'>
             {member.role === 'HOST' && (
@@ -35,9 +38,12 @@ const MemberCard = ({ member, isHost }: MemberCardProps) => {
             )}
             {RoleLabels[member.role as RoleType]}
           </span>
-          <span className='text-center text-16_B leading-normal tracking-[-0.4px] text-gray-950'>
+          <Link
+            href={`/profiles/${member.memberId}`}
+            className='text-center text-16_B leading-normal tracking-[-0.4px] text-gray-950'
+          >
             {member.name}
-          </span>
+          </Link>
         </div>
       </div>
 

--- a/src/components/pages/groupDetail/Members/MemberCard.tsx
+++ b/src/components/pages/groupDetail/Members/MemberCard.tsx
@@ -1,6 +1,7 @@
 import { CrownIcon } from 'lucide-react';
 import ProfileImage from '@/components/common/ProfileImage/ProfileImage';
 import { RoleLabels } from '@/constants/roleLabels';
+import { useAuthStore } from '@/providers/AuthStoreProvider';
 import { RoleType } from '@/types/enums';
 import { Member } from '@/types/group';
 import MemberDeleteModal from './MemberDeleteModal';
@@ -8,39 +9,46 @@ import MemberRoleModal from './MemberRoleModal';
 
 interface MemberCardProps {
   member: Member;
+  isHost?: boolean;
 }
 
-const MemberCard = ({ member }: MemberCardProps) => (
-  <div
-    key={member.memberId}
-    className='flex items-center justify-between rounded-[16px] border-1 border-gray-100 bg-white p-3.5'
-  >
-    <div className='flex items-center justify-center gap-3'>
-      <ProfileImage
-        size='md'
-        src={member.profileImage}
-        alt={member.name}
-        border={false}
-        className='aspect-square shrink-0'
-      />
-      <div className='flex flex-col justify-center gap-0.5'>
-        <span className='flex items-center text-center text-12_M tracking-[-0.35px] text-gray-500'>
-          {member.role === 'HOST' && (
-            <CrownIcon className='mr-[1px] aspect-square h-3 w-3' />
-          )}
-          {RoleLabels[member.role as RoleType]}
-        </span>
-        <span className='text-center text-16_B leading-normal tracking-[-0.4px] text-gray-950'>
-          {member.name}
-        </span>
-      </div>
-    </div>
+const MemberCard = ({ member, isHost }: MemberCardProps) => {
+  const isLoggedIn = useAuthStore((state) => state.isLoggedin);
 
-    <div className='flex gap-3'>
-      <MemberRoleModal member={member} />
-      <MemberDeleteModal member={member} />
+  return (
+    <div
+      key={member.memberId}
+      className='flex items-center justify-between rounded-[16px] border-1 border-gray-100 bg-white p-3.5'
+    >
+      <div className='flex items-center justify-center gap-3'>
+        <ProfileImage
+          size='md'
+          src={member.profileImage}
+          alt={member.name}
+          border={false}
+          className='aspect-square shrink-0'
+        />
+        <div className='flex flex-col justify-center gap-0.5'>
+          <span className='ml-[0.5px] flex items-center text-center text-12_M tracking-[-0.35px] text-gray-500'>
+            {member.role === 'HOST' && (
+              <CrownIcon className='mr-[1px] aspect-square h-3 w-3' />
+            )}
+            {RoleLabels[member.role as RoleType]}
+          </span>
+          <span className='text-center text-16_B leading-normal tracking-[-0.4px] text-gray-950'>
+            {member.name}
+          </span>
+        </div>
+      </div>
+
+      {isHost && member.role !== 'HOST' && isLoggedIn && (
+        <div className='flex gap-3'>
+          <MemberRoleModal member={member} />
+          <MemberDeleteModal member={member} />
+        </div>
+      )}
     </div>
-  </div>
-);
+  );
+};
 
 export default MemberCard;

--- a/src/components/pages/groupDetail/Members/MemberCard.tsx
+++ b/src/components/pages/groupDetail/Members/MemberCard.tsx
@@ -21,7 +21,7 @@ const MemberCard = ({ member, isHost }: MemberCardProps) => {
       key={member.memberId}
       className='flex items-center justify-between rounded-[16px] border-1 border-gray-100 bg-white p-3.5'
     >
-      <div className='flex items-center justify-start gap-3'>
+      <div className='flex min-w-0 items-center justify-start gap-2.5'>
         <Link href={`/profiles/${member.memberId}`}>
           <ProfileImage
             size='md'
@@ -31,7 +31,7 @@ const MemberCard = ({ member, isHost }: MemberCardProps) => {
             className='aspect-square shrink-0'
           />
         </Link>
-        <div className='flex flex-col justify-center gap-0.5'>
+        <div className='flex min-w-0 flex-col justify-center gap-0.5'>
           <span className='ml-[0.5px] flex items-center text-center text-12_M tracking-[-0.35px] text-gray-500'>
             {member.role === 'HOST' && (
               <CrownIcon className='mr-[1px] aspect-square h-3 w-3' />
@@ -40,7 +40,7 @@ const MemberCard = ({ member, isHost }: MemberCardProps) => {
           </span>
           <Link
             href={`/profiles/${member.memberId}`}
-            className='text-center text-16_B leading-normal tracking-[-0.4px] text-gray-950'
+            className='truncate text-16_B leading-normal tracking-[-0.35px] text-gray-950'
           >
             {member.name}
           </Link>
@@ -48,7 +48,7 @@ const MemberCard = ({ member, isHost }: MemberCardProps) => {
       </div>
 
       {isHost && member.role !== 'HOST' && isLoggedIn && (
-        <div className='flex gap-3'>
+        <div className='flex gap-2.5'>
           <MemberRoleModal member={member} />
           <MemberDeleteModal member={member} />
         </div>

--- a/src/components/pages/groupDetail/Members/MemberCard.tsx
+++ b/src/components/pages/groupDetail/Members/MemberCard.tsx
@@ -1,0 +1,105 @@
+import { CrownIcon } from 'lucide-react';
+import { Button } from '@/components/common';
+import {
+  Modal,
+  ModalAction,
+  ModalCancel,
+  ModalContent,
+  ModalTrigger,
+} from '@/components/common/Modal';
+import ProfileImage from '@/components/common/ProfileImage/ProfileImage';
+import { RoleLabels } from '@/constants/roleLabels';
+import { RoleType } from '@/types/enums';
+import { Member } from '@/types/group';
+
+interface MemberCardProps {
+  member: Member;
+}
+
+const MemberCard = ({ member }: MemberCardProps) => (
+  <div
+    key={member.memberId}
+    className='flex items-center justify-between rounded-[16px] border-1 border-gray-100 bg-white p-3.5'
+  >
+    <div className='flex items-center justify-center gap-3'>
+      <ProfileImage
+        size='md'
+        src={member.profileImage}
+        alt={member.name}
+        border={false}
+        className='aspect-square shrink-0'
+      />
+      <div className='flex flex-col justify-center gap-0.5'>
+        <span className='flex items-center text-center text-12_M tracking-[-0.35px] text-gray-500'>
+          {member.role === 'HOST' && (
+            <CrownIcon className='mr-[1px] aspect-square h-3 w-3' />
+          )}
+          {RoleLabels[member.role as RoleType]}
+        </span>
+        <span className='text-center text-16_B leading-normal tracking-[-0.4px] text-gray-950'>
+          {member.name}
+        </span>
+      </div>
+    </div>
+
+    <div className='flex gap-3'>
+      <Modal>
+        <ModalTrigger>
+          <Button
+            variant='primary'
+            className='px-3 py-1'
+          >
+            <span className='shrink-0 text-center text-12_M leading-normal tracking-[-0.35px] whitespace-pre-wrap'>
+              {`모임장\n넘기기`}
+            </span>
+          </Button>
+        </ModalTrigger>
+        <ModalContent className='h-fit w-[calc(100%-32px)] max-w-[480px] rounded-[16px] p-5'>
+          <div className='flex flex-col gap-7.5 pt-5.5'>
+            <p className='flex w-full justify-center text-16_B text-black'>
+              모임장을 {member.name}님에게 넘기시겠습니까?
+            </p>
+            <div className='flex gap-2'>
+              <ModalCancel className='inline-flex w-full cursor-pointer items-center justify-center rounded-12 border border-primary-red py-2.5 text-center text-14_M text-primary-red'>
+                취소
+              </ModalCancel>
+              <ModalAction className='inline-flex w-full cursor-pointer items-center justify-center rounded-12 bg-primary-red py-2.5 text-center text-14_M text-white'>
+                넘기기
+              </ModalAction>
+            </div>
+          </div>
+        </ModalContent>
+      </Modal>
+
+      <Modal>
+        <ModalTrigger>
+          <Button
+            variant='secondary'
+            className='px-3 py-1'
+          >
+            <span className='text-center text-14_M leading-normal tracking-[-0.35px]'>
+              퇴출
+            </span>
+          </Button>
+        </ModalTrigger>
+        <ModalContent className='h-fit w-[calc(100%-32px)] max-w-[480px] rounded-[16px] p-5'>
+          <div className='flex flex-col gap-7.5 pt-5.5'>
+            <p className='flex w-full justify-center text-16_B text-black'>
+              {member.name}님을 모임에서 퇴출시키시겠습니까?
+            </p>
+            <div className='flex gap-2'>
+              <ModalCancel className='inline-flex w-full cursor-pointer items-center justify-center rounded-12 border border-primary-red py-2.5 text-center text-14_M text-primary-red'>
+                취소
+              </ModalCancel>
+              <ModalAction className='inline-flex w-full cursor-pointer items-center justify-center rounded-12 bg-primary-red py-2.5 text-center text-14_M text-white'>
+                퇴출하기
+              </ModalAction>
+            </div>
+          </div>
+        </ModalContent>
+      </Modal>
+    </div>
+  </div>
+);
+
+export default MemberCard;

--- a/src/components/pages/groupDetail/Members/MemberCard.tsx
+++ b/src/components/pages/groupDetail/Members/MemberCard.tsx
@@ -14,7 +14,7 @@ interface MemberCardProps {
 }
 
 const MemberCard = ({ member, isHost }: MemberCardProps) => {
-  const isLoggedIn = useAuthStore((state) => state.isLoggedin);
+  const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
 
   return (
     <div

--- a/src/components/pages/groupDetail/Members/MemberCard.tsx
+++ b/src/components/pages/groupDetail/Members/MemberCard.tsx
@@ -1,16 +1,10 @@
 import { CrownIcon } from 'lucide-react';
-import { Button } from '@/components/common';
-import {
-  Modal,
-  ModalAction,
-  ModalCancel,
-  ModalContent,
-  ModalTrigger,
-} from '@/components/common/Modal';
 import ProfileImage from '@/components/common/ProfileImage/ProfileImage';
 import { RoleLabels } from '@/constants/roleLabels';
 import { RoleType } from '@/types/enums';
 import { Member } from '@/types/group';
+import MemberDeleteModal from './MemberDeleteModal';
+import MemberRoleModal from './MemberRoleModal';
 
 interface MemberCardProps {
   member: Member;
@@ -43,61 +37,8 @@ const MemberCard = ({ member }: MemberCardProps) => (
     </div>
 
     <div className='flex gap-3'>
-      <Modal>
-        <ModalTrigger>
-          <Button
-            variant='primary'
-            className='px-3 py-1'
-          >
-            <span className='shrink-0 text-center text-12_M leading-normal tracking-[-0.35px] whitespace-pre-wrap'>
-              {`모임장\n넘기기`}
-            </span>
-          </Button>
-        </ModalTrigger>
-        <ModalContent className='h-fit w-[calc(100%-32px)] max-w-[480px] rounded-[16px] p-5'>
-          <div className='flex flex-col gap-7.5 pt-5.5'>
-            <p className='flex w-full justify-center text-16_B text-black'>
-              모임장을 {member.name}님에게 넘기시겠습니까?
-            </p>
-            <div className='flex gap-2'>
-              <ModalCancel className='inline-flex w-full cursor-pointer items-center justify-center rounded-12 border border-primary-red py-2.5 text-center text-14_M text-primary-red'>
-                취소
-              </ModalCancel>
-              <ModalAction className='inline-flex w-full cursor-pointer items-center justify-center rounded-12 bg-primary-red py-2.5 text-center text-14_M text-white'>
-                넘기기
-              </ModalAction>
-            </div>
-          </div>
-        </ModalContent>
-      </Modal>
-
-      <Modal>
-        <ModalTrigger>
-          <Button
-            variant='secondary'
-            className='px-3 py-1'
-          >
-            <span className='text-center text-14_M leading-normal tracking-[-0.35px]'>
-              퇴출
-            </span>
-          </Button>
-        </ModalTrigger>
-        <ModalContent className='h-fit w-[calc(100%-32px)] max-w-[480px] rounded-[16px] p-5'>
-          <div className='flex flex-col gap-7.5 pt-5.5'>
-            <p className='flex w-full justify-center text-16_B text-black'>
-              {member.name}님을 모임에서 퇴출시키시겠습니까?
-            </p>
-            <div className='flex gap-2'>
-              <ModalCancel className='inline-flex w-full cursor-pointer items-center justify-center rounded-12 border border-primary-red py-2.5 text-center text-14_M text-primary-red'>
-                취소
-              </ModalCancel>
-              <ModalAction className='inline-flex w-full cursor-pointer items-center justify-center rounded-12 bg-primary-red py-2.5 text-center text-14_M text-white'>
-                퇴출하기
-              </ModalAction>
-            </div>
-          </div>
-        </ModalContent>
-      </Modal>
+      <MemberRoleModal member={member} />
+      <MemberDeleteModal member={member} />
     </div>
   </div>
 );

--- a/src/components/pages/groupDetail/Members/MemberDeleteModal.tsx
+++ b/src/components/pages/groupDetail/Members/MemberDeleteModal.tsx
@@ -1,0 +1,62 @@
+import { useParams } from 'next/navigation';
+import { Button } from '@/components/common';
+import {
+  Modal,
+  ModalAction,
+  ModalCancel,
+  ModalContent,
+  ModalTrigger,
+} from '@/components/common/Modal';
+import { useDeleteGroupMember } from '@/hooks/groupHooks/groupHooks';
+import { Member } from '@/types/group';
+
+interface MemberDeleteModalProps {
+  member: Member;
+}
+
+const MemberDeleteModal = ({ member }: MemberDeleteModalProps) => {
+  const { groupId } = useParams();
+  const { mutate: deleteGroupMember } = useDeleteGroupMember();
+
+  const handleDeleteGroupMember = () => {
+    deleteGroupMember({
+      groupId: groupId as string,
+      memberId: member.memberId,
+    });
+  };
+
+  return (
+    <Modal>
+      <ModalTrigger>
+        <Button
+          variant='secondary'
+          className='px-3 py-1.5'
+        >
+          <span className='text-center text-14_M leading-4.5 tracking-[-0.35px]'>
+            퇴출
+          </span>
+        </Button>
+      </ModalTrigger>
+      <ModalContent className='h-fit w-[calc(100%-32px)] max-w-[480px] rounded-[16px] p-5'>
+        <div className='flex flex-col gap-7.5 pt-5.5'>
+          <p className='flex w-full justify-center text-16_B text-black'>
+            {member.name}님을 모임에서 퇴출시키시겠습니까?
+          </p>
+          <div className='flex gap-2'>
+            <ModalCancel className='inline-flex w-full cursor-pointer items-center justify-center rounded-12 border border-primary-red py-2.5 text-center text-14_M text-primary-red'>
+              취소
+            </ModalCancel>
+            <ModalAction
+              onClick={handleDeleteGroupMember}
+              className='inline-flex w-full cursor-pointer items-center justify-center rounded-12 bg-primary-red py-2.5 text-center text-14_M text-white'
+            >
+              퇴출하기
+            </ModalAction>
+          </div>
+        </div>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default MemberDeleteModal;

--- a/src/components/pages/groupDetail/Members/MemberRoleModal.tsx
+++ b/src/components/pages/groupDetail/Members/MemberRoleModal.tsx
@@ -34,7 +34,7 @@ const MemberRoleModal = ({ member }: MemberRoleModalProps) => {
           className='px-3 py-1.5'
         >
           <span className='text-center text-14_M leading-4.5 tracking-[-0.35px]'>
-            권한 수정
+            모임장 넘기기
           </span>
         </Button>
       </ModalTrigger>

--- a/src/components/pages/groupDetail/Members/MemberRoleModal.tsx
+++ b/src/components/pages/groupDetail/Members/MemberRoleModal.tsx
@@ -18,11 +18,11 @@ const MemberRoleModal = ({ member }: MemberRoleModalProps) => {
   const { groupId } = useParams();
   const { mutate: patchMemberRole } = usePatchGroupMemberRole();
 
-  const handlePatchMemberRole = (role: string) => {
+  const handlePatchMemberRole = () => {
     patchMemberRole({
       groupId: groupId as string,
       memberId: member.memberId,
-      role,
+      role: 'HOST',
     });
   };
 
@@ -48,7 +48,7 @@ const MemberRoleModal = ({ member }: MemberRoleModalProps) => {
               취소
             </ModalCancel>
             <ModalAction
-              onClick={() => handlePatchMemberRole('HOST')}
+              onClick={handlePatchMemberRole}
               className='inline-flex w-full cursor-pointer items-center justify-center rounded-12 bg-primary-red py-2.5 text-center text-14_M text-white'
             >
               넘기기

--- a/src/components/pages/groupDetail/Members/MemberRoleModal.tsx
+++ b/src/components/pages/groupDetail/Members/MemberRoleModal.tsx
@@ -1,0 +1,63 @@
+import { useParams } from 'next/navigation';
+import { Button } from '@/components/common';
+import {
+  Modal,
+  ModalAction,
+  ModalCancel,
+  ModalContent,
+  ModalTrigger,
+} from '@/components/common/Modal';
+import { usePatchGroupMemberRole } from '@/hooks/groupHooks/groupHooks';
+import { Member } from '@/types/group';
+
+interface MemberRoleModalProps {
+  member: Member;
+}
+
+const MemberRoleModal = ({ member }: MemberRoleModalProps) => {
+  const { groupId } = useParams();
+  const { mutate: patchMemberRole } = usePatchGroupMemberRole();
+
+  const handlePatchMemberRole = (role: string) => {
+    patchMemberRole({
+      groupId: groupId as string,
+      memberId: member.memberId,
+      role,
+    });
+  };
+
+  return (
+    <Modal>
+      <ModalTrigger>
+        <Button
+          variant='primary'
+          className='px-3 py-1.5'
+        >
+          <span className='text-center text-14_M leading-4.5 tracking-[-0.35px]'>
+            권한 수정
+          </span>
+        </Button>
+      </ModalTrigger>
+      <ModalContent className='h-fit w-[calc(100%-32px)] max-w-[480px] rounded-[16px] p-5'>
+        <div className='flex flex-col gap-7.5 pt-5.5'>
+          <p className='flex w-full justify-center text-16_B text-black'>
+            모임장을 {member.name}님에게 넘기시겠습니까?
+          </p>
+          <div className='flex gap-2'>
+            <ModalCancel className='inline-flex w-full cursor-pointer items-center justify-center rounded-12 border border-primary-red py-2.5 text-center text-14_M text-primary-red'>
+              취소
+            </ModalCancel>
+            <ModalAction
+              onClick={() => handlePatchMemberRole('HOST')}
+              className='inline-flex w-full cursor-pointer items-center justify-center rounded-12 bg-primary-red py-2.5 text-center text-14_M text-white'
+            >
+              넘기기
+            </ModalAction>
+          </div>
+        </div>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default MemberRoleModal;

--- a/src/components/pages/groupDetail/Members/MembersHeader.tsx
+++ b/src/components/pages/groupDetail/Members/MembersHeader.tsx
@@ -24,7 +24,7 @@ const MembersHeader = ({
 }: MembersHeaderProps) => (
   <div className='flex justify-between'>
     <span className='text-16_B leading-normal tracking-[-0.4px] text-gray-950'>
-      멤버 <span>{memberCount}</span>명
+      멤버 <span>{memberCount ? memberCount : '0'}</span>명
     </span>
 
     <Modal>

--- a/src/components/pages/groupDetail/Members/MembersHeader.tsx
+++ b/src/components/pages/groupDetail/Members/MembersHeader.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { ReactNode, RefObject } from 'react';
 import InfiniteList from '@/components/common/InfiniteList/InfiniteList ';
 import {
   Modal,
@@ -15,12 +15,14 @@ interface MembersHeaderProps {
   groupId: string;
   memberCount?: number;
   isHost?: boolean;
+  modalTriggerRef: RefObject<HTMLButtonElement | null>;
 }
 
 const MembersHeader = ({
   groupId,
   memberCount,
   isHost,
+  modalTriggerRef,
 }: MembersHeaderProps) => (
   <div className='flex justify-between'>
     <span className='text-16_B leading-normal tracking-[-0.4px] text-gray-950'>
@@ -29,18 +31,20 @@ const MembersHeader = ({
 
     <Modal>
       <ModalTrigger>
-        <span
-          className='text-sm leading-normal font-medium tracking-[-0.35px] text-gray-500 underline decoration-solid decoration-1 underline-offset-auto'
-          style={{
-            textDecorationSkipInk: 'none',
-            textUnderlinePosition: 'from-font',
-          }}
-        >
-          더보기
-        </span>
+        <button ref={modalTriggerRef}>
+          <span
+            className='text-sm leading-normal font-medium tracking-[-0.35px] text-gray-500 underline decoration-solid decoration-1 underline-offset-auto'
+            style={{
+              textDecorationSkipInk: 'none',
+              textUnderlinePosition: 'from-font',
+            }}
+          >
+            더보기
+          </span>
+        </button>
       </ModalTrigger>
-      <ModalContent className='relative scrollbar-hide w-full rounded-[16px] p-5'>
-        <ModalClose className='sticky top-0 right-0 ml-auto block' />
+      <ModalContent className='relative scrollbar-hide h-full w-full rounded-[16px] p-5'>
+        <ModalClose className='sticky top-0 right-0 mb-4 ml-auto block' />
         <InfiniteList<
           GetGroupMembersFormattedResponse,
           GetGroupMembersFormattedResponse['data'][number]

--- a/src/components/pages/groupDetail/Members/MembersHeader.tsx
+++ b/src/components/pages/groupDetail/Members/MembersHeader.tsx
@@ -13,12 +13,18 @@ import MemberCard from './MemberCard';
 
 interface MembersHeaderProps {
   groupId: string;
+  memberCount?: number;
+  isHost?: boolean;
 }
 
-const MembersHeader = ({ groupId }: MembersHeaderProps) => (
+const MembersHeader = ({
+  groupId,
+  memberCount,
+  isHost,
+}: MembersHeaderProps) => (
   <div className='flex justify-between'>
     <span className='text-16_B leading-normal tracking-[-0.4px] text-gray-950'>
-      멤버
+      멤버 <span>{memberCount}</span>명
     </span>
 
     <Modal>
@@ -41,7 +47,12 @@ const MembersHeader = ({ groupId }: MembersHeaderProps) => (
         >
           options={infiniteGroupMembersOptions(groupId, 20)}
           getDataId={(member) => member.memberId}
-          renderData={(member): ReactNode => <MemberCard member={member} />}
+          renderData={(member): ReactNode => (
+            <MemberCard
+              member={member}
+              isHost={isHost}
+            />
+          )}
           fallback={<Skeleton className='mt-5 h-20 w-full rounded-[16px]' />}
           isFetchingFallback={
             <Skeleton className='mt-5 h-20 w-full rounded-[16px]' />

--- a/src/components/pages/groupDetail/Members/MembersHeader.tsx
+++ b/src/components/pages/groupDetail/Members/MembersHeader.tsx
@@ -1,0 +1,56 @@
+import { ReactNode } from 'react';
+import InfiniteList from '@/components/common/InfiniteList/InfiniteList ';
+import {
+  Modal,
+  ModalClose,
+  ModalContent,
+  ModalTrigger,
+} from '@/components/common/Modal';
+import { Skeleton } from '@/components/ui/skeleton';
+import { infiniteGroupMembersOptions } from '@/hooks/groupHooks/groupHooks';
+import { GetGroupMembersFormattedResponse } from '@/types/group';
+import MemberCard from './MemberCard';
+
+interface MembersHeaderProps {
+  groupId: string;
+}
+
+const MembersHeader = ({ groupId }: MembersHeaderProps) => (
+  <div className='flex justify-between'>
+    <span className='text-16_B leading-normal tracking-[-0.4px] text-gray-950'>
+      멤버
+    </span>
+
+    <Modal>
+      <ModalTrigger>
+        <span
+          className='text-sm leading-normal font-medium tracking-[-0.35px] text-gray-500 underline decoration-solid decoration-1 underline-offset-auto'
+          style={{
+            textDecorationSkipInk: 'none',
+            textUnderlinePosition: 'from-font',
+          }}
+        >
+          더보기
+        </span>
+      </ModalTrigger>
+      <ModalContent className='relative scrollbar-hide w-full rounded-[16px] p-5'>
+        <ModalClose className='sticky top-0 right-0 ml-auto block' />
+        <InfiniteList<
+          GetGroupMembersFormattedResponse,
+          GetGroupMembersFormattedResponse['data'][number]
+        >
+          options={infiniteGroupMembersOptions(groupId, 20)}
+          getDataId={(member) => member.memberId}
+          renderData={(member): ReactNode => <MemberCard member={member} />}
+          fallback={<Skeleton className='mt-5 h-20 w-full rounded-[16px]' />}
+          isFetchingFallback={
+            <Skeleton className='mt-5 h-20 w-full rounded-[16px]' />
+          }
+          className='flex flex-col gap-5'
+        />
+      </ModalContent>
+    </Modal>
+  </div>
+);
+
+export default MembersHeader;

--- a/src/components/pages/groupDetail/Members/MembersList.tsx
+++ b/src/components/pages/groupDetail/Members/MembersList.tsx
@@ -1,0 +1,107 @@
+import { CrownIcon } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import ProfileImage from '@/components/common/ProfileImage/ProfileImage';
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+} from '@/components/ui/carousel';
+import { Skeleton } from '@/components/ui/skeleton';
+import { RoleLabels } from '@/constants/roleLabels';
+import { useGetGroupMembers } from '@/hooks/groupHooks/groupHooks';
+import { RoleType } from '@/types/enums';
+import { Member } from '@/types/group';
+
+interface MembersListProps {
+  groupId: string;
+}
+
+const MembersList = ({ groupId }: MembersListProps) => {
+  const router = useRouter();
+  const {
+    data: groupMembers,
+    isPending,
+    isError,
+  } = useGetGroupMembers(groupId, 5);
+
+  if (isPending) {
+    return (
+      <Carousel
+        opts={{
+          align: 'start',
+        }}
+        className='w-full'
+      >
+        <CarouselContent>
+          <CarouselItem className='basis-[calc(100%/2.4)] rounded-[16px]'>
+            <Skeleton className='h-30 w-full' />
+          </CarouselItem>
+          <CarouselItem className='basis-[calc(100%/2.4)] rounded-[16px]'>
+            <Skeleton className='h-30 w-full' />
+          </CarouselItem>
+          <CarouselItem className='basis-[calc(100%/2.4)] rounded-[16px]'>
+            <Skeleton className='h-30 w-full' />
+          </CarouselItem>
+        </CarouselContent>
+      </Carousel>
+    );
+  }
+
+  if (isError || !groupMembers.data) {
+    return (
+      <div className='flex flex-col items-center justify-center px-4 py-5'>
+        <p className='font-semibold text-gray-500'>
+          모임원 목록을 불러오지 못했습니다.
+        </p>
+      </div>
+    );
+  }
+
+  const members: Member[] = groupMembers.data.members;
+
+  const routeToMemberProfile = (memberId: string) => {
+    router.push(`/profiles/${memberId}`);
+  };
+
+  return (
+    <Carousel
+      opts={{
+        align: 'start',
+      }}
+      className='w-full'
+    >
+      <CarouselContent className='m-0 gap-3'>
+        {members?.map((member) => (
+          <CarouselItem
+            key={member.memberId}
+            onClick={() => routeToMemberProfile(member.memberId)}
+            className='flex basis-[calc(100%/2.4)] flex-col gap-3.5 rounded-[16px] border-1 border-gray-100 bg-white p-5'
+          >
+            <div className='flex items-center justify-center gap-2.5'>
+              <ProfileImage
+                size='lg'
+                src={member.profileImage}
+                alt={member.name}
+                border={false}
+                className='aspect-square shrink-0'
+              />
+            </div>
+            <div className='flex flex-col items-center gap-0.5'>
+              <span className='flex items-center text-center text-12_M tracking-[-0.35px] text-gray-500'>
+                {member.role === 'HOST' && (
+                  <CrownIcon className='mr-[1px] aspect-square h-3 w-3' />
+                )}
+                {RoleLabels[member.role as RoleType]}
+              </span>
+              <span className='text-center text-16_B leading-normal tracking-[-0.4px] text-gray-950'>
+                {member.name}
+              </span>
+            </div>
+          </CarouselItem>
+        ))}
+      </CarouselContent>
+    </Carousel>
+  );
+};
+
+export default MembersList;

--- a/src/components/pages/groupDetail/Members/MembersList.tsx
+++ b/src/components/pages/groupDetail/Members/MembersList.tsx
@@ -8,21 +8,17 @@ import {
 } from '@/components/ui/carousel';
 import { Skeleton } from '@/components/ui/skeleton';
 import { RoleLabels } from '@/constants/roleLabels';
-import { useGetGroupMembers } from '@/hooks/groupHooks/groupHooks';
 import { RoleType } from '@/types/enums';
 import { Member } from '@/types/group';
 
 interface MembersListProps {
-  groupId: string;
+  members?: Member[];
+  isPending: boolean;
+  isError: boolean;
 }
 
-const MembersList = ({ groupId }: MembersListProps) => {
+const MembersList = ({ members, isPending, isError }: MembersListProps) => {
   const router = useRouter();
-  const {
-    data: groupMembers,
-    isPending,
-    isError,
-  } = useGetGroupMembers(groupId, 5);
 
   if (isPending) {
     return (
@@ -47,7 +43,7 @@ const MembersList = ({ groupId }: MembersListProps) => {
     );
   }
 
-  if (isError || !groupMembers.data) {
+  if (isError) {
     return (
       <div className='flex flex-col items-center justify-center px-4 py-5'>
         <p className='font-semibold text-gray-500'>
@@ -56,8 +52,6 @@ const MembersList = ({ groupId }: MembersListProps) => {
       </div>
     );
   }
-
-  const members: Member[] = groupMembers.data.members;
 
   const routeToMemberProfile = (memberId: string) => {
     router.push(`/profiles/${memberId}`);

--- a/src/components/pages/groupDetail/Members/MembersList.tsx
+++ b/src/components/pages/groupDetail/Members/MembersList.tsx
@@ -1,3 +1,4 @@
+import { RefObject } from 'react';
 import { CrownIcon } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import ProfileImage from '@/components/common/ProfileImage/ProfileImage';
@@ -13,11 +14,19 @@ import { Member } from '@/types/group';
 
 interface MembersListProps {
   members?: Member[];
+  memberCount?: number;
   isPending: boolean;
   isError: boolean;
+  modalTriggerRef: RefObject<HTMLButtonElement | null>;
 }
 
-const MembersList = ({ members, isPending, isError }: MembersListProps) => {
+const MembersList = ({
+  members,
+  memberCount,
+  isPending,
+  isError,
+  modalTriggerRef,
+}: MembersListProps) => {
   const router = useRouter();
 
   if (isPending) {
@@ -43,7 +52,7 @@ const MembersList = ({ members, isPending, isError }: MembersListProps) => {
     );
   }
 
-  if (isError) {
+  if (isError || members?.length === 0) {
     return (
       <div className='flex flex-col items-center justify-center px-4 py-5'>
         <p className='font-semibold text-gray-500'>
@@ -55,6 +64,10 @@ const MembersList = ({ members, isPending, isError }: MembersListProps) => {
 
   const routeToMemberProfile = (memberId: string) => {
     router.push(`/profiles/${memberId}`);
+  };
+
+  const handleOpenMembersModal = () => {
+    modalTriggerRef.current?.click();
   };
 
   return (
@@ -69,7 +82,7 @@ const MembersList = ({ members, isPending, isError }: MembersListProps) => {
           <CarouselItem
             key={member.memberId}
             onClick={() => routeToMemberProfile(member.memberId)}
-            className='flex basis-[calc(100%/2.4)] flex-col gap-3.5 rounded-[16px] border-1 border-gray-100 bg-white p-5'
+            className='flex basis-[calc(100%/2.4)] flex-col items-center justify-center gap-3.5 rounded-[16px] border-1 border-gray-100 bg-white p-5'
           >
             <div className='flex items-center justify-center gap-2.5'>
               <ProfileImage
@@ -80,19 +93,29 @@ const MembersList = ({ members, isPending, isError }: MembersListProps) => {
                 className='aspect-square shrink-0'
               />
             </div>
-            <div className='flex flex-col items-center gap-0.5'>
+            <div className='flex min-w-0 flex-col items-center gap-0.5'>
               <span className='flex items-center text-center text-12_M tracking-[-0.35px] text-gray-500'>
                 {member.role === 'HOST' && (
                   <CrownIcon className='mr-[1px] aspect-square h-3 w-3' />
                 )}
                 {RoleLabels[member.role as RoleType]}
               </span>
-              <span className='text-center text-16_B leading-normal tracking-[-0.4px] text-gray-950'>
+              <span className='w-full truncate text-center text-16_B leading-normal tracking-[-0.4px] text-gray-950'>
                 {member.name}
               </span>
             </div>
           </CarouselItem>
         ))}
+        {memberCount !== undefined && memberCount > 5 && (
+          <CarouselItem
+            onClick={handleOpenMembersModal}
+            className='flex basis-[calc(100%/5)] flex-col items-center justify-center gap-3.5 rounded-[16px] border-1 border-gray-100 bg-white p-5'
+          >
+            <span className='flex items-center text-center text-12_M tracking-[-0.35px] text-gray-500'>
+              ...
+            </span>
+          </CarouselItem>
+        )}
       </CarouselContent>
     </Carousel>
   );

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -18,6 +18,7 @@ export const GROUP_QUERY_KEYS = {
   groupPosts: 'groupPosts',
   createGroup: 'createGroup',
   schedules: 'schedules',
+  groupMembers: 'groupMembers',
 };
 
 export const REVIEWS_QUERY_KEYS = {

--- a/src/constants/roleLabels.ts
+++ b/src/constants/roleLabels.ts
@@ -1,0 +1,6 @@
+import { Role, RoleType } from '@/types/enums';
+
+export const RoleLabels: Record<RoleType, string> = {
+  [Role.HOST]: '모임장',
+  [Role.MEMBER]: '모임원',
+};

--- a/src/hooks/groupHooks/groupHooks.ts
+++ b/src/hooks/groupHooks/groupHooks.ts
@@ -10,11 +10,13 @@ import { GROUP_QUERY_KEYS } from '@/constants/queryKeys';
 import { groupsApi } from '@/services/groupsService';
 import { ApiResponse, CursorRequest } from '@/types/api';
 import {
+  DeleteGroupMemberRequest,
   GetGroupMembersFormattedResponse,
   GetGroupMembersRequest,
   GetGroupMembersResponse,
   GetGroupsParams,
   GroupInfoResponse,
+  PatchGroupMemberRoleRequest,
   PostJoinGroupRequest,
 } from '@/types/group';
 import { CreateGroupFormData } from '@/types/group';
@@ -148,3 +150,33 @@ export const infiniteGroupMembersOptions = (
     lastPage.hasNext ? lastPage.cursorId : undefined,
   initialPageParam: undefined,
 });
+
+export const usePatchGroupMemberRole = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<ApiResponse, ApiResponse, PatchGroupMemberRoleRequest>({
+    mutationFn: ({ groupId, memberId, role }: PatchGroupMemberRoleRequest) =>
+      groupsApi.patchGroupMemberRole({ groupId, memberId, role }),
+
+    onSuccess: (_, { groupId }) => {
+      queryClient.invalidateQueries({
+        queryKey: [GROUP_QUERY_KEYS.groupMembers, groupId],
+      });
+    },
+  });
+};
+
+export const useDeleteGroupMember = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<ApiResponse, ApiResponse, DeleteGroupMemberRequest>({
+    mutationFn: ({ groupId, memberId }: DeleteGroupMemberRequest) =>
+      groupsApi.deleteGroupMember({ groupId, memberId }),
+
+    onSuccess: (_, { groupId }) => {
+      queryClient.invalidateQueries({
+        queryKey: [GROUP_QUERY_KEYS.groupMembers, groupId],
+      });
+    },
+  });
+};

--- a/src/hooks/groupHooks/groupHooks.ts
+++ b/src/hooks/groupHooks/groupHooks.ts
@@ -1,6 +1,5 @@
 import {
   InfiniteData,
-  useInfiniteQuery,
   useMutation,
   useQuery,
   useQueryClient,
@@ -110,19 +109,10 @@ export const useGetGroupMembers = (
   groupId: GetGroupMembersRequest['groupId'],
   size: CursorRequest['size']
 ) =>
-  useInfiniteQuery<
-    GetGroupMembersResponse,
-    ApiResponse,
-    InfiniteData<GetGroupMembersResponse>,
-    string[],
-    number | undefined
-  >({
-    queryKey: [GROUP_QUERY_KEYS.groupMembers, groupId],
-    queryFn: ({ pageParam }) =>
-      groupsApi.getGroupMembers({ groupId, cursorId: pageParam, size }),
-    getNextPageParam: (lastPage) =>
-      lastPage.hasNext ? lastPage.cursorId : undefined,
-    initialPageParam: undefined,
+  useQuery<GetGroupMembersResponse>({
+    queryKey: [GROUP_QUERY_KEYS.groupMembers, groupId, size],
+    queryFn: () =>
+      groupsApi.getGroupMembers({ groupId, cursorId: undefined, size }),
   });
 
 export const infiniteGroupMembersOptions = (
@@ -136,7 +126,7 @@ export const infiniteGroupMembersOptions = (
   string[],
   number | undefined
 > => ({
-  queryKey: [GROUP_QUERY_KEYS.groupMembers, groupId],
+  queryKey: [GROUP_QUERY_KEYS.groupMembers, groupId, (size ?? 20).toString()],
   queryFn: async ({ pageParam }) => {
     const res = await groupsApi.getGroupMembers({
       groupId,

--- a/src/hooks/groupHooks/groupHooks.ts
+++ b/src/hooks/groupHooks/groupHooks.ts
@@ -1,9 +1,17 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  InfiniteData,
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { GROUP_QUERY_KEYS } from '@/constants/queryKeys';
 import { groupsApi } from '@/services/groupsService';
-import { ApiResponse } from '@/types/api';
+import { ApiResponse, CursorRequest } from '@/types/api';
 import {
+  GetGroupMembersRequest,
+  GetGroupMembersResponse,
   GetGroupsParams,
   GroupInfoResponse,
   PostJoinGroupRequest,
@@ -95,3 +103,22 @@ export const useCreateGroup = () => {
     },
   });
 };
+
+export const useGetGroupMembers = (
+  groupId: GetGroupMembersRequest['groupId'],
+  size: CursorRequest['size']
+) =>
+  useInfiniteQuery<
+    GetGroupMembersResponse,
+    ApiResponse,
+    InfiniteData<GetGroupMembersResponse>,
+    string[],
+    number | undefined
+  >({
+    queryKey: [GROUP_QUERY_KEYS.groupMembers, groupId],
+    queryFn: ({ pageParam }) =>
+      groupsApi.getGroupMembers({ groupId, cursorId: pageParam, size }),
+    getNextPageParam: (lastPage) =>
+      lastPage.hasNext ? lastPage.cursorId : undefined,
+    initialPageParam: undefined,
+  });

--- a/src/hooks/groupHooks/groupHooks.ts
+++ b/src/hooks/groupHooks/groupHooks.ts
@@ -140,6 +140,7 @@ export const infiniteGroupMembersOptions = (
       groupId: res.data.groupId,
       performanceId: res.data.performanceId,
       memberCount: res.data.memberCount,
+      isHost: res.data.isHost,
       cursorId: res.cursorId,
       hasNext: res.hasNext,
       code: res.code,

--- a/src/mocks/handlers/groupsHandlers.ts
+++ b/src/mocks/handlers/groupsHandlers.ts
@@ -795,7 +795,7 @@ export const groupsHandlers = [
       const cursorId = Number(url.searchParams.get('cursorId'));
       const size = Number(url.searchParams.get('size')) || 20;
 
-      const startIndex = isNaN(cursorId) ? cursorId : 0;
+      const startIndex = isNaN(cursorId) ? 0 : cursorId;
       const endIndex = startIndex + size;
       const slicedData = GROUP_MEMBERS_DATA.slice(startIndex, endIndex);
 

--- a/src/services/groupsService.ts
+++ b/src/services/groupsService.ts
@@ -10,6 +10,8 @@ import {
   CreateGroupApiRequest,
   CreateGroupFormData,
   ScheduleRequest,
+  GetGroupMembersRequest,
+  GetGroupMembersResponse,
 } from '@/types/group';
 import { Post } from '@/types/post';
 import { formatPostDate } from '@/utils/date';
@@ -122,4 +124,18 @@ export const groupsApi = {
     await apiFetcher.delete(
       `/api/v1/groups/${groupId}/schedules/${scheduleId}`
     ),
+
+  getGroupMembers: async ({
+    groupId,
+    cursorId,
+    size = 20,
+  }: GetGroupMembersRequest) =>
+    (
+      await apiFetcher.get<GetGroupMembersResponse>(
+        `/api/v1/groups/${groupId}/members`,
+        {
+          params: { groupId, cursorId, size },
+        }
+      )
+    ).data,
 };

--- a/src/services/groupsService.ts
+++ b/src/services/groupsService.ts
@@ -12,6 +12,8 @@ import {
   ScheduleRequest,
   GetGroupMembersRequest,
   GetGroupMembersResponse,
+  PatchGroupMemberRoleRequest,
+  DeleteGroupMemberRequest,
 } from '@/types/group';
 import { Post } from '@/types/post';
 import { formatPostDate } from '@/utils/date';
@@ -136,6 +138,25 @@ export const groupsApi = {
         {
           params: { groupId, cursorId, size },
         }
+      )
+    ).data,
+
+  patchGroupMemberRole: async ({
+    groupId,
+    memberId,
+    role,
+  }: PatchGroupMemberRoleRequest) =>
+    (
+      await apiFetcher.patch<ApiResponse>(
+        `/api/v1/groups/${groupId}/members/${memberId}/role`,
+        { role }
+      )
+    ).data,
+
+  deleteGroupMember: async ({ groupId, memberId }: DeleteGroupMemberRequest) =>
+    (
+      await apiFetcher.delete<ApiResponse>(
+        `/api/v1/groups/${groupId}/members/${memberId}`
       )
     ).data,
 };

--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -95,6 +95,7 @@ export const ReportStatus = {
 } as const;
 
 export type ReportStatusType = (typeof ReportStatus)[keyof typeof ReportStatus];
+
 export const EventColor = {
   RED: 'red',
   BLUE: 'blue',
@@ -105,3 +106,10 @@ export const EventColor = {
 } as const;
 
 export type EventColorName = (typeof EventColor)[keyof typeof EventColor];
+
+export const Role = {
+  HOST: 'HOST', // 모임장
+  MEMBER: 'MEMBER', // 모임원
+} as const;
+
+export type RoleType = (typeof Role)[keyof typeof Role];

--- a/src/types/group.ts
+++ b/src/types/group.ts
@@ -173,3 +173,14 @@ export type GetGroupMembersFormattedResponse = {
   memberCount: number;
 } & CursorResponse
   & ApiResponse;
+
+export type PatchGroupMemberRoleRequest = {
+  groupId: string;
+  memberId: string;
+  role: string;
+};
+
+export type DeleteGroupMemberRequest = {
+  groupId: string;
+  memberId: string;
+};

--- a/src/types/group.ts
+++ b/src/types/group.ts
@@ -165,3 +165,11 @@ export type GetGroupMembersResponse = {
   };
 } & CursorResponse
   & ApiResponse;
+
+export type GetGroupMembersFormattedResponse = {
+  data: Member[];
+  groupId: string;
+  performanceId: string;
+  memberCount: number;
+} & CursorResponse
+  & ApiResponse;

--- a/src/types/group.ts
+++ b/src/types/group.ts
@@ -1,5 +1,10 @@
 import { DateRange } from '@/types/dateRange';
-import { ApiResponse, PageResponse } from './api';
+import {
+  ApiResponse,
+  CursorRequest,
+  CursorResponse,
+  PageResponse,
+} from './api';
 import { GroupCategoryType, GenderType, EventColorName } from './enums';
 
 export interface Group {
@@ -139,3 +144,24 @@ export interface ScheduleRequest {
   location: string;
   eventColor?: EventColorName;
 }
+
+export interface Member {
+  memberId: string; // 모임원 ID
+  name: string; // 이름
+  profileImage?: string; // 프로필 이미지
+  role: string; // 역할
+}
+
+export type GetGroupMembersRequest = {
+  groupId: string;
+} & CursorRequest;
+
+export type GetGroupMembersResponse = {
+  data: {
+    groupId: string;
+    performanceId: string;
+    memberCount: number;
+    members: Member[];
+  };
+} & CursorResponse
+  & ApiResponse;

--- a/src/types/group.ts
+++ b/src/types/group.ts
@@ -75,7 +75,7 @@ export interface GroupInfo {
   description?: string;
   hashtag?: string[];
   host: {
-    hostId: string;
+    id: string;
     name: string;
     rating?: number;
     profileImage?: string;
@@ -161,6 +161,7 @@ export type GetGroupMembersResponse = {
     groupId: string;
     performanceId: string;
     memberCount: number;
+    isHost: boolean;
     members: Member[];
   };
 } & CursorResponse
@@ -170,6 +171,7 @@ export type GetGroupMembersFormattedResponse = {
   data: Member[];
   groupId: string;
   performanceId: string;
+  isHost: boolean;
   memberCount: number;
 } & CursorResponse
   & ApiResponse;


### PR DESCRIPTION
### 무엇을 위한 PR인가요? (: 뒤 설명 추가)

- 신규 기능 추가: 모임원 목록 조회, 역할 변경, 퇴출 기능 추가
- 버그 수정: 채팅창 버그 수정

### 변경사항 및 이유 (bullet 으로 구분)

- 모임원 목록 조회, 역할 변경, 퇴출 기능 추가
- 모임원 목록 조회, 역할 변경, 퇴출 api 연결
- 채팅창 버그 수정

### 작업 내역 (bullet 으로 구분)

- 모임원 목록 조회
  - api 연결
  - Carousel용 일반 호출 hook 추가
  - InfiniteList용 무한스크롤 option, hook 추가
  - Suspensive 라이브러리 사용
  - 로딩 시 스켈레톤 ui 적용
  - 사용자 프로필 사진이나 이름 클릭 시 프로필 페이지로 라우팅
- 모임원 역할 변경
  - api 연결
  - 모임장일 경우에만 모임장 위임 가능
  - 모임장 본인은 역할 변경 불가능
- 모임원 퇴출
  - api 연결
  - 모임장일 경우에만 모임원 퇴출 가능
  - 모임장 본인은 퇴출 불가능
- 채팅창 버그 수정
  - 이전 채팅 메세지가 없을 경우 채팅 입력이 안되는 버그 수정

### 작업 후 기대 동작(스크린샷)

https://github.com/user-attachments/assets/eb31afdd-147c-48ce-a02b-a6935802a481

https://github.com/user-attachments/assets/a077978f-8098-4728-96af-963b03521ba2

https://github.com/user-attachments/assets/3f33459f-461b-4a07-8227-09615fda05fa

### Issue Number

close: #383