### PR TITLE
[Feature/issue-393] 모임 정보 수정 관련 컴포넌트 추가 및 페이지 구현

### DIFF
--- a/src/app/(hasGNB)/(isLogin)/groups/[groupId]/edit/page.tsx
+++ b/src/app/(hasGNB)/(isLogin)/groups/[groupId]/edit/page.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import EditGroupWrapper from '@/components/pages/groupDetail/editGroup/EditGroupWrapper';
+
+const page = () => <EditGroupWrapper />;
+
+export default page;

--- a/src/components/icons/BlankIcon.tsx
+++ b/src/components/icons/BlankIcon.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+const BlankIcon = ({ className }: { className?: string }) => (
+  <svg
+    className={className}
+    width='24'
+    height='24'
+    viewBox='0 0 24 24'
+    fill='none'
+    xmlns='http://www.w3.org/2000/svg'
+  >
+    <path
+      d='M14.9725 12.7226C15.3731 12.3612 15.3731 11.6389 14.9725 11.2775L9.93021 6.72802C9.43478 6.28103 8.72749 6.70596 8.72749 7.4506V16.5495C8.72749 17.2941 9.43478 17.7191 9.93021 17.2721L14.9725 12.7226Z'
+      fill='#1F1F22'
+    />
+  </svg>
+);
+
+export default BlankIcon;

--- a/src/components/pages/groupDetail/GroupInfoCard/GroupInfoCard.tsx
+++ b/src/components/pages/groupDetail/GroupInfoCard/GroupInfoCard.tsx
@@ -1,11 +1,17 @@
+import { useRef } from 'react';
 import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';
+import { useRouter } from 'next/navigation';
 import Badge from '@/components/common/Badge/Badge';
 import Button from '@/components/common/Button/Button';
+import CreateReportModal from '@/components/common/CreateReportModal/CreateReportModal';
 import HashtagBadgeGroup from '@/components/common/HashtagBadgeGroup/HashtagBadgeGroup';
+import MoreDropdown from '@/components/common/MoreDropdown/MoreDropdown';
 import ProfileImage from '@/components/common/ProfileImage/ProfileImage';
 import ProgressBar from '@/components/common/ProgressBar/ProgressBar';
 import StarIcon from '@/components/icons/StarIcon';
+import { useGetUserId } from '@/hooks/userHooks/userHooks';
+import { ReportTarget } from '@/types/enums';
 import { GroupInfo } from '@/types/group';
 
 const DATE_FORMAT = 'yy.MM.dd';
