### PR TITLE
[Feature/issue-418] 모임 정보, 게시글 관련 기능 추가 및 리팩토링 (#428)

### DIFF
--- a/src/components/common/MessageInput/MessageInput.tsx
+++ b/src/components/common/MessageInput/MessageInput.tsx
@@ -13,6 +13,7 @@ interface MessageInputProps {
   type: 'comment' | 'chat';
   maxLength?: number;
   minLength?: number;
+  className?: string;
 }
 
 const MessageInput = ({
@@ -21,6 +22,7 @@ const MessageInput = ({
   type = 'chat',
   maxLength = 300,
   minLength = 1,
+  className,
 }: MessageInputProps) => {
   const [message, setMessage] = useState<string>('');
   const [error, setError] = useState<string>('');
@@ -73,7 +75,8 @@ const MessageInput = ({
     <div
       className={cn(
         'fixed bottom-0 z-1 flex w-full flex-col gap-1',
-        type === 'comment' && 'border-t border-gray-100 bg-white p-4'
+        type === 'comment' && 'border-t border-gray-100 bg-white p-4',
+        className
       )}
     >
       <form

--- a/src/components/common/TabBar/TabBar.tsx
+++ b/src/components/common/TabBar/TabBar.tsx
@@ -29,6 +29,7 @@ const INVISIBLE_ROUTE = [
   '/groups/:groupId/edit',
   '/groups/:groupId/posts/:postId',
   '/groups/:groupId/posts/create',
+  '/groups/:groupId/posts/:postId/edit',
 ];
 
 const tabBarHide = (pathname: string) =>

--- a/src/components/icons/EditIcon.tsx
+++ b/src/components/icons/EditIcon.tsx
@@ -3,8 +3,8 @@ import React from 'react';
 const EditIcon = ({ className }: { className?: string }) => (
   <svg
     className={className}
-    width='16'
-    height='16'
+    width='24'
+    height='24'
     viewBox='0 0 16 16'
     fill='none'
     xmlns='http://www.w3.org/2000/svg'
@@ -12,15 +12,6 @@ const EditIcon = ({ className }: { className?: string }) => (
     <path
       d='M10.667 1.34131L12.667 3.34131L11.1423 4.86664L9.14233 2.86664L10.667 1.34131ZM2.66699 9.33331V11.3333H4.66699L10.1997 5.80864L8.19966 3.80864L2.66699 9.33331ZM2.66699 13.3333H13.3337V14.6666H2.66699V13.3333Z'
       fill='currentColor'
-      //   xmlns='http://www.w3.org/2000/svg'
-      //   width='24'
-      //   height='24'
-      //   viewBox='0 0 24 24'
-      //   fill='none'
-      // >
-      //   <path
-      //     d='M16.0833 2.01172L19.0833 5.01172L16.7963 7.29972L13.7963 4.29972L16.0833 2.01172ZM4.08325 13.9997V16.9997H7.08325L15.3823 8.71272L12.3823 5.71272L4.08325 13.9997ZM4.08325 19.9997H20.0833V21.9997H4.08325V19.9997Z'
-      //     fill='white'
     />
   </svg>
 );

--- a/src/components/pages/groupDetail/GroupInfoCard/GroupInfoCard.tsx
+++ b/src/components/pages/groupDetail/GroupInfoCard/GroupInfoCard.tsx
@@ -1,6 +1,4 @@
 import { useRef } from 'react';
-import { format } from 'date-fns';
-import { ko } from 'date-fns/locale';
 import { useRouter } from 'next/navigation';
 import Badge from '@/components/common/Badge/Badge';
 import Button from '@/components/common/Button/Button';
@@ -13,8 +11,7 @@ import StarIcon from '@/components/icons/StarIcon';
 import { useGetUserId } from '@/hooks/userHooks/userHooks';
 import { ReportTarget } from '@/types/enums';
 import { GroupInfo } from '@/types/group';
-
-const DATE_FORMAT = 'yy.MM.dd';
+import { formatNormalDate } from '@/utils/date';
 
 interface GroupInfoCardProps {
   groupInfo: GroupInfo;
@@ -48,14 +45,8 @@ const GroupInfoCard = ({
             />
           </div>
           <span className='text-12_M text-gray-600'>
-            {/* TODO: date.ts 파일 추가 후 수정 */}
-            {format(new Date(groupInfo.startDate), DATE_FORMAT, {
-              locale: ko,
-            })}
-            ~
-            {format(new Date(groupInfo.endDate), DATE_FORMAT, {
-              locale: ko,
-            })}
+            {formatNormalDate(groupInfo.startDate)}~
+            {formatNormalDate(groupInfo.endDate)}
           </span>
           <MoreDropdown
             items={[
@@ -76,7 +67,6 @@ const GroupInfoCard = ({
             ]}
           />
         </div>
-
         <div className='flex w-full justify-between gap-4'>
           <div className='flex flex-1 flex-col justify-between overflow-hidden'>
             <h4 className='mb-1.5 truncate text-16_B text-black'>
@@ -91,36 +81,39 @@ const GroupInfoCard = ({
                 {groupInfo.startAge}~{groupInfo.endAge}세
               </span>
             </div>
-            <div className='flex items-center gap-0.5'>
-              <ProfileImage
-                size='xs'
-                src={groupInfo.host.profileImage}
-                alt={groupInfo.host.name}
-                border={false}
-              />
-              <span className='text-12_M text-gray-700'>
-                {groupInfo.host.name}
-              </span>
-              <span className='flex text-12_M text-gray-700'>
-                (<StarIcon className='h-3 w-3' />
-                {groupInfo.host.rating})
-              </span>
+            <div>
+              <button
+                type='button'
+                className='flex items-center gap-0.5'
+                onClick={() => router.push(`/profiles/${groupInfo.host.id}`)}
+              >
+                <ProfileImage
+                  size='xs'
+                  src={groupInfo.host.profileImage}
+                  alt={groupInfo.host.name}
+                  border={false}
+                />
+                <span className='text-12_M text-gray-700'>
+                  {groupInfo.host.name}
+                </span>
+                <span className='flex text-12_M text-gray-700'>
+                  (<StarIcon className='h-3 w-3' />
+                  {groupInfo.host.rating})
+                </span>
+              </button>
             </div>
             <p className='line-clamp-2 w-full text-14_body_M text-gray-950'>
               {groupInfo.description}
             </p>
           </div>
         </div>
-
         <ProgressBar
           current={groupInfo.memberCount}
           total={groupInfo.maxMembers}
         />
-
         {groupInfo.hashtag && (
           <HashtagBadgeGroup hashtags={groupInfo.hashtag} />
         )}
-
         <div className='flex w-full gap-2'>
           <Button
             variant='primary'

--- a/src/components/pages/groupDetail/GroupModal/GroupModal.tsx
+++ b/src/components/pages/groupDetail/GroupModal/GroupModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import Button from '@/components/common/Button/Button';
 import Portal from '@/components/common/Portal';
 import TextareaInput from '@/components/common/TextareaInput/TextareaInput';
@@ -29,6 +30,7 @@ const GroupModal = ({
   const { mutate: leaveGroup, status: leaveStatus } = useLeaveGroup();
   const dialogRef = useRef<HTMLDialogElement>(null);
   const [description, setDescription] = useState<string>('');
+  const router = useRouter();
 
   const onCloseModal = () => {
     setDescription('');
@@ -78,6 +80,7 @@ const GroupModal = ({
               message: '모임에서 탈퇴하였습니다.',
               type: 'success',
             });
+            router.back();
           },
           onError: (error) => {
             if (error.code === 400) {

--- a/src/components/pages/groupDetail/GroupPosts.tsx
+++ b/src/components/pages/groupDetail/GroupPosts.tsx
@@ -5,6 +5,7 @@ import { useGetGroupPosts } from '@/hooks/groupHooks/groupHooks';
 import { useReactionPost } from '@/hooks/postHooks/postHook';
 import { Post } from '@/types/post';
 import PostCard from './PostCard/PostCard';
+import PostNotice from './PostNotice/PostNotice';
 import { CheckButton, CommentButton } from '.';
 
 const GroupPosts = () => {
@@ -32,7 +33,8 @@ const GroupPosts = () => {
   };
 
   return (
-    <div className='flex w-full flex-col px-4 pb-4'>
+    <div className='flex w-full flex-col gap-5 px-4 pt-5 pb-4'>
+      <PostNotice />
       {posts.posts.map((post: Post) => (
         <PostCard
           key={post.id}

--- a/src/components/pages/groupDetail/PinCheckbox/PinCheckbox.tsx
+++ b/src/components/pages/groupDetail/PinCheckbox/PinCheckbox.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { CheckIcon } from '@/components/icons';
+
+interface PinCheckboxProps {
+  isPinned: boolean;
+  onClick: () => void;
+}
+
+const PinCheckbox = ({ isPinned, onClick }: PinCheckboxProps) => (
+  <div className='bg-primary-100 px-4 pt-16 pb-[14.5px]'>
+    <button
+      type='button'
+      onClick={onClick}
+      className='flex items-center gap-1.5'
+    >
+      <CheckIcon
+        type={isPinned ? 'filled' : 'empty'}
+        w-5
+        h-5
+      />
+      <p className='text-14_M text-gray-950'>상단 고정</p>
+    </button>
+  </div>
+);
+
+export default PinCheckbox;

--- a/src/components/pages/groupDetail/PostCard/PostCard.tsx
+++ b/src/components/pages/groupDetail/PostCard/PostCard.tsx
@@ -121,16 +121,31 @@ const PostCard = ({ post, type = 'posts', children }: PostCardProps) => {
         <div className='flex w-full flex-col gap-3.5'>
           <div className='relative flex items-start justify-between'>
             <div className='flex items-center gap-2.5'>
-              <ProfileImage
-                size='sm'
-                border={false}
-                {...(profileImage
-                  && profileImage.src && { src: profileImage.src.toString() })}
-              />
+              <button
+                type='button'
+                onClick={() => router.push(`/profiles/${author.id}`)}
+              >
+                <ProfileImage
+                  size='sm'
+                  border={false}
+                  {...(profileImage
+                    && profileImage.src && {
+                      src: profileImage.src.toString(),
+                    })}
+                />
+              </button>
 
-              <div className='flex flex-col text-sm'>
-                <span className='text-sm font-bold text-gray-950'>{name}</span>
-                <div className='flex items-center gap-1 text-13_M font-medium text-gray-500'>
+              <div className='flex flex-col items-start'>
+                <button
+                  type='button'
+                  onClick={() => router.push(`/profiles/${author.id}`)}
+                  className='text-left'
+                >
+                  <span className='line-clamp-1 text-14_B text-gray-950'>
+                    {name}
+                  </span>
+                </button>
+                <div className='flex items-center gap-1 text-13_M text-gray-500'>
                   <span>{createdAt}</span>
                   {isPinned && <span>· 공지</span>}
                 </div>
@@ -156,7 +171,7 @@ const PostCard = ({ post, type = 'posts', children }: PostCardProps) => {
                 data-testid='carousel'
                 className='relative mx-auto w-full'
               >
-                <CarouselContent>
+                <CarouselContent className='flex items-center'>
                   {Array.from(images ?? [], (img) => (
                     <CarouselItem key={img.id}>
                       <Image

--- a/src/components/pages/groupDetail/PostDetailWrapper.tsx
+++ b/src/components/pages/groupDetail/PostDetailWrapper.tsx
@@ -43,7 +43,7 @@ const PostDetailWrapper = () => {
         hasLeftIcon={<BackIcon />}
         onLeftClick={() => router.back()}
       />
-      <div className='flex w-full flex-col px-4 pt-11 pb-4'>
+      <div className='scrollbar-hide flex h-screen w-full flex-col overflow-auto px-4 pt-11 pb-[89px]'>
         <PostCard
           post={post}
           type='detail'
@@ -60,6 +60,7 @@ const PostDetailWrapper = () => {
         type='comment'
         sendMessage={handleSubmit}
         maxLength={150}
+        className='fixed bottom-0'
       />
     </>
   );

--- a/src/components/pages/groupDetail/PostEditWrapper.tsx
+++ b/src/components/pages/groupDetail/PostEditWrapper.tsx
@@ -4,15 +4,15 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import DetailHeader from '@/components/common/DetailHeader/DetailHeader';
 import TextareaInput from '@/components/common/TextareaInput/TextareaInput';
+import { UploadedImage, useImageUploader } from '@/hooks';
 import { useGetPost, useUpdatePost } from '@/hooks/postHooks/postHook';
 import { useGetPresignedURL } from '@/hooks/useGetPresignedUrl/useGetPresignedUrl';
 import { hasProfanity } from '@/lib/utils';
 import { imagesApi } from '@/services/imagesService';
-import { Image } from '@/types/image';
+import PinCheckbox from './PinCheckbox/PinCheckbox';
 import PostImageUploader from './PostImageUploader/PostImageUploader';
 
-// 최소/최대 줄 수 상수 정의
-const MAX_TEXTAREA_ROWS = 33; // 최대 20줄까지 늘어남
+const MAX_TEXTAREA_ROWS = 33;
 const MAX_TEXTAREA_LENGTH = 500;
 
 const PostEditWrapper = () => {
@@ -24,13 +24,22 @@ const PostEditWrapper = () => {
   const { data: post } = useGetPost({ groupId, postId });
   const [content, setContent] = useState('');
   const [isValidText, setIsValidText] = useState(true);
-  const [images, setImages] = useState<Image[]>([]);
+  const [hasImage, setHasImage] = useState(false);
+  const [originalImages, setOriginalImages] = useState<UploadedImage[]>([]);
+  const [isPinned, setIsPinned] = useState(false);
   const { mutateAsync: getPresignedURL } = useGetPresignedURL();
   const { mutateAsync: updatePost } = useUpdatePost();
+  const {
+    upload,
+    images: stagedImages,
+    remove,
+    defaultUrlUpload,
+  } = useImageUploader('multi');
 
   const isContentChanged = content !== (post?.content ?? '');
   const isImagesChanged =
-    JSON.stringify(images) !== JSON.stringify(post?.images ?? []);
+    originalImages.length !== stagedImages.length
+    || originalImages.some((img, idx) => img.url !== stagedImages[idx]?.url);
   const canSubmit = useMemo(
     () =>
       isValidText
@@ -42,13 +51,20 @@ const PostEditWrapper = () => {
   useEffect(() => {
     if (post) {
       setContent(post.content);
-      setImages(post.images || []);
+      setIsPinned(post.isPinned);
+      const originalImagesUrls = post.images?.map((img) => img.src.toString());
+      defaultUrlUpload(originalImagesUrls || []);
     }
-  }, [post]);
+    if (post?.images && post.images.length > 0) {
+      setHasImage(true);
+    }
+  }, [post, defaultUrlUpload]);
 
-  const handleImageUpload = (newImages: Image[]) => setImages(newImages);
-  const handleImageRemove = (idx: number) =>
-    setImages((prev) => prev.filter((_, i) => i !== idx));
+  useEffect(() => {
+    if (originalImages?.length === 0 && hasImage) {
+      setOriginalImages(stagedImages);
+    }
+  }, [stagedImages, originalImages, hasImage]);
 
   const handleChange = (value: string) => {
     setContent(value);
@@ -58,12 +74,12 @@ const PostEditWrapper = () => {
   const handleSubmit = async () => {
     let uploadResults: { idx: number; url: string }[] = [];
     try {
-      const uploadPromises = images
+      const uploadPromises = stagedImages
         .map((img) => {
           if (!img.file) {
             return null;
           }
-          return getPresignedURL(img.name!).then((res) => {
+          return getPresignedURL(img.file.name).then((res) => {
             if (res.code !== 200) {
               throw new Error('URL 생성 실패');
             }
@@ -75,7 +91,7 @@ const PostEditWrapper = () => {
             return imagesApi
               .uploadImage(presignedUrl, fileToUpload)
               .then(() => ({
-                idx: images.indexOf(img),
+                idx: stagedImages.indexOf(img),
                 url: presignedUrl.split('?')[0],
               }));
           });
@@ -89,19 +105,18 @@ const PostEditWrapper = () => {
       console.error('이미지 업로드 오류:', error);
       return;
     }
-    // 업로드된 이미지라면 새 URL로, 아니면 기존 src 사용
-    const finalImageObjects = images.map((img, idx) => {
+    const finalImageObjects = stagedImages.map((img, idx) => {
       const uploaded = uploadResults.find((r) => r && r.idx === idx);
       return {
-        alt: img.alt ?? img.name ?? '',
-        src: uploaded ? uploaded.url : img.src.toString(),
+        alt: img.file.name,
+        src: uploaded ? uploaded.url : img.url,
       };
     });
     const res = await updatePost({
       groupId,
       postId,
       content,
-      isPinned: post?.isPinned ?? false,
+      isPinned,
       images: finalImageObjects,
     });
     if ((res.data as { result: boolean }).result === true) {
@@ -109,16 +124,23 @@ const PostEditWrapper = () => {
     }
   };
 
+  const handlePinClick = () => {
+    setIsPinned((prev) => !prev);
+  };
+
   return (
-    <div className='flex h-full flex-col gap-4'>
+    <div className='flex h-full min-h-screen flex-col'>
       <DetailHeader
         title='게시글 수정'
         hasRightText='수정'
         onRightClick={handleSubmit}
         rightDisabled={!canSubmit}
       />
-
-      <div className='h-full flex-1 px-4 pt-16 pb-20'>
+      <PinCheckbox
+        isPinned={isPinned}
+        onClick={handlePinClick}
+      />
+      <div className='h-full flex-1 px-4 pt-1 pb-20'>
         <TextareaInput
           value={content}
           onChange={handleChange}
@@ -133,11 +155,11 @@ const PostEditWrapper = () => {
           showWarning={false}
         />
       </div>
-      <div className='fixed bottom-[80px] w-full'>
+      <div className='fixed bottom-0 w-full'>
         <PostImageUploader
-          images={images}
-          onImageUpload={handleImageUpload}
-          onImageRemove={handleImageRemove}
+          images={stagedImages}
+          onImageUpload={upload}
+          onImageRemove={remove}
         />
       </div>
     </div>

--- a/src/components/pages/groupDetail/PostImageUploader/PostImageUploader.tsx
+++ b/src/components/pages/groupDetail/PostImageUploader/PostImageUploader.tsx
@@ -2,11 +2,11 @@ import React, { useRef } from 'react';
 import Image from 'next/image';
 import PhotoIcon from '@/components/icons/PhotoIcon';
 import XIcon from '@/components/icons/XIcon';
-import { Image as ImageType } from '@/types/image';
+import { UploadedImage } from '@/hooks';
 
 interface PostImageUploaderProps {
-  images: ImageType[];
-  onImageUpload: (images: ImageType[]) => void;
+  images: UploadedImage[];
+  onImageUpload: (files: File | File[] | FileList | null) => void;
   onImageRemove: (index: number) => void;
 }
 
@@ -17,26 +17,8 @@ const PostImageUploader = ({
 }: PostImageUploaderProps) => {
   const imgRef = useRef<HTMLInputElement>(null);
 
-  const extensionMap: Record<string, string> = {
-    'image/jpeg': 'jpeg',
-    'image/jpg': 'jpg',
-    'image/png': 'png',
-    'image/gif': 'gif',
-    'image/webp': 'webp',
-  };
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const files = e.target.files;
-    if (!files) return;
-
-    const newImages = Array.from(files)
-      .filter((file) => extensionMap[file.type])
-      .map((file) => ({
-        src: URL.createObjectURL(file),
-        name: file.name,
-        file,
-      }));
-
-    onImageUpload([...images, ...newImages]);
+    onImageUpload(e.target.files);
   };
 
   const handleAddClick = () => {
@@ -44,21 +26,20 @@ const PostImageUploader = ({
   };
 
   return (
-    <div className='flex w-full flex-col gap-4 border-t border-t-gray-100 bg-white py-4 pl-4'>
+    <div className='flex w-full flex-col gap-4 border-t border-t-gray-100 bg-white p-4'>
       {images.length > 0 && (
         <div className='scrollbar-hide flex gap-2 overflow-x-auto'>
           {images.map((img, index) => (
             <div
-              key={img.src.toString()}
-              className='relative h-[60px] w-[60px] flex-shrink-0'
+              key={img.url.toString()}
+              className='relative flex h-[60px] w-[60px] flex-shrink-0 items-center justify-center overflow-hidden rounded-sm'
             >
               <Image
-                src={img.src}
-                alt={img.src.toString()}
-                width={60}
-                height={60}
+                src={img.url}
+                alt={img.url.toString()}
+                fill
                 sizes='60px'
-                className='rounded-sm object-cover'
+                className='object-cover'
               />
               <button
                 type='button'

--- a/src/components/pages/groupDetail/PostNotice/PostNotice.tsx
+++ b/src/components/pages/groupDetail/PostNotice/PostNotice.tsx
@@ -27,7 +27,7 @@ const PostNotice = ({ className }: PostNoticeProps) => {
 
   return (
     <div className={cn('relative mb-11', className)}>
-      <div className='absolute top-0 z-1 rounded-[12px] bg-primary-100 px-4.5 py-2.5'>
+      <div className='absolute top-0 z-1 w-full rounded-[12px] bg-primary-100 px-4.5 py-2.5'>
         <div className='flex items-start justify-between gap-2'>
           <div className='flex w-full flex-1 items-start gap-2 overflow-hidden'>
             <MegaphoneIcon className='aspect-square h-5 w-5 shrink-0 text-primary-red' />

--- a/src/components/pages/groupDetail/editGroup/EditGroupWrapper.tsx
+++ b/src/components/pages/groupDetail/editGroup/EditGroupWrapper.tsx
@@ -1,8 +1,8 @@
 'use client';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { Button } from '@/components/common';
-import Header from '@/components/common/Header/Header';
+import DetailHeader from '@/components/common/DetailHeader/DetailHeader';
 import NormalCategorySelector from '@/components/pages/groupDetail/editGroup/NormalCategorySelector';
 import NormalDateSelector from '@/components/pages/groupDetail/editGroup/NormalDateSelector';
 import NormalDescriptionInput from '@/components/pages/groupDetail/editGroup/NormalDescriptionInput';
@@ -38,7 +38,7 @@ const EditGroupWrapper = () => {
   const params = useParams();
   const groupId = params?.groupId as string;
   const router = useRouter();
-  const { data: groupDetail, isLoading } = useGetGroupInfo(groupId);
+  const { data: groupDetail, isPending } = useGetGroupInfo(groupId);
   const { mutateAsync: updateGroup } = useUpdateGroup();
 
   const [category, setCategory] = useState<
@@ -66,7 +66,6 @@ const EditGroupWrapper = () => {
     setTitle(d.title);
     setDescription(d.description || '');
     setRegion(labelToKey(d.location));
-    // 날짜 포맷이 ISO 문자열일 때, 앞 10자리만 잘라서 YYYY-MM-DD 로
     setDateRange({
       startDate: new Date(d.startDate.slice(0, 10)),
       endDate: new Date(d.endDate.slice(0, 10)),
@@ -75,10 +74,41 @@ const EditGroupWrapper = () => {
     setTags(d.hashtag || []);
   }, [groupDetail]);
 
-  if (isLoading) return <div>로딩 중…</div>;
+  const canSubmit = useMemo(() => {
+    if (!groupDetail?.data) return false;
+    const isTagsChanged = !(
+      Array.isArray(groupDetail?.data?.hashtag)
+      && tags.length === groupDetail?.data?.hashtag?.length
+      && tags.every((tag, idx) => tag === groupDetail?.data?.hashtag?.[idx])
+    );
+
+    return (
+      category !== groupDetail?.data?.category
+      || title !== groupDetail?.data?.title
+      || description !== groupDetail?.data?.description
+      || LocationLabels[region as LocationType] !== groupDetail?.data?.location
+      || dateRange.startDate?.toISOString().slice(0, 10)
+        !== groupDetail?.data?.startDate.slice(0, 10)
+      || dateRange.endDate?.toISOString().slice(0, 10)
+        !== groupDetail?.data?.endDate.slice(0, 10)
+      || (participants !== groupDetail?.data?.maxMembers
+        && participants >= groupDetail?.data?.memberCount)
+      || isTagsChanged
+    );
+  }, [
+    category,
+    title,
+    description,
+    region,
+    dateRange,
+    participants,
+    tags,
+    groupDetail,
+  ]);
 
   const handleSubmit = async () => {
     if (!groupDetail) return;
+
     const payload = {
       title,
       category: category,
@@ -107,14 +137,20 @@ const EditGroupWrapper = () => {
     }
   };
 
+  if (isPending) return <div>로딩 중…</div>;
+
   return (
-    <>
-      {/* TODO: DetailHeader 컴포넌트로 수정*/}
-      <Header title='모임 정보 수정' />
-      <div className='mx-auto flex max-w-md flex-col gap-[30px] px-4 pt-6 pb-[88px]'>
+    <div className='flex h-screen flex-col'>
+      <DetailHeader
+        title='모임 정보 수정'
+        hasLeftIcon={false}
+      />
+      <div className='mx-auto scrollbar-hide flex min-h-0 max-w-md flex-1 flex-col gap-[30px] overflow-auto px-4 pt-[68px] pb-[88px]'>
         <div className='flex justify-between'>
-          <span className='text-14_B text-black'>공연 이름</span>
-          <span className='text-16_M text-gray-950'>
+          <span className='h-5 w-2/12 text-left text-14_B text-black'>
+            공연 이름
+          </span>
+          <span className='line-clamp-2 w-9/12 overflow-hidden text-right text-16_M break-all text-ellipsis text-gray-950'>
             {groupDetail?.data?.performance?.title}
           </span>
         </div>
@@ -135,6 +171,7 @@ const EditGroupWrapper = () => {
         <NormalLocationSelector
           value={region}
           onChange={setRegion}
+          originalValue={labelToKey(groupDetail?.data?.location || '')}
         />
         <NormalDateSelector
           value={dateRange}
@@ -151,18 +188,24 @@ const EditGroupWrapper = () => {
           onAdd={(tag) => setTags([...tags, tag])}
           onRemove={(tag) => setTags(tags.filter((t) => t !== tag))}
         />
-        <div className='fixed right-0 bottom-0 left-0 z-20 flex justify-end gap-2.5 bg-white px-4 py-5'>
-          <Button
-            variant='secondary'
-            color='normal'
-            onClick={() => router.replace(`/groups/${groupId}`)}
-          >
-            취소
-          </Button>
-          <Button onClick={handleSubmit}>수정</Button>
-        </div>
       </div>
-    </>
+      <div className='fixed right-0 bottom-0 left-0 z-20 flex justify-end gap-2.5 bg-white px-4 py-5'>
+        <Button
+          variant='secondary'
+          color='normal'
+          onClick={() => router.replace(`/groups/${groupId}`)}
+        >
+          취소
+        </Button>
+        <Button
+          color={canSubmit ? 'normal' : 'disable'}
+          onClick={handleSubmit}
+          disabled={!canSubmit}
+        >
+          수정
+        </Button>
+      </div>
+    </div>
   );
 };
 

--- a/src/components/pages/groupDetail/editGroup/NormalLocationSelector.tsx
+++ b/src/components/pages/groupDetail/editGroup/NormalLocationSelector.tsx
@@ -8,21 +8,24 @@ import { LocationLabels } from '@/constants/locationLabels';
 import { cn } from '@/lib/utils';
 import { generateFilterOptions } from '@/utils';
 
-const LOCATION_OPTIONS = generateFilterOptions(LocationLabels);
+const LOCATION_OPTIONS = generateFilterOptions(LocationLabels, false);
 
 interface LocationSelectorProps {
   onChange: (value: string) => void;
   className?: string;
   triggerClassName?: string;
   value: string;
+  originalValue: string;
 }
 
 const LocationSelectorContent = ({
   value,
   onChange,
+  originalValue,
 }: {
   value: string;
   onChange: (value: string) => void;
+  originalValue: string;
 }) => {
   const { closeModal } = useModalContext();
 
@@ -55,10 +58,10 @@ const LocationSelectorContent = ({
         ))}
       </div>
 
-      {value && (
+      {value !== undefined && (
         <div className='flex justify-between gap-2.5 pt-4'>
           <Button
-            onClick={() => handleSelect('')}
+            onClick={() => handleSelect(originalValue)}
             variant='secondary'
           >
             초기화
@@ -74,6 +77,7 @@ const NormalLocationSelector: React.FC<LocationSelectorProps> = ({
   onChange,
   className,
   triggerClassName,
+  originalValue,
   value,
 }) => {
   const selectedOption = LOCATION_OPTIONS.find(
@@ -111,6 +115,7 @@ const NormalLocationSelector: React.FC<LocationSelectorProps> = ({
         <LocationSelectorContent
           value={value}
           onChange={onChange}
+          originalValue={originalValue}
         />
       </BottomSheetModal>
     </div>

--- a/src/components/pages/groupDetail/editGroup/NormalTagInput.tsx
+++ b/src/components/pages/groupDetail/editGroup/NormalTagInput.tsx
@@ -18,6 +18,12 @@ const NormalTagInput: React.FC<TagSelectorProps> = ({
   className,
 }) => {
   const [input, setInput] = useState('');
+  const handleAdd = () => {
+    if (input.trim() && !tags.includes(input.trim())) {
+      onAdd(input.trim());
+      setInput('');
+    }
+  };
   return (
     <div className={className}>
       <div className='mb-2.5 text-14_B text-black'>태그 추가</div>
@@ -27,16 +33,16 @@ const NormalTagInput: React.FC<TagSelectorProps> = ({
             type='text'
             value={input}
             onChange={(e) => setInput(e.target.value)}
-            placeholder='태그를 추가해 주세요.'
+            onKeyUp={(e) => {
+              if (e.key === 'Enter') {
+                handleAdd();
+              }
+            }}
+            placeholder='태그를 추가해 주세요'
             className='flex-1 rounded-2xl border border-gray-100 px-5 py-4 placeholder-gray-400'
           />
           <Button
-            onClick={() => {
-              if (input.trim() && !tags.includes(input.trim())) {
-                onAdd(input.trim());
-                setInput('');
-              }
-            }}
+            onClick={handleAdd}
             disabled={!input.trim()}
             size='sm'
             color={!input.trim() ? 'disable' : 'normal'}

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -28,9 +28,7 @@ export const formatRelativeDate = (dateStr: string): string => {
 
 // M월 d일 a hh:mm
 export const formatPostDate = (dateStr: string): string => {
-  console.log('formatPostDate input:', dateStr);
   if (!dateStr) {
-    console.log('dateStr is empty');
     return '';
   }
 


### PR DESCRIPTION
* chore: 주석 삭제

* style: 공지글 w-full 추가

* feat: 모임 정보에서 탈퇴 클릭 시 뒤로가기 추가

* feat: 프로필 클릭 시 프로필 페이지로 이동

* feat: 모임 정보 수정시 엔터로 해시태그 입력 추가

* feat: 모임 수정 시 지역 초기화 클릭하면 기존 지역으로 표시

* feat: 모임 수정 시 수정사항 없으면 버튼 disabled

* style: 하단 탭바 삭제, 주석 삭제, 아이콘 컴포넌트 수정

* feat: 댓글 하단 fix를 위한 className props추가

* feat: 하단 탭바 INVISIBLE에 게시글 수정 페이지 추가

* feat: 게시글 목록 탭에 공지 추가

* chore: 미사용 import 삭제

* feat: 모임 수정 시 지역선택에서 전체 제외

* style: 캐러셀에 세로크기가 다른 이미지들 가운데 정렬

* refactor: 이미지 업로드 useImageUploader 훅 사용으로 변경

* feat: 게시글 작성, 수정시 상단 고정 체크 기능 추가

### 무엇을 위한 PR인가요? (: 뒤 설명 추가)

- 신규 기능 추가: 
- 버그 수정:
- 리펙토링:
- 문서 업데이트:
- 기타:

### 변경사항 및 이유 (bullet 으로 구분)

- 이유

### 작업 내역 (bullet 으로 구분)

- 작업 내역

### ?작업 후 기대 동작(스크린샷)

- 동작

### ?PR 특이 사항

- 특이 사항

### Issue Number

close: #