### PR TITLE
[Feature/issue 425] 모임 상세페이지 모임원 목록, 모임 탭 블러 처리

### DIFF
--- a/src/components/pages/groupDetail/GroupBlurredContainer.tsx
+++ b/src/components/pages/groupDetail/GroupBlurredContainer.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { CrownIcon } from 'lucide-react';
 import { ProfileImage, Tabs } from '@/components/common';
+import { Skeleton } from '@/components/ui/skeleton';
 import { RoleLabels } from '@/constants/roleLabels';
 import { RoleType } from '@/types/enums';
 import { GroupInfo } from '@/types/group';
@@ -15,11 +16,25 @@ const blurredMembers = Array.from({ length: 3 }, (_, i) => ({
 const groupTabs = ['게시글', '채팅', '캘린더'];
 
 interface GroupBlurredContainerProps {
+  isPending: boolean;
   groupInfo?: GroupInfo;
 }
 
-const GroupBlurredContainer = ({ groupInfo }: GroupBlurredContainerProps) => {
+const GroupBlurredContainer = ({
+  isPending,
+  groupInfo,
+}: GroupBlurredContainerProps) => {
   const [selectedTab, setSelectedTab] = useState(groupTabs[0]);
+
+  if (isPending) {
+    return (
+      <div className='flex flex-col gap-7.5 px-4'>
+        <Skeleton className='h-[20dvh] w-full rounded-[16px]' />
+        <Skeleton className='h-[40dvh] w-full rounded-[16px]' />
+      </div>
+    );
+  }
+
   return (
     <>
       <div className='flex flex-col gap-5 px-4'>

--- a/src/components/pages/groupDetail/GroupBlurredContainer.tsx
+++ b/src/components/pages/groupDetail/GroupBlurredContainer.tsx
@@ -1,0 +1,91 @@
+import { useState } from 'react';
+import { CrownIcon } from 'lucide-react';
+import { ProfileImage, Tabs } from '@/components/common';
+import { RoleLabels } from '@/constants/roleLabels';
+import { RoleType } from '@/types/enums';
+import { GroupInfo } from '@/types/group';
+
+const blurredMembers = Array.from({ length: 3 }, (_, i) => ({
+  memberId: `member-${i + 1}`,
+  name: i === 0 ? '모임장' : `모임원 ${i}`,
+  profileImage: '',
+  role: i === 0 ? 'HOST' : 'MEMBER',
+}));
+
+const groupTabs = ['게시글', '채팅', '캘린더'];
+
+interface GroupBlurredContainerProps {
+  groupInfo?: GroupInfo;
+}
+
+const GroupBlurredContainer = ({ groupInfo }: GroupBlurredContainerProps) => {
+  const [selectedTab, setSelectedTab] = useState(groupTabs[0]);
+  return (
+    <>
+      <div className='flex flex-col gap-5 px-4'>
+        <div className='flex justify-between'>
+          <span className='text-16_B leading-normal tracking-[-0.4px] text-gray-950'>
+            멤버{' '}
+            <span>{groupInfo?.memberCount ? groupInfo.memberCount : '0'}</span>
+            명
+          </span>
+        </div>
+
+        <div className='relative'>
+          <div className='absolute top-1/2 left-1/2 z-1 -translate-x-1/2 -translate-y-1/2'>
+            <p className='text-16_B leading-normal tracking-[-0.35px] text-gray-700'>
+              모임에 참가하면 볼 수 있어요 👀
+            </p>
+          </div>
+
+          <div className='w-full blur-[6px]'>
+            <div className='m-0 flex gap-3 overflow-hidden'>
+              {blurredMembers?.map((member) => (
+                <div
+                  key={member.memberId}
+                  className='flex h-30 shrink-0 basis-[calc(100%/2.7)] flex-col items-center justify-center gap-3.5 rounded-[16px] border-1 border-gray-100 bg-white p-5'
+                >
+                  <div className='flex items-center justify-center gap-2.5'>
+                    <ProfileImage
+                      size='lg'
+                      src=''
+                      alt={member.name}
+                      border={false}
+                      className='aspect-square shrink-0'
+                    />
+                  </div>
+                  <div className='flex min-w-0 flex-col items-center gap-0.5'>
+                    <span className='flex items-center text-center text-12_M tracking-[-0.35px] text-gray-500'>
+                      {member.role === 'HOST' && (
+                        <CrownIcon className='mr-[1px] aspect-square h-3 w-3' />
+                      )}
+                      {RoleLabels[member.role as RoleType]}
+                    </span>
+                    <span className='w-full truncate text-center text-16_B leading-normal tracking-[-0.4px] text-gray-950'>
+                      {member.name}
+                    </span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <Tabs
+          tabs={groupTabs}
+          activeTab={selectedTab}
+          onTabChange={setSelectedTab}
+        />
+        <div className='w-ull mt-5 flex h-50 flex-col items-center justify-center gap-3.5 bg-white p-5'>
+          <p className='-ml-1 text-16_B leading-normal tracking-[-0.35px] text-gray-500'>
+            모임에 참가하고 이용해 보세요 ☺️
+          </p>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default GroupBlurredContainer;

--- a/src/components/pages/groupDetail/GroupInfoCard/GroupInfoCard.tsx
+++ b/src/components/pages/groupDetail/GroupInfoCard/GroupInfoCard.tsx
@@ -49,6 +49,7 @@ const GroupInfoCard = ({
             {formatNormalDate(groupInfo.endDate)}
           </span>
           <MoreDropdown
+            className='flex items-center justify-center'
             items={[
               ...(isHost
                 ? [
@@ -128,7 +129,10 @@ const GroupInfoCard = ({
         targetId={groupInfo.host.id || ''}
         category={ReportTarget.GROUP}
       >
-        <button ref={reportTriggerRef}></button>
+        <button
+          ref={reportTriggerRef}
+          className='hidden'
+        ></button>
       </CreateReportModal>
     </div>
   );

--- a/src/components/pages/groupDetail/GroupWrapper.tsx
+++ b/src/components/pages/groupDetail/GroupWrapper.tsx
@@ -25,7 +25,7 @@ const GroupWrapper = ({ groupId }: GroupWrapperProps) => {
   }
 
   return (
-    <div className='flex flex-col gap-7.5 bg-white'>
+    <div className='flex flex-col gap-7.5 bg-white pt-1'>
       <GroupInfo
         isPending={isPending}
         groupInfo={groupInfo?.data}
@@ -37,7 +37,10 @@ const GroupWrapper = ({ groupId }: GroupWrapperProps) => {
           <GroupTabs groupInfo={groupInfo?.data} />
         </>
       ) : (
-        <GroupBlurredContainer groupInfo={groupInfo?.data} />
+        <GroupBlurredContainer
+          isPending={isPending}
+          groupInfo={groupInfo?.data}
+        />
       )}
     </div>
   );

--- a/src/components/pages/groupDetail/GroupWrapper.tsx
+++ b/src/components/pages/groupDetail/GroupWrapper.tsx
@@ -2,6 +2,7 @@
 
 import { useGetGroupInfo } from '@/hooks/groupHooks/groupHooks';
 import { useAuthStore } from '@/providers/AuthStoreProvider';
+import GroupBlurredContainer from './GroupBlurredContainer';
 import GroupInfo from './GroupInfo';
 import GroupMembers from './GroupMembers';
 import GroupTabs from './GroupTabs';
@@ -30,11 +31,13 @@ const GroupWrapper = ({ groupId }: GroupWrapperProps) => {
         groupInfo={groupInfo?.data}
       />
 
-      {isLoggedIn && isMember && (
+      {isLoggedIn && isMember ? (
         <>
           <GroupMembers groupId={groupId} />
           <GroupTabs groupInfo={groupInfo?.data} />
         </>
+      ) : (
+        <GroupBlurredContainer groupInfo={groupInfo?.data} />
       )}
     </div>
   );

--- a/src/components/pages/groupsManagement/AppliedGroups.tsx
+++ b/src/components/pages/groupsManagement/AppliedGroups.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import Button from '@/components/common/Button/Button';
 import Modal from '@/components/common/Modal/Modal';
 import ModalAction from '@/components/common/Modal/ModalAction';
@@ -17,6 +18,7 @@ import { formatAppliedGroups } from '@/utils/formatApplicationData';
 import AppliedGroup from './AppliedGroup/AppliedGroup';
 
 const AppliedGroups = () => {
+  const router = useRouter();
   const triggerRef = useRef<HTMLButtonElement>(null);
   const { mutate: cancelApplication } = useCancelApplication();
   const { mutate: confirmApplication } = useConfirmApplication();
@@ -36,9 +38,7 @@ const AppliedGroups = () => {
     isFetchingNextPage
   );
 
-  useEffect(() => {
-    console.log(data);
-  }, [data]);
+  useEffect(() => {}, [data]);
   if (isPending) {
     return (
       <div className='flex h-full items-center justify-center'>
@@ -46,6 +46,10 @@ const AppliedGroups = () => {
       </div>
     );
   }
+
+  const routeToGroupPage = (groupId: string) => {
+    router.push(`/groups/${groupId}`);
+  };
 
   const handlePrimaryClick = (applicationId: string, status: string) => {
     if (status === ApplicationStatus.ACCEPTED) {
@@ -76,6 +80,7 @@ const AppliedGroups = () => {
             key={group.applicationId}
             applicationData={group}
             primaryButtonText={primaryText(group.status)}
+            onCardClick={() => routeToGroupPage(group.groupId)}
             onPrimaryClick={() =>
               handlePrimaryClick(group.applicationId, group.status)
             }


### PR DESCRIPTION
### 무엇을 위한 PR인가요? (: 뒤 설명 추가)

- 신규 기능 추가: 모임 상세페이지 모임원 목록, 모임 탭 블러 처리

### 변경사항 및 이유 (bullet 으로 구분)

- 모임 상세페이지: 사용자 경험 개선, 디자인 수정
- 나의 모임 페이지: 사용자 경험 개선, 불필요한 console 제거

### 작업 내역 (bullet 으로 구분)

- 모임 상세 페이지
  - 모임 참가자가 아닐 경우 모임원 목록, 모임 탭 안 블러 처리
  - 모임 정보와 모임원 목록 사이 갭 조정
  - 모임 정보 카드 [카테고리 - 날짜 - 신고버튼] align 맞춤
- 나의 모임 페이지
  - 신청한 모임에서 뜨는 console.log 삭제 (`AppliedGroups.tsx`)
  - 신청한 모임 클릭 시 해당 모임 페이지로 이동

### 작업 후 기대 동작(스크린샷)

https://github.com/user-attachments/assets/6f36edcb-b85f-4c53-b7e9-9a81feed1a7a

### Issue Number

close: #425 