### PR TITLE
[Bug/issue-438] 모임 개설 api 스펙과 불일치 해결 및 스타일링 개선

### DIFF
--- a/src/app/(hasGNB)/performances/[performanceId]/createGroup/page.tsx
+++ b/src/app/(hasGNB)/performances/[performanceId]/createGroup/page.tsx
@@ -26,7 +26,7 @@ import { CreateGroupFormData } from '@/types/group';
 
 const DEFAULT_VALUES: CreateGroupFormData = {
   name: '공연 이름',
-  category: '동행',
+  category: '같이 동행',
   title: '',
   description: '',
   region: '',

--- a/src/app/(hasGNB)/performances/[performanceId]/createGroup/page.tsx
+++ b/src/app/(hasGNB)/performances/[performanceId]/createGroup/page.tsx
@@ -86,7 +86,7 @@ const CreateGroupPage = () => {
         <h1 className='sr-only'>모임 개설</h1>
         <form
           onSubmit={handleSubmit(onSubmit)}
-          className='mx-auto flex flex-col gap-12.5 p-6 pb-4'
+          className='mx-auto flex flex-col gap-7.5 p-6 pb-4'
         >
           <LabeledWrapper label='공연 이름'>
             <FormText

--- a/src/app/(hasGNB)/performances/[performanceId]/createGroup/page.tsx
+++ b/src/app/(hasGNB)/performances/[performanceId]/createGroup/page.tsx
@@ -225,6 +225,8 @@ const CreateGroupPage = () => {
               onReset={onReset}
               isValid={isValid}
               isSubmitting={createGroupMutation.isPending}
+              submitError={createGroupMutation.error?.message}
+              showSuccessToast={createGroupMutation.isSuccess}
             />
           </div>
         </form>

--- a/src/components/common/BottomSheetModal/BottomSheetContent.tsx
+++ b/src/components/common/BottomSheetModal/BottomSheetContent.tsx
@@ -134,7 +134,7 @@ const BottomSheetContent: React.FC<Props> = ({
       <Overlay />
       <div
         className={cn(
-          'easy fixed bottom-0 left-1/2 z-50 flex w-full max-w-lg -translate-x-1/2 transform flex-col rounded-t-2xl bg-white shadow-2xl transition-all duration-300',
+          'easy fixed bottom-0 left-1/2 z-50 flex w-full max-w-lg -translate-x-1/2 transform flex-col rounded-t-[20px] bg-white shadow-2xl transition-all duration-300',
           isAnimating
             ? '-translate-x-1/2 translate-y-0'
             : '-translate-x-1/2 translate-y-full',

--- a/src/components/common/Calendar/Calendar.tsx
+++ b/src/components/common/Calendar/Calendar.tsx
@@ -24,6 +24,7 @@ interface CalendarProps {
   onDateClick?: (date: Date) => void;
   isControllable?: boolean;
   className?: string;
+  colorScheme?: 'red' | 'black';
 }
 
 const WEEKDAYS_KR = ['일', '월', '화', '수', '목', '금', '토'];
@@ -35,9 +36,12 @@ const Calendar = ({
   onDateClick,
   isControllable,
   className,
+  colorScheme = 'red',
 }: CalendarProps) => {
   const [internalMonth, setInternalMonth] = useState<Date>(month);
   const currentMonth = isControllable ? internalMonth : month;
+
+  const isRed = colorScheme === 'red';
 
   const days = useMemo(() => {
     const firstDay = startOfWeek(startOfMonth(currentMonth), {
@@ -89,10 +93,10 @@ const Calendar = ({
     );
 
     const rangeBackgroundClasses = cn(
-      'absolute inset-0 overflow-hidden bg-primary-100',
+      'absolute inset-0 overflow-hidden',
+      isRed ? 'bg-primary-100' : 'bg-gray-100',
       isStart && endDate && 'rounded-r-none',
-      isEnd && startDate && 'rounded-l-none',
-      isRange && 'bg-primary-100'
+      isEnd && startDate && 'rounded-l-none'
     );
 
     const startMaskClasses = cn('absolute inset-0 bg-white', 'left-0 w-1/2');
@@ -101,8 +105,10 @@ const Calendar = ({
     const dayButtonClasses = cn(
       'relative z-10 flex items-center justify-center',
       onDateClick && 'cursor-pointer',
-      (isStart || isEnd)
-        && 'h-12.5 w-12.5 rounded-full bg-primary-red font-bold text-white'
+      (isStart || isEnd) && [
+        'h-12.5 w-12.5 rounded-full font-bold text-white',
+        isRed ? 'bg-primary-red' : 'bg-gray-900',
+      ]
     );
 
     const showRangeBackground =

--- a/src/components/common/Calendar/Calendar.tsx
+++ b/src/components/common/Calendar/Calendar.tsx
@@ -94,7 +94,7 @@ const Calendar = ({
 
     const rangeBackgroundClasses = cn(
       'absolute inset-0 overflow-hidden',
-      isRed ? 'bg-primary-100' : 'bg-gray-100',
+      isRed ? 'bg-primary-100' : 'bg-gray-50',
       isStart && endDate && 'rounded-r-none',
       isEnd && startDate && 'rounded-l-none'
     );

--- a/src/components/common/Form/FormText.tsx
+++ b/src/components/common/Form/FormText.tsx
@@ -48,7 +48,7 @@ const FormText = <
 
   return (
     <div className={cn('flex flex-col', className)}>
-      <span className='text-gray-900'>{value}</span>
+      <span className='line-clamp-2 text-gray-900'>{value}</span>
       {showError && error && (
         <p
           className='mt-1 text-sm text-red-500'

--- a/src/components/common/Toast/Toast.tsx
+++ b/src/components/common/Toast/Toast.tsx
@@ -12,6 +12,7 @@ export interface ToastProps {
   onClose: () => void;
   className?: string;
   blockBackgroundClick?: boolean;
+  position?: 'top' | 'center' | 'bottom';
 }
 
 const typeStyles: Record<NonNullable<ToastProps['type']>, string> = {
@@ -40,8 +41,33 @@ const iconStyles: Record<NonNullable<ToastProps['type']>, React.ReactNode> = {
   info: <BellIcon className='aspect-square h-6 w-6 text-primary-red' />,
 };
 
-const animationClass = (visible: boolean) =>
-  visible ? 'translate-y-0 opacity-100' : 'translate-y-4 opacity-0';
+const positionStyles: Record<NonNullable<ToastProps['position']>, string> = {
+  top: 'top-4',
+  center: 'top-1/2 -translate-y-1/2',
+  bottom: 'bottom-4',
+};
+
+const animationClass = (
+  visible: boolean,
+  position: NonNullable<ToastProps['position']>
+) => {
+  if (position === 'center') {
+    return visible
+      ? '-translate-x-1/2 -translate-y-1/2 opacity-100'
+      : '-translate-x-1/2 -translate-y-1/2 opacity-0';
+  }
+
+  const yAnimation =
+    position === 'top'
+      ? visible
+        ? '-translate-x-1/2 translate-y-0 opacity-100'
+        : '-translate-x-1/2 -translate-y-4 opacity-0'
+      : visible
+        ? '-translate-x-1/2 translate-y-0 opacity-100'
+        : '-translate-x-1/2 translate-y-4 opacity-0';
+
+  return yAnimation;
+};
 
 const Toast = ({
   message,
@@ -49,6 +75,7 @@ const Toast = ({
   onClose,
   className,
   blockBackgroundClick = false,
+  position = 'bottom',
 }: ToastProps) => {
   const [isVisible, setIsVisible] = useState(false);
 
@@ -73,9 +100,13 @@ const Toast = ({
         aria-label='toast'
         role='alert'
         className={cn(
-          'fixed bottom-4 left-1/2 z-50 flex w-full max-w-[343px] -translate-x-1/2 flex-col items-center justify-center gap-2.5 rounded-[18px] px-5 py-5.5 text-gray-950 shadow-[0px_4px_14px_0px_rgba(0,0,0,0.10)] transition-all duration-500 ease-in-out',
+          'fixed left-1/2 z-50 flex items-center justify-center',
+          'w-full max-w-[343px] flex-col gap-2.5 rounded-[18px] px-5 py-5.5',
+          'text-gray-950 shadow-[0px_4px_14px_0px_rgba(0,0,0,0.10)]',
+          'transition-all duration-500 ease-in-out',
           typeStyles[type],
-          animationClass(isVisible),
+          positionStyles[position],
+          animationClass(isVisible, position),
           className
         )}
       >

--- a/src/components/common/TwoButtonModal/TwoButtonModal.style.ts
+++ b/src/components/common/TwoButtonModal/TwoButtonModal.style.ts
@@ -18,7 +18,7 @@ export const defaultModalStyles: ModalStyles = {
   trigger:
     'inline-flex items-center justify-center px-4 py-2 text-sm font-medium rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 bg-blue-600 text-white hover:bg-blue-700 focus:ring-blue-500',
   modal:
-    'bg-white rounded-lg shadow-xl p-0 max-w-md w-full h-fit mx-4 overflow-hidden',
+    'bg-white rounded-lg shadow-xl p-0 max-w-md w-[calc(100vw-2rem)] h-fit overflow-hidden',
   header: 'text-lg font-semibold text-gray-900 leading-6',
   content: 'text-sm text-gray-500 leading-5',
   confirmButton:
@@ -33,7 +33,7 @@ export const modalVariants: Record<string, ModalStyles> = {
     trigger:
       'inline-flex items-center justify-center px-4 py-2 text-sm font-medium rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 bg-red-600 text-white hover:bg-red-700 focus:ring-red-500',
     modal:
-      'bg-white rounded-lg shadow-xl p-0 max-w-md w-full mx-4 overflow-hidden border-2 border-red-200',
+      'bg-white rounded-lg shadow-xl p-0 max-w-md w-[calc(100vw-2rem)] overflow-hidden border-2 border-red-200',
     header: 'text-lg font-semibold text-red-900 leading-6',
     content: 'text-sm text-red-700 leading-5',
     confirmButton:

--- a/src/components/pages/createGroup/CategorySelector.tsx
+++ b/src/components/pages/createGroup/CategorySelector.tsx
@@ -6,6 +6,8 @@ import {
   RegisterOptions,
 } from 'react-hook-form';
 import { FormButtonGroup } from '@/components/common/Form';
+import { GroupCategoryLabels } from '@/constants/groupLabels';
+import { GroupCategory } from '@/types/enums';
 
 interface CategorySelectorProps<
   TFieldValues extends FieldValues = FieldValues,
@@ -26,7 +28,9 @@ const CategorySelector = <
   rules,
   className,
 }: CategorySelectorProps<TFieldValues, TName>) => {
-  const categories = ['동행', '탑승', '숙박'];
+  const categories = Object.values(GroupCategory).map(
+    (category) => GroupCategoryLabels[category]
+  );
 
   return (
     <div className={className}>

--- a/src/components/pages/createGroup/DateSelector.tsx
+++ b/src/components/pages/createGroup/DateSelector.tsx
@@ -55,9 +55,11 @@ const DateSelector = <
   };
 
   const handleDateClick = (date: Date) => {
-    if (!tempStartDate) {
+    if (!tempStartDate && !dateRange.startDate) {
+      // 처음 선택하는 경우
       setTempStartDate(date);
-    } else {
+    } else if (tempStartDate) {
+      // 종료일 선택하는 경우
       const startDate = tempStartDate;
       const endDate = date;
 
@@ -74,6 +76,12 @@ const DateSelector = <
       }
 
       setTempStartDate(null);
+    } else {
+      field.onChange({
+        startDate: null,
+        endDate: null,
+      });
+      setTempStartDate(date);
     }
   };
 
@@ -143,13 +151,16 @@ const DateSelector = <
             endDate={getCurrentEndDate()}
             onDateClick={handleDateClick}
             className='mb-4 flex flex-col gap-1'
+            colorScheme='black'
           />
 
           <div className='mb-4 flex items-center justify-between text-sm text-gray-600'>
             <span>
               {tempStartDate
                 ? '종료일을 선택해주세요'
-                : '시작일을 선택해주세요'}
+                : dateRange.startDate && dateRange.endDate
+                  ? ''
+                  : '시작일을 선택해주세요'}
             </span>
             {(dateRange.startDate || dateRange.endDate || tempStartDate) && (
               <button
@@ -162,11 +173,29 @@ const DateSelector = <
             )}
           </div>
 
-          {tempStartDate && (
-            <div className='rounded-md bg-blue-50 p-3 text-sm text-blue-700'>
-              시작일: {format(tempStartDate, 'yyyy년 M월 d일', { locale: ko })}
+          <div className='flex min-h-11 items-center justify-center rounded-md bg-blue-50 p-3 text-sm text-blue-700'>
+            <div>
+              {tempStartDate
+                ? format(tempStartDate, 'yyyy년 M월 d일', { locale: ko })
+                : ''}
+              {dateRange.startDate
+                && !tempStartDate
+                && format(dateRange.startDate, 'yyyy년 M월 d일', {
+                  locale: ko,
+                })}
+              {(dateRange.endDate
+                || (tempStartDate && dateRange.startDate)) && (
+                <>
+                  {' - '}
+                  {dateRange.endDate
+                    ? format(dateRange.endDate, 'yyyy년 M월 d일', {
+                        locale: ko,
+                      })
+                    : ''}
+                </>
+              )}
             </div>
-          )}
+          </div>
         </div>
       </BottomSheetModal>
 

--- a/src/components/pages/createGroup/FormActions.tsx
+++ b/src/components/pages/createGroup/FormActions.tsx
@@ -23,7 +23,7 @@ const FormAction = ({
           type='button'
           onClick={() => resetModal.openModal()}
           variant='secondary'
-          className='flex-1'
+          className='flex-1 whitespace-nowrap'
         >
           초기화
         </Button>
@@ -32,7 +32,7 @@ const FormAction = ({
           onClick={onSubmit}
           disabled={!isValid || isSubmitting}
           variant='primary'
-          className='flex-1 disabled:cursor-not-allowed'
+          className='flex-1 whitespace-nowrap disabled:cursor-not-allowed'
         >
           {isSubmitting ? '생성 중...' : '모임 만들기'}
         </Button>

--- a/src/components/pages/createGroup/FormActions.tsx
+++ b/src/components/pages/createGroup/FormActions.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Button, TwoButtonModal } from '@/components/common';
+import React, { useState, useEffect } from 'react';
+import { Button, TwoButtonModal, Toast } from '@/components/common';
 import { useModalController } from '@/hooks';
 
 interface FormActionProps {
@@ -7,6 +7,8 @@ interface FormActionProps {
   onReset: () => void;
   isValid: boolean;
   isSubmitting: boolean;
+  submitError?: string;
+  showSuccessToast?: boolean;
 }
 
 const FormAction = ({
@@ -14,8 +16,28 @@ const FormAction = ({
   onReset,
   isValid,
   isSubmitting,
+  submitError,
+  showSuccessToast,
 }: FormActionProps) => {
   const resetModal = useModalController();
+
+  const [showErrorToast, setShowErrorToast] = useState(false);
+  const [showSubmittingToast, setShowSubmittingToast] = useState(false);
+
+  useEffect(() => {
+    if (isSubmitting) {
+      setShowSubmittingToast(true);
+    } else {
+      setShowSubmittingToast(false);
+    }
+  }, [isSubmitting]);
+
+  useEffect(() => {
+    if (submitError) {
+      setShowErrorToast(true);
+    }
+  }, [submitError]);
+
   return (
     <>
       <div className='flex gap-4'>
@@ -48,6 +70,30 @@ const FormAction = ({
         cancelText='취소'
         onConfirm={() => onReset()}
       />
+
+      {showSubmittingToast && (
+        <Toast
+          message='모임을 생성 중입니다...'
+          type='info'
+          onClose={() => setShowSubmittingToast(false)}
+        />
+      )}
+
+      {showSuccessToast && (
+        <Toast
+          message='모임이 성공적으로 생성되었습니다!'
+          type='success'
+          onClose={() => {}}
+        />
+      )}
+
+      {showErrorToast && submitError && (
+        <Toast
+          message={submitError}
+          type='error'
+          onClose={() => setShowErrorToast(false)}
+        />
+      )}
     </>
   );
 };

--- a/src/components/pages/createGroup/LocationSelector.tsx
+++ b/src/components/pages/createGroup/LocationSelector.tsx
@@ -11,7 +11,7 @@ import { AltArrowUpIcon } from '@/components/icons';
 import { LocationLabels } from '@/constants/locationLabels';
 import { cn } from '@/lib/utils';
 import { generateFilterOptions } from '@/utils';
-const LOCATION_OPTIONS = generateFilterOptions(LocationLabels);
+const LOCATION_OPTIONS = generateFilterOptions(LocationLabels, false);
 
 interface FormLocationSelectorProps<
   TFieldValues extends FieldValues = FieldValues,
@@ -102,28 +102,26 @@ const FormLocationSelector = <
                   'border-1 border-gray-100 px-5 py-3',
                   'text-14_M leading-normal tracking-[-0.35px] whitespace-nowrap',
                   'transition-colors duration-200',
-                  'hover:bg-gray-50 focus:ring-2 focus:ring-blue-500 focus:outline-none',
+                  'hover:bg-gray-50 focus:ring-2 focus:ring-gray-500 focus:outline-none',
                   option.value === field.value
-                    ? 'border-blue-200 bg-blue-50 text-blue-700'
-                    : 'bg-white text-gray-700'
+                    ? 'bg-gray-950 text-white hover:bg-gray-700'
+                    : 'text-gray-950'
                 )}
               >
                 {option.label}
               </button>
             ))}
           </div>
-
-          {/* 선택된 항목이 있을 때 초기화 버튼 */}
-          {field.value && (
-            <div className='mt-4 border-t border-gray-100 pt-4'>
-              <button
-                onClick={() => handleLocationSelect('')}
-                className='w-full py-2 text-sm text-red-500 transition-colors hover:text-red-700'
-              >
-                선택 초기화
-              </button>
-            </div>
-          )}
+          <div className='my-4 border-b border-gray-100' />
+          <button
+            onClick={() => handleLocationSelect('')}
+            className={cn(
+              'text-md w-full text-gray-500 transition-colors',
+              field.value && 'text-red-500 hover:text-red-700'
+            )}
+          >
+            {field.value ? '선택 초기화' : '지역을 선택해 주세요'}
+          </button>
         </div>
       </BottomSheetModal>
 

--- a/src/components/pages/createGroup/TagInput.tsx
+++ b/src/components/pages/createGroup/TagInput.tsx
@@ -7,6 +7,7 @@ import {
   RegisterOptions,
 } from 'react-hook-form';
 import { X } from 'lucide-react';
+import { Toast } from '@/components/common';
 import { cn } from '@/lib/utils';
 
 interface TagInputProps<
@@ -29,6 +30,7 @@ const TagInput = <
   className,
 }: TagInputProps<TFieldValues, TName>) => {
   const [inputValue, setInputValue] = useState('');
+  const [showDuplicateToast, setShowDuplicateToast] = useState(false);
 
   const {
     field,
@@ -57,6 +59,8 @@ const TagInput = <
   const handleInputAdd = () => {
     if (addTag(inputValue)) {
       setInputValue('');
+    } else if (inputValue.trim() && tags.includes(inputValue.trim())) {
+      setShowDuplicateToast(true);
     }
   };
 
@@ -121,6 +125,15 @@ const TagInput = <
         >
           {error.message}
         </p>
+      )}
+
+      {showDuplicateToast && (
+        <Toast
+          message='중복된 태그는 추가되지 않습니다.'
+          type='error'
+          onClose={() => setShowDuplicateToast(false)}
+          position='center'
+        />
       )}
     </div>
   );

--- a/src/components/pages/favorite/FavoriteTabContainer.tsx
+++ b/src/components/pages/favorite/FavoriteTabContainer.tsx
@@ -25,14 +25,22 @@ const FavoriteTabContainer: React.FC = () => {
   const currentTab = getQueryParam('tab') || TABS[0];
   const selectedTab = TABS.includes(currentTab) ? currentTab : TABS[0];
 
+  const SpinnerWrapper = () => (
+    <div className='flex min-h-96 w-full items-center justify-center'>
+      <Spinner />
+    </div>
+  );
+
   return (
-    <>
-      <QueryTabs
-        tabs={TABS}
-        defaultTab={TABS[0]}
-        queryParamKey='tab'
-      />
-      <div className='p-4'>
+    <div className='flex flex-col'>
+      <div className='sticky top-11 z-20 bg-white'>
+        <QueryTabs
+          tabs={TABS}
+          defaultTab={TABS[0]}
+          queryParamKey='tab'
+        />
+      </div>
+      <div className='flex-1 p-4'>
         {selectedTab === '공연' && (
           <InfiniteList<
             GetFavoritePerformancesResponse,
@@ -46,8 +54,8 @@ const FavoriteTabContainer: React.FC = () => {
                 size='auto'
               />
             )}
-            fallback={<Spinner />}
-            isFetchingFallback={<Spinner />}
+            fallback={<SpinnerWrapper />}
+            isFetchingFallback={<SpinnerWrapper />}
             className='mx-auto grid grid-cols-2 gap-4'
             emptyFallback={
               <div className='col-span-2 py-8 text-center text-gray-500'>
@@ -66,8 +74,8 @@ const FavoriteTabContainer: React.FC = () => {
             renderData={(user) => (
               <ProfileCard profile={{ ...user, isMine: false }} />
             )}
-            fallback={<Spinner />}
-            isFetchingFallback={<Spinner />}
+            fallback={<SpinnerWrapper />}
+            isFetchingFallback={<SpinnerWrapper />}
             className='mx-auto grid w-fit grid-cols-2 gap-4'
             emptyFallback={
               <div className='col-span-2 py-8 text-center text-gray-500'>
@@ -77,7 +85,7 @@ const FavoriteTabContainer: React.FC = () => {
           />
         )}
       </div>
-    </>
+    </div>
   );
 };
 

--- a/src/hooks/useStyles/useStyles.tsx
+++ b/src/hooks/useStyles/useStyles.tsx
@@ -8,7 +8,7 @@ const useStyles = () => {
     className?: string | undefined
   ) =>
     cn(
-      'inline-flex cursor-pointer items-center justify-center gap-1 rounded-[100px] border-1 border-gray-100 bg-white px-5 py-3 text-16_M text-gray-950 transition-all',
+      'inline-flex cursor-pointer items-center justify-center gap-1 rounded-[100px] border-1 border-gray-100 bg-white px-5 py-3 text-16_M whitespace-nowrap text-gray-950 transition-all',
       (isOpen || selectedItem || isSelected)
         && 'border-gray-950 bg-gray-950 text-white',
 

--- a/src/schema/groupsCreate.ts
+++ b/src/schema/groupsCreate.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { GroupCategoryLabels } from '@/constants/groupLabels';
 
 const dateRangeSchema = z
   .object({
@@ -30,10 +31,17 @@ export const groupCreateSchema = z.object({
   name: z
     .string({ required_error: '공연 이름이 필요합니다' })
     .min(1, '공연 이름을 입력해주세요'),
-  category: z.enum(['같이 동행', '같이 탑승', '같이 숙박'], {
-    required_error: '모임 종류를 선택해주세요',
-    invalid_type_error: '유효한 모임 종류를 선택해주세요',
-  }),
+  category: z.enum(
+    [
+      GroupCategoryLabels.COMPANION,
+      GroupCategoryLabels.RIDE_SHARE,
+      GroupCategoryLabels.ROOM_SHARE,
+    ] as const,
+    {
+      required_error: '모임 종류를 선택해주세요',
+      invalid_type_error: '유효한 모임 종류를 선택해주세요',
+    }
+  ),
   title: z
     .string({ required_error: '제목이 필요합니다' })
     .min(1, '모임 제목을 입력해주세요')

--- a/src/schema/groupsCreate.ts
+++ b/src/schema/groupsCreate.ts
@@ -30,7 +30,7 @@ export const groupCreateSchema = z.object({
   name: z
     .string({ required_error: '공연 이름이 필요합니다' })
     .min(1, '공연 이름을 입력해주세요'),
-  category: z.enum(['동행', '탑승', '숙박'], {
+  category: z.enum(['같이 동행', '같이 탑승', '같이 숙박'], {
     required_error: '모임 종류를 선택해주세요',
     invalid_type_error: '유효한 모임 종류를 선택해주세요',
   }),

--- a/src/services/groupsService.ts
+++ b/src/services/groupsService.ts
@@ -1,7 +1,7 @@
 import QueryString from 'qs';
 import apiFetcher from '@/lib/apiFetcher';
 import { ApiResponse } from '@/types/api';
-import { GroupCategory, Gender } from '@/types/enums';
+import { Gender } from '@/types/enums';
 import {
   GetGroupsParams,
   GroupInfoResponse,
@@ -62,12 +62,7 @@ export const groupsApi = {
     const apiRequest: CreateGroupApiRequest = {
       performanceId,
       title: data.title,
-      category:
-        data.category === '동행'
-          ? GroupCategory.COMPANION
-          : data.category === '탑승'
-            ? GroupCategory.RIDE_SHARE
-            : GroupCategory.ROOM_SHARE,
+      category: data.category,
       gender:
         data.gender === '남성'
           ? Gender.MALE

--- a/src/types/group.ts
+++ b/src/types/group.ts
@@ -1,3 +1,4 @@
+import { GroupCategoryLabels } from '@/constants/groupLabels';
 import { DateRange } from '@/types/dateRange';
 import {
   ApiResponse,
@@ -94,7 +95,7 @@ export type PostJoinGroupRequest = {
 
 export interface CreateGroupFormData {
   name: string;
-  category: '같이 동행' | '같이 탑승' | '같이 숙박';
+  category: (typeof GroupCategoryLabels)[keyof typeof GroupCategoryLabels];
   title: string;
   description: string;
   region: string;

--- a/src/types/group.ts
+++ b/src/types/group.ts
@@ -94,7 +94,7 @@ export type PostJoinGroupRequest = {
 
 export interface CreateGroupFormData {
   name: string;
-  category: '동행' | '탑승' | '숙박';
+  category: '같이 동행' | '같이 탑승' | '같이 숙박';
   title: string;
   description: string;
   region: string;


### PR DESCRIPTION
### 무엇을 위한 PR인가요? (: 뒤 설명 추가)

-   버그 수정: 모임 개설 API 스펙과 프론트엔드 데이터 불일치 문제를 해결했습니다.
-   리펙토링: 모임 개설 페이지의 전반적인 스타일링을 개선하고 사용자 경험을 향상시켰습니다.

### 변경사항 및 이유 (bullet 으로 구분)

-   **API 스펙 동기화**: 모임 개설 시 전달되는 `category` 값이 백엔드 API 명세와 달라 정상적으로 모임이 생성되지 않는 문제가 있었습니다. 이를 해결하기 위해 프론트엔드에서 사용하는 상수 값을 API 명세에 맞게 수정했습니다.
-   **사용자 피드백 강화**: 모임 개설 과정에서 사용자가 현재 상태를 명확히 인지할 수 있도록 피드백 메커니즘이 부족했습니다. 폼 제출 시, 태그 중복 입력 시 등 다양한 상황에 맞는 토스트 메시지를 추가하여 사용자 경험을 개선했습니다.
-   **UI 일관성 및 스타일 개선**: 모임 개설 페이지 내 컴포넌트들의 스타일이 일관되지 않고, 일부 UI가 사용자에게 혼동을 줄 수 있었습니다. `Calendar`, `DateSelector`, `LocationSelector` 등의 UI를 직관적으로 개선하고 전체적인 디자인 통일성을 높였습니다.

### 작업 내역 (bullet 으로 구분)

-   `CategorySelector`가 API 명세에 정의된 `GroupCategoryLabels` 상수를 사용하도록 수정했습니다.
-   `FormActions` 컴포넌트에 모임 생성 진행, 성공, 실패 상태를 알려주는 토스트 메시지 기능을 추가했습니다.
-   `TagInput` 컴포넌트에 중복된 태그 입력 시 에러 토스트가 표시되도록 개선했습니다.
-   `DateSelector`의 날짜 선택 로직을 개선하고, 날짜 범위가 명확하게 표시되도록 UI를 수정했습니다.
-   `Calendar` 컴포ポー넌트에 `colorScheme` prop을 추가하여 용도에 따라 다른 색상 테마를 적용할 수 있도록 확장했습니다.
-   `LocationSelector`의 옵션 선택 및 초기화 UI를 더 명확하게 개선했습니다.
-   `BottomSheetModal`, `TwoButtonModal` 등 모달 컴포넌트의 스타일을 일부 수정하여 UI 일관성을 높였습니다.
-   모임 개설 페이지의 전체적인 레이아웃 간격을 조정하여 더 간결한 디자인을 적용했습니다.

### ?작업 후 기대 동작(스크린샷)

-   모임 개설 시 API 명세에 맞는 `category` 값이 전송되어 정상적으로 모임이 생성됩니다.
-   사용자는 모임 생성 요청 시 '생성 중', '성공', '실패' 상태에 대한 명확한 피드백을 토스트 메시지로 받게 됩니다.
-   중복된 태그를 입력하려고 하면, 에러 메시지가 담긴 토스트가 나타납니다.
-   모임 개설 페이지의 UI가 전반적으로 개선되어 사용자가 더 쉽고 편리하게 폼을 작성할 수 있습니다.

### ?PR 특이 사항

-   `Toast` 컴포넌트에 `position` prop을 추가하여 화면의 상단, 중앙, 하단에 토스트를 띄울 수 있도록 기능을 확장했습니다.
-   `Calendar` 컴포넌트는 이제 `colorScheme='black'` 옵션을 통해 기존의 파란색/빨간색 테마가 아닌 회색조 테마로 렌더링될 수 있습니다.

### Issue Number

close: #438