### PR TITLE
[Featrue/issue-442] 찜한 유저 카드 변경, 슬라이드 카드 스크롤 관련 수정

### DIFF
--- a/src/components/common/ProfileCard/ProfileHeader.tsx
+++ b/src/components/common/ProfileCard/ProfileHeader.tsx
@@ -27,13 +27,16 @@ const ProfileHeader = ({ profile, onEditClick }: ProfileHeaderProps) => {
   const { mutate: toggleLike, isPending } = useMutation({
     mutationFn: ({ isLiked, userId }: { isLiked: boolean; userId: string }) =>
       usersApi.updateLikeUser(userId, isLiked),
-    onSuccess: (res) => {
-      setIsLiked(res.isLiked);
+    onSettled: (res) => {
+      setIsLiked((pre) => res?.isLiked ?? !pre);
     },
   });
 
   const handleLikeClick = () => {
-    if (!isPending) toggleLike({ isLiked: !isLiked, userId });
+    if (!isPending) {
+      setIsLiked((pre) => !pre);
+      toggleLike({ isLiked: !isLiked, userId });
+    }
   };
 
   const filteredTags = hashtag?.filter((tag) => tag.trim().length > 0) ?? [];
@@ -42,7 +45,7 @@ const ProfileHeader = ({ profile, onEditClick }: ProfileHeaderProps) => {
     <section className='flex flex-col items-center'>
       <div className='mb-[10px] w-full max-w-xl'>
         <ProfileInfoBox
-          profile={profile}
+          profile={{ ...profile, isLiked }}
           onEditClick={onEditClick}
           onLikeClick={handleLikeClick}
         />

--- a/src/components/common/ProfileImage/ProfileImage.tsx
+++ b/src/components/common/ProfileImage/ProfileImage.tsx
@@ -5,7 +5,7 @@ import { cn } from '@/lib/utils';
 interface ProfileImageProps {
   src?: string;
   alt?: string;
-  size?: 'xs' | 'sm' | 'md' | 'lg';
+  size?: 'xs' | 'sm' | 'md' | 'md-lg' | 'lg';
   rounded?: boolean;
   border?: boolean;
   className?: string;
@@ -15,6 +15,7 @@ const sizeMap = {
   xs: { width: 16, height: 16, className: 'w-4 h-4' },
   sm: { width: 40, height: 40, className: 'w-10 h-10' },
   md: { width: 48, height: 48, className: 'w-12 h-12' },
+  'md-lg': { width: 60, height: 60, className: 'w-[60px] h-[60px]' },
   lg: { width: 64, height: 64, className: 'w-16 h-16' },
 };
 

--- a/src/components/common/SlideCard/SlideCard.test.tsx
+++ b/src/components/common/SlideCard/SlideCard.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import SlideCard from '@/components/common/SlideCard/SlideCard';
 import '@testing-library/jest-dom';
 import { ApplicationGroupInfo } from '@/types/application';
@@ -72,25 +72,5 @@ describe('SlideCard component', () => {
     expect(screen.getByText('연극 햄릿')).toBeInTheDocument();
     expect(screen.getByText(/모집 인원 \(3\/10명\)/)).toBeInTheDocument();
     expect(screen.getByText('더보기')).toBeInTheDocument();
-  });
-
-  test('더보기 버튼 클릭 시 콘텐츠가 나타난다', () => {
-    render(
-      <SlideCard
-        type='review'
-        groupInfo={mockReviewGroupInfo}
-        reviewsCount={2}
-        content={'내용 나왔음'}
-      />
-    );
-
-    const toggleButton = screen.getByText('더보기');
-    expect(screen.getByText('내용 나왔음')).toHaveClass('max-h-0');
-
-    fireEvent.click(toggleButton);
-    expect(screen.getByText('내용 나왔음')).toHaveClass('max-h-dvh');
-
-    fireEvent.click(toggleButton);
-    expect(screen.getByText('내용 나왔음')).toHaveClass('max-h-0');
   });
 });

--- a/src/components/common/SlideCard/SlideCard.tsx
+++ b/src/components/common/SlideCard/SlideCard.tsx
@@ -131,7 +131,7 @@ const SlideCard = (props: SlideCardProps) => {
       <div
         className={cn(
           'overflow-y-scroll transition-all duration-300',
-          open ? 'max-h-dvh' : 'max-h-0'
+          open ? 'max-h-[220px]' : 'max-h-0'
         )}
       >
         {content}

--- a/src/components/common/SlideCard/SlideCard.tsx
+++ b/src/components/common/SlideCard/SlideCard.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { ReactNode, useState } from 'react';
+import { ReactNode, useEffect, useRef, useState } from 'react';
 import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';
 import Image from 'next/image';
+import { ScrollArea } from '@/components/ui/scroll-area';
 import {
   GroupCategoryIconLabels,
   GroupCategoryLabels,
@@ -34,6 +35,17 @@ const SlideCard = (props: SlideCardProps) => {
   const { type, groupInfo, content } = props;
   const [open, setOpen] = useState(false);
   const [openToClose, setOpenToClose] = useState(false);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [contentHeight, setContentHeight] = useState(0);
+
+  useEffect(() => {
+    if (open && contentRef.current) {
+      const measured = contentRef.current.scrollHeight;
+      setContentHeight(Math.min(measured, 220));
+    } else {
+      setContentHeight(0);
+    }
+  }, [open, content]);
 
   const handleOpen = () => {
     if (open) {
@@ -128,14 +140,15 @@ const SlideCard = (props: SlideCardProps) => {
         </div>
       </div>
 
-      <div
+      <ScrollArea
         className={cn(
-          'overflow-y-scroll transition-all duration-300',
-          open ? 'max-h-[220px]' : 'max-h-0'
+          'transition-all duration-300',
+          !open && 'h-0 overflow-hidden'
         )}
+        style={{ height: contentHeight }}
       >
-        {content}
-      </div>
+        <div ref={contentRef}>{content}</div>
+      </ScrollArea>
     </div>
   );
 };

--- a/src/components/common/SlideCard/SlideCard.tsx
+++ b/src/components/common/SlideCard/SlideCard.tsx
@@ -33,9 +33,18 @@ type SlideCardProps = ReviewCardProps | ApplicationCardProps;
 const SlideCard = (props: SlideCardProps) => {
   const { type, groupInfo, content } = props;
   const [open, setOpen] = useState(false);
+  const [openToClose, setOpenToClose] = useState(false);
 
   const handleOpen = () => {
-    setOpen((pre) => !pre);
+    if (open) {
+      setOpenToClose(true);
+      setOpen(false);
+      setTimeout(() => {
+        setOpenToClose(false);
+      }, 300);
+    } else {
+      setOpen(true);
+    }
   };
 
   const Icon = GroupCategoryIconLabels[groupInfo.category];
@@ -44,7 +53,7 @@ const SlideCard = (props: SlideCardProps) => {
     <div
       className={cn(
         'flex w-[343px] flex-col rounded-2xl bg-gray-25 p-5',
-        open && 'gap-4'
+        (open || openToClose) && 'gap-4'
       )}
     >
       <div className='flex gap-4'>

--- a/src/components/pages/favorite/FavoriteTabContainer.tsx
+++ b/src/components/pages/favorite/FavoriteTabContainer.tsx
@@ -4,7 +4,6 @@ import {
   QueryTabs,
   Spinner,
   PerformanceCard,
-  ProfileCard,
   InfiniteList,
 } from '@/components/common';
 import { useQueryParam } from '@/hooks';
@@ -14,6 +13,7 @@ import {
 } from '@/hooks/favoriteHooks';
 import { GetFavoritePerformancesResponse } from '@/types/performance';
 import { GetFavoriteUsersResponse } from '@/types/users';
+import FavoriteUserCard from './FavoriteUserCard';
 
 const TABS = ['찜한 유저', '찜한 공연'];
 
@@ -71,13 +71,11 @@ const FavoriteTabContainer: React.FC = () => {
             GetFavoriteUsersResponse['data'][number]
           >
             options={favoriteUsersOptions(DEFAULT_SIZE)}
-            getDataId={(user) => user.id}
-            renderData={(user) => (
-              <ProfileCard profile={{ ...user, isMine: false }} />
-            )}
-            fallback={<SpinnerWrapper />}
-            isFetchingFallback={<SpinnerWrapper />}
-            className='mx-auto grid w-fit grid-cols-2 gap-4'
+            getDataId={(user) => user.userUid}
+            renderData={(user) => <FavoriteUserCard {...user} />}
+            fallback={<Spinner />}
+            isFetchingFallback={<Spinner />}
+            className='flex flex-col gap-5'
             emptyFallback={
               <div className='col-span-2 py-8 text-center text-gray-500'>
                 찜한 사용자가 없습니다.

--- a/src/components/pages/favorite/FavoriteUserCard.tsx
+++ b/src/components/pages/favorite/FavoriteUserCard.tsx
@@ -1,0 +1,79 @@
+'use client';
+import React, { useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { ProfileImage } from '@/components/common';
+import { LikeIcon } from '@/components/icons';
+import { GenderLabels } from '@/constants';
+import { usersApi } from '@/services/usersService';
+import { GenderType } from '@/types/enums';
+import { Image } from '@/types/profiles';
+
+interface FavoriteUserCardProps {
+  userUid: string;
+  profileImage: Image | null;
+  name: string;
+  gender: GenderType;
+  age: number;
+  isLiked: boolean;
+}
+
+const FavoriteUserCard = ({
+  userUid,
+  profileImage,
+  isLiked: initialIsLiked,
+  age,
+  gender,
+  name,
+}: FavoriteUserCardProps) => {
+  const [isLiked, setIsLiked] = useState(initialIsLiked ?? false);
+  const { mutate: toggleLike, isPending } = useMutation({
+    mutationFn: ({ isLiked, userId }: { isLiked: boolean; userId: string }) =>
+      usersApi.updateLikeUser(userId, isLiked),
+    onSettled: (res) => {
+      setIsLiked((pre) => res?.isLiked ?? !pre);
+    },
+  });
+
+  const handleLikeClick = () => {
+    if (!isPending) {
+      setIsLiked((pre) => !pre);
+      toggleLike({ isLiked: !isLiked, userId: userUid });
+    }
+  };
+
+  return (
+    <div className='h-[68px] py-1'>
+      <div className='flex h-[60px] items-center gap-[14px]'>
+        <ProfileImage
+          src={profileImage?.src || ''}
+          size='md-lg'
+          className='shrink-0'
+        />
+
+        <div className='flex w-full flex-col gap-2'>
+          <div className='flex h-5 items-center justify-between'>
+            <h2 className='text-16_B text-gray-950'>{name}</h2>
+            <button
+              className='flex h-5 w-5 items-center justify-center'
+              onClick={handleLikeClick}
+            >
+              <LikeIcon
+                type={isLiked ? 'active' : 'empty'}
+                className='h-5 w-5'
+              />
+            </button>
+          </div>
+          <div className='flex h-4 items-center gap-2'>
+            <span className='text-13_M text-gray-700'>
+              {GenderLabels[gender]}
+            </span>
+            <span className='h-2 w-[1px] bg-gray-200' />
+            <span className='text-13_M text-gray-700'>{age}세</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default FavoriteUserCard;

--- a/src/components/pages/reviews/managements/ReviewTabs.tsx
+++ b/src/components/pages/reviews/managements/ReviewTabs.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import Tabs from '@/components/common/Tabs/Tabs';
+import { ScrollArea } from '@/components/ui/scroll-area';
 import WritableReviews from './WritableReviews';
 import WrittenReviews from './WrittenReviews';
 
@@ -16,10 +17,10 @@ const ReviewTabs = () => {
         activeTab={selectedTab}
         onTabChange={setSelectedTab}
       />
-      <div className='h-full px-4 pt-5'>
+      <ScrollArea className='h-[calc(100dvh-93px)] px-4'>
         {selectedTab === '작성 가능한 리뷰' && <WritableReviews />}
         {selectedTab === '작성한 리뷰' && <WrittenReviews />}
-      </div>
+      </ScrollArea>
     </div>
   );
 };

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -39,9 +39,9 @@ const ScrollBar = function ({
       className={cn(
         'flex touch-none p-px transition-colors select-none',
         orientation === 'vertical'
-          && 'h-full w-2.5 border-l border-l-transparent',
+          && 'h-full w-1.5 border-l border-l-transparent',
         orientation === 'horizontal'
-          && 'h-2.5 flex-col border-t border-t-transparent',
+          && 'h-1.5 flex-col border-t border-t-transparent',
         className
       )}
       {...props}

--- a/src/types/users.ts
+++ b/src/types/users.ts
@@ -1,6 +1,6 @@
-import { Gender } from '@/types/enums';
+import { Gender, GenderType } from '@/types/enums';
 import { ApiResponse, CursorResponse } from './api';
-import { FullProfile } from './profiles';
+import { FullProfile, Image } from './profiles';
 
 export interface User {
   id: string;
@@ -34,7 +34,17 @@ export interface UserIsLikedResponse {
   };
 }
 
-export type GetFavoriteUsersResponse = { data: User[] } & ApiResponse
+export type GetFavoriteUsersResponse = {
+  data: {
+    name: string;
+    gender: GenderType;
+    age: number;
+    userUid: string;
+    profileImage: Image | null;
+    hashtag: string[];
+    isLiked: boolean;
+  }[];
+} & ApiResponse
   & CursorResponse;
 
 export interface UserId {


### PR DESCRIPTION
### 무엇을 위한 PR인가요? (: 뒤 설명 추가)

- 신규 기능 추가: 
- 버그 수정: 슬라이드 카드 스크롤 관련 수정
- 리펙토링: 찜한 유저 카드 변경
- 문서 업데이트:
- 기타:

### 변경사항 및 이유 (bullet 으로 구분)

- 찜한 유저 카드에서 원래 사용하던 데이터가 실제 들어오는 데이터와 다름
- 슬라이드 카드 열고 닫을때 버벅임
- 리뷰 관리 페이지 스크롤 안됨

### 작업 내역 (bullet 으로 구분)

- 찜한 유저 카드를 새로 만들어 사용
- 슬라이드 카드 닫힐때 gap이 duration지나고 없어지도록 변경
- 리뷰 관리 페이지에 scrollArea컴포넌트 사용

### ?작업 후 기대 동작(스크린샷)

- 동작

### ?PR 특이 사항

- 특이 사항

### Issue Number

close: #442