@@ -18,87 +24,121 @@ interface GroupInfoCardProps {
 const GroupInfoCard = ({
   groupInfo,
   handleButtonClick,
-}: GroupInfoCardProps) => (
-  <div className='px-4'>
-    <div className='flex w-full flex-col items-start justify-center gap-4 rounded-2xl bg-gray-25 p-5'>
-      {/* 카테고리, 날짜 */}
-      <div className='flex w-full items-center justify-between'>
-        <div className='flex gap-0.5'>
-          <Badge
-            label={groupInfo.category}
-            className='flex items-center gap-1 text-14_M text-gray-600'
+}: GroupInfoCardProps) => {
+  const { data: userId, isPending, isError } = useGetUserId();
+  const isHost = String(userId?.data?.userId) === String(groupInfo.host.id);
+  const router = useRouter();
+  const reportTriggerRef = useRef<HTMLButtonElement>(null);
+
+  const handleReportPost = () => {
+    reportTriggerRef.current?.click();
+  };
+
+  // TODO: 로딩 상태 처리
+  if (isPending || isError) return null;
+
+  return (
+    <div className='px-4'>
+      <div className='flex w-full flex-col items-start justify-center gap-4 rounded-2xl bg-gray-25 p-5'>
+        <div className='flex w-full items-center justify-between'>
+          <div className='flex gap-0.5'>
+            <Badge
+              label={groupInfo.category}
+              className='flex items-center gap-1 text-14_M text-gray-600'
+            />
+          </div>
+          <span className='text-12_M text-gray-600'>
+            {/* TODO: date.ts 파일 추가 후 수정 */}
+            {format(new Date(groupInfo.startDate), DATE_FORMAT, {
+              locale: ko,
+            })}
+            ~
+            {format(new Date(groupInfo.endDate), DATE_FORMAT, {
+              locale: ko,
+            })}
+          </span>
+          <MoreDropdown
+            items={[
+              ...(isHost
+                ? [
+                    {
+                      label: '수정하기',
+                      onClick: () =>
+                        router.push(`/groups/${groupInfo.id}/edit`),
+                    },
+                  ]
+                : [
+                    {
+                      label: '신고하기',
+                      onClick: () => handleReportPost(),
+                    },
+                  ]),
+            ]}
           />
         </div>
-        <span className='text-12_M text-gray-600'>
-          {format(new Date(groupInfo.startDate), DATE_FORMAT, {
-            locale: ko,
-          })}
-          ~
-          {format(new Date(groupInfo.endDate), DATE_FORMAT, {
-            locale: ko,
-          })}
-        </span>
-      </div>
 
-      <div className='flex w-full justify-between gap-4'>
-        <div className='flex flex-1 flex-col justify-between overflow-hidden'>
-          {/* 모임명 */}
-          <h4 className='mb-1.5 truncate text-16_B text-black'>
-            {groupInfo.title}
-          </h4>
-          {/* 모임 정보 */}
-          <div className='mb-2.5 flex items-center gap-2 text-13_M text-gray-700'>
-            <span>{groupInfo.location}</span>
-            <div className='h-2 w-[1px] bg-gray-200' />
-            <span>{groupInfo.gender}</span>
-            <div className='h-2 w-[1px] bg-gray-200' />
-            <span>
-              {groupInfo.startAge}~{groupInfo.endAge}세
-            </span>
+        <div className='flex w-full justify-between gap-4'>
+          <div className='flex flex-1 flex-col justify-between overflow-hidden'>
+            <h4 className='mb-1.5 truncate text-16_B text-black'>
+              {groupInfo.title}
+            </h4>
+            <div className='mb-2.5 flex items-center gap-2 text-13_M text-gray-700'>
+              <span>{groupInfo.location}</span>
+              <div className='h-2 w-[1px] bg-gray-200' />
+              <span>{groupInfo.gender}</span>
+              <div className='h-2 w-[1px] bg-gray-200' />
+              <span>
+                {groupInfo.startAge}~{groupInfo.endAge}세
+              </span>
+            </div>
+            <div className='flex items-center gap-0.5'>
+              <ProfileImage
+                size='xs'
+                src={groupInfo.host.profileImage}
+                alt={groupInfo.host.name}
+                border={false}
+              />
+              <span className='text-12_M text-gray-700'>
+                {groupInfo.host.name}
+              </span>
+              <span className='flex text-12_M text-gray-700'>
+                (<StarIcon className='h-3 w-3' />
+                {groupInfo.host.rating})
+              </span>
+            </div>
+            <p className='line-clamp-2 w-full text-14_body_M text-gray-950'>
+              {groupInfo.description}
+            </p>
           </div>
-          {/* 방장 정보 */}
-          <div className='flex items-center gap-0.5'>
-            <ProfileImage
-              size='xs'
-              src={groupInfo.host.profileImage}
-              alt={groupInfo.host.name}
-              border={false}
-            />
-            <span className='text-12_M text-gray-700'>
-              {groupInfo.host.name}
-            </span>
-            <span className='flex text-12_M text-gray-700'>
-              (<StarIcon className='h-3 w-3' />
-              {groupInfo.host.rating})
-            </span>
-          </div>
-          {/* 소개글 */}
-          <p className='line-clamp-2 w-full text-14_body_M text-gray-950'>
-            {groupInfo.description}
-          </p>
+        </div>
+
+        <ProgressBar
+          current={groupInfo.memberCount}
+          total={groupInfo.maxMembers}
+        />
+
+        {groupInfo.hashtag && (
+          <HashtagBadgeGroup hashtags={groupInfo.hashtag} />
+        )}
+
+        <div className='flex w-full gap-2'>
+          <Button
+            variant='primary'
+            color='normal'
+            onClick={handleButtonClick}
+          >
+            {groupInfo.isMember ? '모임 탈퇴' : '참가 신청'}
+          </Button>
         </div>
       </div>
-
-      {/* 인원 수 프로그레스 바 */}
-      <ProgressBar
-        current={groupInfo.memberCount}
-        total={groupInfo.maxMembers}
-      />
-
-      {/* 해시태그 */}
-      {groupInfo.hashtag && <HashtagBadgeGroup hashtags={groupInfo.hashtag} />}
-
-      <div className='flex w-full gap-2'>
-        <Button
-          variant='primary'
-          color='normal'
-          onClick={handleButtonClick}
-        >
-          {groupInfo.isMember ? '모임 탈퇴' : '참가 신청'}
-        </Button>
-      </div>
+      <CreateReportModal
+        targetId={groupInfo.host.id || ''}
+        category={ReportTarget.GROUP}
+      >
+        <button ref={reportTriggerRef}></button>
+      </CreateReportModal>
     </div>
-  </div>
-);
+  );
+};
 
 export default GroupInfoCard;

--- a/src/components/pages/groupDetail/editGroup/EditGroupWrapper.tsx
+++ b/src/components/pages/groupDetail/editGroup/EditGroupWrapper.tsx
@@ -1,0 +1,169 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { Button } from '@/components/common';
+import Header from '@/components/common/Header/Header';
+import NormalCategorySelector from '@/components/pages/groupDetail/editGroup/NormalCategorySelector';
+import NormalDateSelector from '@/components/pages/groupDetail/editGroup/NormalDateSelector';
+import NormalDescriptionInput from '@/components/pages/groupDetail/editGroup/NormalDescriptionInput';
+import NormalLocationSelector from '@/components/pages/groupDetail/editGroup/NormalLocationSelector';
+import NormalParticipantsInput from '@/components/pages/groupDetail/editGroup/NormalParticipantsInput';
+import NormalTagInput from '@/components/pages/groupDetail/editGroup/NormalTagInput';
+import NormalTitleInput from '@/components/pages/groupDetail/editGroup/NormalTitleInput';
+import { GenderLabels } from '@/constants/genderLabels';
+import { GroupCategoryLabels } from '@/constants/groupLabels';
+import { LocationLabels } from '@/constants/locationLabels';
+import { useGetGroupInfo } from '@/hooks/groupHooks/groupHooks';
+import { useUpdateGroup } from '@/hooks/groupHooks/groupHooks';
+import { DateRange } from '@/types/dateRange';
+import { GenderType, LocationType } from '@/types/enums';
+import { UpdateGroupApiRequest } from '@/types/group';
+
+const MIN_PARTICIPANTS = 2;
+const MAX_PARTICIPANTS = 50;
+
+const labelToKey = (label: string): LocationType | '' => {
+  const entry = (
+    Object.entries(LocationLabels) as [LocationType, string][]
+  ).find(([, lbl]) => lbl === label);
+  return entry ? entry[0] : '';
+};
+
+const genderLabelToKey = (label: string): GenderType => {
+  const entry = Object.entries(GenderLabels).find(([, lbl]) => lbl === label);
+  return entry ? (entry[0] as GenderType) : 'ALL';
+};
+
+const EditGroupWrapper = () => {
+  const params = useParams();
+  const groupId = params?.groupId as string;
+  const router = useRouter();
+  const { data: groupDetail, isLoading } = useGetGroupInfo(groupId);
+  const { mutateAsync: updateGroup } = useUpdateGroup();
+
+  const [category, setCategory] = useState<
+    (typeof GroupCategoryLabels)[keyof typeof GroupCategoryLabels]
+  >(GroupCategoryLabels.COMPANION);
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [region, setRegion] = useState('');
+  const [participants, setParticipants] = useState<number>(0);
+  const [tags, setTags] = useState<string[]>([]);
+  const [dateRange, setDateRange] = useState<DateRange>({
+    startDate: null,
+    endDate: null,
+  });
+
+  const originalGender = groupDetail?.data?.gender;
+  const originalStartAge = groupDetail?.data?.startAge;
+  const originalEndAge = groupDetail?.data?.endAge;
+
+  useEffect(() => {
+    if (!groupDetail?.data) return;
+    const d = groupDetail.data;
+
+    setCategory(d.category || GroupCategoryLabels.COMPANION);
+    setTitle(d.title);
+    setDescription(d.description || '');
+    setRegion(labelToKey(d.location));
+    // 날짜 포맷이 ISO 문자열일 때, 앞 10자리만 잘라서 YYYY-MM-DD 로
+    setDateRange({
+      startDate: new Date(d.startDate.slice(0, 10)),
+      endDate: new Date(d.endDate.slice(0, 10)),
+    });
+    setParticipants(d.maxMembers);
+    setTags(d.hashtag || []);
+  }, [groupDetail]);
+
+  if (isLoading) return <div>로딩 중…</div>;
+
+  const handleSubmit = async () => {
+    if (!groupDetail) return;
+    const payload = {
+      title,
+      category: category,
+      gender: genderLabelToKey(originalGender as string),
+      startAge: originalStartAge!,
+      endAge: originalEndAge!,
+      location: LocationLabels[region as LocationType],
+      startDate: dateRange.startDate!.toISOString().replace('.000', ''),
+      endDate: dateRange.endDate!.toISOString().replace('.000', ''),
+      maxMembers: participants,
+      description,
+      hashtag: tags,
+    };
+
+    try {
+      const res = await updateGroup({
+        groupId,
+        groupData: payload as UpdateGroupApiRequest,
+      });
+      if (res.code === 200) {
+        router.replace(`/groups/${groupId}`);
+      }
+    } catch (err) {
+      console.error('수정 API 오류', err);
+      // TODO: 에러 토스트 등 UI 처리
+    }
+  };
+
+  return (
+    <>
+      {/* TODO: DetailHeader 컴포넌트로 수정*/}
+      <Header title='모임 정보 수정' />
+      <div className='mx-auto flex max-w-md flex-col gap-[30px] px-4 pt-6 pb-[88px]'>
+        <div className='flex justify-between'>
+          <span className='text-14_B text-black'>공연 이름</span>
+          <span className='text-16_M text-gray-950'>
+            {groupDetail?.data?.performance?.title}
+          </span>
+        </div>
+        <div>
+          <NormalCategorySelector
+            value={category}
+            onChange={setCategory}
+          />
+        </div>
+        <NormalTitleInput
+          value={title}
+          onChange={setTitle}
+        />
+        <NormalDescriptionInput
+          value={description}
+          onChange={setDescription}
+        />
+        <NormalLocationSelector
+          value={region}
+          onChange={setRegion}
+        />
+        <NormalDateSelector
+          value={dateRange}
+          onChange={setDateRange}
+        />
+        <NormalParticipantsInput
+          value={participants}
+          onChange={setParticipants}
+          min={MIN_PARTICIPANTS}
+          max={MAX_PARTICIPANTS}
+        />
+        <NormalTagInput
+          tags={tags}
+          onAdd={(tag) => setTags([...tags, tag])}
+          onRemove={(tag) => setTags(tags.filter((t) => t !== tag))}
+        />
+        <div className='fixed right-0 bottom-0 left-0 z-20 flex justify-end gap-2.5 bg-white px-4 py-5'>
+          <Button
+            variant='secondary'
+            color='normal'
+            onClick={() => router.replace(`/groups/${groupId}`)}
+          >
+            취소
+          </Button>
+          <Button onClick={handleSubmit}>수정</Button>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default EditGroupWrapper;

--- a/src/components/pages/groupDetail/editGroup/NormalCategorySelector.tsx
+++ b/src/components/pages/groupDetail/editGroup/NormalCategorySelector.tsx
@@ -1,0 +1,65 @@
+'use client';
+import React from 'react';
+import CarIcon from '@/components/icons/CarIcon';
+import GroupIcon from '@/components/icons/GroupIcon';
+import SleepIcon from '@/components/icons/SleepIcon';
+import { GroupCategoryLabels } from '@/constants/groupLabels';
+import { cn } from '@/lib/utils';
+
+interface CategorySelectorProps {
+  value: (typeof GroupCategoryLabels)[keyof typeof GroupCategoryLabels];
+  onChange: (
+    v: (typeof GroupCategoryLabels)[keyof typeof GroupCategoryLabels]
+  ) => void;
+  className?: string;
+}
+
+const NormalCategorySelector: React.FC<CategorySelectorProps> = ({
+  value,
+  onChange,
+  className,
+}) => (
+  <>
+    <div className='mb-2.5 text-14_B text-black'>종류</div>
+    <div className={cn('flex w-full gap-2 text-16_M', className)}>
+      <button
+        onClick={() => onChange(GroupCategoryLabels.COMPANION)}
+        className={cn(
+          'flex items-center justify-center gap-1 rounded-full px-5 py-3',
+          value === GroupCategoryLabels.COMPANION
+            ? 'bg-gray-950 text-white'
+            : 'border border-gray-100 bg-white text-gray-950'
+        )}
+      >
+        <GroupIcon className='h-4 w-4' />
+        <span>동행</span>
+      </button>
+      <button
+        onClick={() => onChange(GroupCategoryLabels.RIDE_SHARE)}
+        className={cn(
+          'flex items-center justify-center gap-1 rounded-full px-5 py-3',
+          value === GroupCategoryLabels.RIDE_SHARE
+            ? 'bg-gray-950 text-white'
+            : 'border border-gray-100 bg-white text-gray-950'
+        )}
+      >
+        <CarIcon className='h-4 w-4' />
+        <span>탑승</span>
+      </button>
+      <button
+        onClick={() => onChange(GroupCategoryLabels.ROOM_SHARE)}
+        className={cn(
+          'flex items-center justify-center gap-1 rounded-full px-5 py-3',
+          value === GroupCategoryLabels.ROOM_SHARE
+            ? 'bg-gray-950 text-white'
+            : 'border border-gray-100 bg-white text-gray-950'
+        )}
+      >
+        <SleepIcon className='h-4 w-4' />
+        <span>숙박</span>
+      </button>
+    </div>
+  </>
+);
+
+export default NormalCategorySelector;

--- a/src/components/pages/groupDetail/editGroup/NormalDateSelector.tsx
+++ b/src/components/pages/groupDetail/editGroup/NormalDateSelector.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import React, { useState } from 'react';
+import { format } from 'date-fns';
+import { ko } from 'date-fns/locale';
+import { Calendar, BottomSheetModal, Button } from '@/components/common';
+import { useModalContext } from '@/components/common/Modal/ModalContext';
+import BlankIcon from '@/components/icons/BlankIcon';
+import { cn } from '@/lib/utils';
+import { DateRange } from '@/types/dateRange';
+
+interface NormalDateSelectorProps {
+  value: DateRange;
+  onChange: (range: DateRange) => void;
+  className?: string;
+  triggerClassName?: string;
+}
+
+const DateSelectorContent = ({
+  value,
+  tempStart,
+  handleDateClick,
+  handleReset,
+}: {
+  value: DateRange;
+  tempStart: Date | null;
+  handleDateClick: (date: Date) => void;
+  handleReset: () => void;
+}) => {
+  const { closeModal } = useModalContext();
+
+  const handleConfirm = () => {
+    closeModal();
+  };
+
+  return (
+    <>
+      <div className='p-6'>
+        <Calendar
+          isControllable
+          startDate={tempStart || value.startDate}
+          endDate={tempStart ? null : value.endDate}
+          onDateClick={handleDateClick}
+          className='mb-4 flex flex-col gap-1'
+        />
+      </div>
+      {value && (
+        <div className='flex justify-between gap-2.5 px-4 pb-4'>
+          <Button
+            onClick={handleReset}
+            variant='secondary'
+          >
+            초기화
+          </Button>
+          <Button onClick={handleConfirm}>선택 완료</Button>
+        </div>
+      )}
+    </>
+  );
+};
+
+const NormalDateSelector: React.FC<NormalDateSelectorProps> = ({
+  value,
+  onChange,
+  className,
+  triggerClassName,
+}) => {
+  const [tempStart, setTempStart] = useState<Date | null>(null);
+
+  const dateRange: DateRange = value || { startDate: null, endDate: null };
+
+  const handleDateClick = (date: Date) => {
+    if (!tempStart) {
+      setTempStart(date);
+    } else {
+      let start = tempStart;
+      let end = date;
+      if (start > end) [start, end] = [end, start];
+      onChange({ startDate: start, endDate: end });
+      setTempStart(null);
+    }
+  };
+
+  const handleReset = () => {
+    onChange({ startDate: null, endDate: null });
+    setTempStart(null);
+  };
+
+  const formatDisplay = () => {
+    const { startDate, endDate } = dateRange;
+    if (startDate && !endDate)
+      return format(startDate, 'yyyy.MM.dd', { locale: ko });
+    if (startDate && endDate) {
+      return `${format(startDate, 'yyyy.MM.dd', { locale: ko })} - ${format(
+        endDate,
+        'yyyy.MM.dd',
+        { locale: ko }
+      )}`;
+    }
+  };
+
+  const displayText = formatDisplay();
+  const hasSelection = Boolean(dateRange.startDate || dateRange.endDate);
+
+  const TriggerButton = ({ onClick }: { onClick?: () => void }) => (
+    <button
+      type='button'
+      onClick={onClick}
+      className={cn(
+        'flex w-full items-center justify-between gap-2 rounded-2xl border bg-white px-5 py-3 text-16_M',
+        'hover:bg-gray-100 focus:ring-2 focus:outline-none',
+        triggerClassName
+      )}
+    >
+      <span className={cn(hasSelection ? 'text-gray-950' : 'text-gray-400')}>
+        {displayText}
+      </span>
+      <BlankIcon className='flex-shrink-0' />
+    </button>
+  );
+
+  return (
+    <div className={className}>
+      <div className='mb-2.5 text-14_B text-black'>날짜</div>
+      <BottomSheetModal
+        trigger={<TriggerButton />}
+        height='auto'
+        hasHandle={false}
+        hasClose={false}
+      >
+        <DateSelectorContent
+          value={dateRange}
+          tempStart={tempStart}
+          handleDateClick={handleDateClick}
+          handleReset={handleReset}
+        />
+      </BottomSheetModal>
+    </div>
+  );
+};
+
+export default NormalDateSelector;

--- a/src/components/pages/groupDetail/editGroup/NormalDescriptionInput.tsx
+++ b/src/components/pages/groupDetail/editGroup/NormalDescriptionInput.tsx
@@ -1,0 +1,29 @@
+'use client';
+import React from 'react';
+import TextareaInput from '@/components/common/TextareaInput/TextareaInput';
+
+interface DescriptionInputProps {
+  value: string;
+  onChange: (v: string) => void;
+  label?: string;
+  className?: string;
+}
+
+const NormalDescriptionInput: React.FC<DescriptionInputProps> = ({
+  value,
+  onChange,
+  className,
+}) => (
+  <div className={className}>
+    <div className='mb-2.5 text-14_B text-black'>소개글</div>
+    <TextareaInput
+      rows={10}
+      value={value}
+      onChange={onChange}
+      maxLength={200}
+      className='h-48 w-full resize-none rounded-2xl border border-gray-100 px-5 py-4 text-16_M text-gray-950'
+    />
+  </div>
+);
+
+export default NormalDescriptionInput;

--- a/src/components/pages/groupDetail/editGroup/NormalLocationSelector.tsx
+++ b/src/components/pages/groupDetail/editGroup/NormalLocationSelector.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import React from 'react';
+import { BottomSheetModal, Button } from '@/components/common';
+import { useModalContext } from '@/components/common/Modal/ModalContext';
+import BlankIcon from '@/components/icons/BlankIcon';
+import { LocationLabels } from '@/constants/locationLabels';
+import { cn } from '@/lib/utils';
+import { generateFilterOptions } from '@/utils';
+
+const LOCATION_OPTIONS = generateFilterOptions(LocationLabels);
+
+interface LocationSelectorProps {
+  onChange: (value: string) => void;
+  className?: string;
+  triggerClassName?: string;
+  value: string;
+}
+
+const LocationSelectorContent = ({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+}) => {
+  const { closeModal } = useModalContext();
+
+  const handleSelect = (val: string) => {
+    onChange(val);
+  };
+
+  const handleConfirm = () => {
+    closeModal();
+  };
+
+  return (
+    <div className='p-5'>
+      <div className='grid grid-cols-4 gap-4'>
+        {LOCATION_OPTIONS.map((option) => (
+          <button
+            key={option.value}
+            onClick={() => handleSelect(option.value)}
+            className={cn(
+              'flex items-center justify-center rounded-full border px-5 py-3',
+              'text-14_M leading-normal tracking-[-0.35px] whitespace-nowrap',
+              'transition-colors duration-200 hover:bg-gray-100 focus:ring-2 focus:outline-none',
+              option.value === value
+                ? 'border-none bg-gray-950 text-white hover:text-gray-950'
+                : 'border-gray-100 bg-white text-gray-950'
+            )}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+
+      {value && (
+        <div className='flex justify-between gap-2.5 pt-4'>
+          <Button
+            onClick={() => handleSelect('')}
+            variant='secondary'
+          >
+            초기화
+          </Button>
+          <Button onClick={handleConfirm}>선택 완료</Button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const NormalLocationSelector: React.FC<LocationSelectorProps> = ({
+  onChange,
+  className,
+  triggerClassName,
+  value,
+}) => {
+  const selectedOption = LOCATION_OPTIONS.find(
+    (o) => o.value === value || o.label === value
+  );
+  const displayText = selectedOption?.label;
+
+  const TriggerButton = ({ onClick }: { onClick?: () => void }) => (
+    <button
+      type='button'
+      onClick={onClick}
+      className={cn(
+        'flex w-full items-center justify-between gap-2 rounded-2xl border bg-white px-5 py-3 text-16_M',
+        'hover:bg-gray-100 focus:ring-2 focus:outline-none',
+        triggerClassName
+      )}
+    >
+      <span className={cn(selectedOption ? 'text-gray-950' : 'text-gray-400')}>
+        {displayText}
+      </span>
+      <BlankIcon className='flex-shrink-0' />
+    </button>
+  );
+
+  return (
+    <div className={className}>
+      <div className='mb-2.5 text-14_B text-black'>지역</div>
+      <BottomSheetModal
+        trigger={<TriggerButton />}
+        height='auto'
+        title=''
+        hasHandle={false}
+        hasClose={false}
+      >
+        <LocationSelectorContent
+          value={value}
+          onChange={onChange}
+        />
+      </BottomSheetModal>
+    </div>
+  );
+};
+
+export default NormalLocationSelector;

--- a/src/components/pages/groupDetail/editGroup/NormalParticipantsInput.tsx
+++ b/src/components/pages/groupDetail/editGroup/NormalParticipantsInput.tsx
@@ -1,0 +1,42 @@
+'use client';
+import React from 'react';
+import { cn } from '@/lib/utils';
+
+interface ParticipantsInputProps {
+  value: number;
+  onChange: (v: number) => void;
+  label?: string;
+  className?: string;
+  min?: number;
+  max?: number;
+}
+
+const NormalParticipantsInput: React.FC<ParticipantsInputProps> = ({
+  value,
+  onChange,
+  className,
+  min = 2,
+  max = 50,
+}) => (
+  <div className={cn('flex items-center justify-between', className)}>
+    <div className='text-14_B text-black'>참여 인원 수</div>
+    <div className='flex items-center justify-center gap-0.5 rounded-2xl border border-gray-100 px-10 py-3.5 text-16_B'>
+      <input
+        type='number'
+        min={min}
+        max={max}
+        value={value === 0 ? '' : value}
+        onChange={(e) => {
+          const newValue = e.target.value === '' ? 0 : Number(e.target.value);
+          if (newValue <= max) {
+            onChange(newValue);
+          }
+        }}
+        className='border-none text-right focus:outline-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none'
+      />
+      <span className='text-left'>명</span>
+    </div>
+  </div>
+);
+
+export default NormalParticipantsInput;

--- a/src/components/pages/groupDetail/editGroup/NormalTagInput.tsx
+++ b/src/components/pages/groupDetail/editGroup/NormalTagInput.tsx
@@ -1,0 +1,71 @@
+'use client';
+import React, { useState } from 'react';
+import { Button } from '@/components/common';
+import XIcon from '@/components/icons/XIcon';
+
+interface TagSelectorProps {
+  tags: string[];
+  onAdd: (tag: string) => void;
+  onRemove: (tag: string) => void;
+  label?: string;
+  className?: string;
+}
+
+const NormalTagInput: React.FC<TagSelectorProps> = ({
+  tags,
+  onAdd,
+  onRemove,
+  className,
+}) => {
+  const [input, setInput] = useState('');
+  return (
+    <div className={className}>
+      <div className='mb-2.5 text-14_B text-black'>태그 추가</div>
+      <div className='flex flex-col gap-4'>
+        <div className='flex gap-2'>
+          <input
+            type='text'
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder='태그를 추가해 주세요.'
+            className='flex-1 rounded-2xl border border-gray-100 px-5 py-4 placeholder-gray-400'
+          />
+          <Button
+            onClick={() => {
+              if (input.trim() && !tags.includes(input.trim())) {
+                onAdd(input.trim());
+                setInput('');
+              }
+            }}
+            disabled={!input.trim()}
+            size='sm'
+            color={!input.trim() ? 'disable' : 'normal'}
+            className='rounded-2xl px-[17px] py-[17.5px]'
+          >
+            추가
+          </Button>
+        </div>
+
+        <div className='mt-2 flex flex-wrap gap-2'>
+          {tags.map((t) => (
+            <span
+              key={t}
+              className='flex items-center gap-1 rounded-full bg-gray-100 px-3 py-1 text-sm'
+            >
+              {t}
+              <button
+                onClick={() => onRemove(t)}
+                className='flex items-center justify-center text-gray-500'
+              >
+                {/* // TODO: 아이콘 변경 필요 */}
+                <XIcon className='flex h-4 w-4 items-center justify-center' />
+              </button>
+            </span>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default NormalTagInput;

--- a/src/components/pages/groupDetail/editGroup/NormalTitleInput.tsx
+++ b/src/components/pages/groupDetail/editGroup/NormalTitleInput.tsx
@@ -1,0 +1,27 @@
+'use client';
+import React from 'react';
+
+interface TitleInputProps {
+  value: string;
+  onChange: (v: string) => void;
+  label?: string;
+  className?: string;
+}
+
+const NormalTitleInput: React.FC<TitleInputProps> = ({
+  value,
+  onChange,
+  className,
+}) => (
+  <div className={className}>
+    <div className='mb-2.5 text-14_B text-black'>제목</div>
+    <input
+      type='text'
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      className='w-full rounded-2xl border border-gray-100 px-5 py-4 text-16_M text-gray-950'
+    />
+  </div>
+);
+
+export default NormalTitleInput;

--- a/src/hooks/groupHooks/groupHooks.ts
+++ b/src/hooks/groupHooks/groupHooks.ts
@@ -1,12 +1,16 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
-import { GROUP_QUERY_KEYS } from '@/constants/queryKeys';
+import {
+  GROUP_QUERY_KEYS,
+  GROUPS_MANAGEMENTS_QUERY_KEYS,
+} from '@/constants/queryKeys';
 import { groupsApi } from '@/services/groupsService';
 import { ApiResponse } from '@/types/api';
 import {
   GetGroupsParams,
   GroupInfoResponse,
   PostJoinGroupRequest,
+  UpdateGroupApiRequest,
 } from '@/types/group';
 import { CreateGroupFormData } from '@/types/group';
 import { GroupPostsResponse } from '@/types/post';
@@ -92,6 +96,25 @@ export const useCreateGroup = () => {
 
     onError: (error) => {
       console.error('Error creating group:', error);
+    },
+  });
+};
+
+export const useUpdateGroup = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    ApiResponse,
+    ApiResponse,
+    { groupId: string; groupData: UpdateGroupApiRequest }
+  >({
+    mutationFn: ({ groupId, groupData }) =>
+      groupsApi.patchUpdateGroup(groupId, groupData),
+
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [GROUPS_MANAGEMENTS_QUERY_KEYS.joinedGroups],
+      });
     },
   });
 };

--- a/src/services/groupsService.ts
+++ b/src/services/groupsService.ts
@@ -8,6 +8,7 @@ import {
   PostJoinGroupRequest,
   CreateGroupApiRequest,
   CreateGroupFormData,
+  UpdateGroupApiRequest,
 } from '@/types/group';
 import { Post } from '@/types/post';
 import { formatPostDate } from '@/utils/date';
@@ -84,5 +85,17 @@ export const groupsApi = {
     return await apiFetcher.post<
       ApiResponse<{ groupId: string; performanceId: string }>
     >(`/api/v1/groups`, apiRequest);
+  },
+
+  patchUpdateGroup: async (
+    groupId: string,
+    groupData: UpdateGroupApiRequest
+  ) => {
+    const response = await apiFetcher.patch<ApiResponse>(
+      `/api/v1/groups/${groupId}`,
+      groupData
+    );
+
+    return response.data;
   },
 };

--- a/src/types/group.ts
+++ b/src/types/group.ts
@@ -70,7 +70,8 @@ export interface GroupInfo {
   description?: string;
   hashtag?: string[];
   host: {
-    hostId: string;
+    hostId?: string;
+    id?: string;
     name: string;
     rating?: number;
     profileImage?: string;
@@ -101,6 +102,20 @@ export interface CreateGroupFormData {
 
 export interface CreateGroupApiRequest {
   performanceId: string;
+  title: string;
+  category: string;
+  gender: 'MALE' | 'FEMALE' | 'ALL';
+  startAge: number;
+  endAge: number;
+  location: string;
+  startDate: string;
+  endDate: string;
+  maxMembers: number;
+  description: string;
+  hashtag?: string[];
+}
+
+export interface UpdateGroupApiRequest {
   title: string;
   category: string;
   gender: 'MALE' | 'FEMALE' | 'ALL';


### PR DESCRIPTION
### 무엇을 위한 PR인가요? (: 뒤 설명 추가)

신규 기능 추가: 모임 정보 수정 기능

### 변경사항 및 이유 (bullet 으로 구분)

- 모임 데이터 타입에 id 필드 추가 및 수정: 모임 정보를 식별하고 수정하기 위해 고유 id가 필요합니다.

- 모임 정보 수정 API 커스텀 훅 추가: 모임 정보 수정과 관련된 비즈니스 로직을 효율적으로 관리하고 재사용하기 위해 커스텀 훅을 구현했습니다.

- 모임 정보 카드에 수정, 신고 모달 추가: 사용자가 모임 정보를 편리하게 수정하거나 부적절한 모임을 신고할 수 있도록 UI에 모달 기능을 추가했습니다.

- 모임 정보 수정용 컴포넌트, 아이콘 추가: 모임 정보 수정 페이지를 구성하는 데 필요한 UI 컴포넌트와 시각적 요소를 추가했습니다.


### 작업 내역 (bullet 으로 구분)

- 모임 데이터 모델에 id 필드를 추가하고 관련 로직을 수정했습니다.

- 모임 정보 수정을 위한 API 연동 로직을 커스텀 훅으로 구현했습니다.

- 모임 정보 카드에 수정 및 신고 기능을 위한 모달 컴포넌트를 추가하고 연결했습니다.

- 모임 정보 수정 페이지에 필요한 입력 필드, 버튼 등 UI 컴포넌트를 개발하고 배치했습니다.

- 모임 정보 수정 기능 관련 아이콘을 추가했습니다.

### ?작업 후 기대 동작(스크린샷)

- 모임 수정
https://github.com/user-attachments/assets/362f5b70-2dbd-435a-8508-e0c9e7b04c13

- 모임 신고
https://github.com/user-attachments/assets/201c44da-79d6-4cd0-b9bd-172347103b87

### PR 특이 사항

- 모임 개설할 때 사용한 reactForm으로 리팩토링 필요