### PR TITLE
[Feature/issue-436] 나의 모임 탭별로 카드에 라우팅 추가, 텍스트 truncate처리

### DIFF
--- a/src/components/common/GroupCard/GroupCard.tsx
+++ b/src/components/common/GroupCard/GroupCard.tsx
@@ -133,8 +133,10 @@ const GroupCard = ({
             <ProfileImage
               size='xs'
               border={false}
+              src={groupData.host.profileImage}
+              className='flex-shrink-0'
             />
-            <span className='text-12_M text-gray-700'>
+            <span className='ml-0.5 min-w-0 truncate text-12_M text-gray-700'>
               {groupData.host.name}
             </span>
             <span className='flex text-12_M text-gray-700'>
@@ -142,7 +144,7 @@ const GroupCard = ({
               {groupData.host.rating})
             </span>
           </div>
-          <p className='line-clamp-2 w-full text-14_body_M text-gray-950'>
+          <p className='line-clamp-2 w-full text-14_body_M break-all text-gray-950'>
             {groupData.description}
           </p>
         </div>

--- a/src/components/common/SlideCard/SlideCard.tsx
+++ b/src/components/common/SlideCard/SlideCard.tsx
@@ -15,6 +15,8 @@ import ProgressBar from '../ProgressBar/ProgressBar';
 
 interface BaseProps {
   content?: ReactNode;
+  className?: string;
+  onCardClick?: () => void;
 }
 
 interface ReviewCardProps extends BaseProps {
@@ -31,10 +33,11 @@ interface ApplicationCardProps extends BaseProps {
 type SlideCardProps = ReviewCardProps | ApplicationCardProps;
 
 const SlideCard = (props: SlideCardProps) => {
-  const { type, groupInfo, content } = props;
+  const { type, groupInfo, content, onCardClick } = props;
   const [open, setOpen] = useState(false);
 
-  const handleOpen = () => {
+  const handleOpen = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
     setOpen((pre) => !pre);
   };
 
@@ -42,8 +45,18 @@ const SlideCard = (props: SlideCardProps) => {
 
   return (
     <div
+      {...(type === 'application' && {
+        onClick: onCardClick,
+        role: 'button',
+        tabIndex: 0,
+        onKeyDown: (e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            onCardClick?.();
+          }
+        },
+      })}
       className={cn(
-        'flex w-[343px] flex-col rounded-2xl bg-gray-25 p-5',
+        'flex w-full flex-col rounded-2xl bg-gray-25 p-5',
         open && 'gap-4'
       )}
     >
@@ -59,7 +72,7 @@ const SlideCard = (props: SlideCardProps) => {
           />
         </div>
 
-        <div className='flex w-[204px] flex-col justify-between'>
+        <div className='flex w-full flex-1 flex-col justify-between overflow-hidden'>
           <div className='flex items-center justify-between'>
             <span className='flex items-center gap-1 text-14_M text-gray-600'>
               {<Icon className='h-4 w-4' />}
@@ -100,7 +113,7 @@ const SlideCard = (props: SlideCardProps) => {
               </p>
               <button
                 className='text-12_M text-gray-700 underline'
-                onClick={handleOpen}
+                onClick={(e) => handleOpen(e)}
               >
                 <span>{open ? '닫기' : '더보기'}</span>
               </button>

--- a/src/components/pages/groupDetail/PostCard/PostCard.tsx
+++ b/src/components/pages/groupDetail/PostCard/PostCard.tsx
@@ -135,7 +135,7 @@ const PostCard = ({ post, type = 'posts', children }: PostCardProps) => {
                 />
               </button>
 
-              <div className='flex flex-col items-start'>
+              <div className='flex flex-col items-start gap-1'>
                 <button
                   type='button'
                   onClick={() => router.push(`/profiles/${author.id}`)}

--- a/src/components/pages/groupsManagement/Application/Application.tsx
+++ b/src/components/pages/groupsManagement/Application/Application.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
 import Button from '@/components/common/Button/Button';
 import ProfileImage from '@/components/common/ProfileImage/ProfileImage';
 import StarIcon from '@/components/icons/StarIcon';
@@ -27,6 +28,7 @@ const Application = ({
   secondaryButtonText,
   onSecondaryClick,
 }: ApplicationProps) => {
+  const router = useRouter();
   const genderLabel = GenderLabels[applicationData.gender as GenderType];
 
   const handleSecondaryClick = () => {
@@ -36,14 +38,26 @@ const Application = ({
   const handlePrimaryClick = () => {
     onPrimaryClick();
   };
+
+  const handleProfileClick = () => {
+    router.push(`/profiles/${applicationData.userId}`);
+  };
+
   return (
     <div
+      role='button'
+      tabIndex={0}
+      onClick={(e) => {
+        e.stopPropagation();
+      }}
+      onKeyDown={(e) => {
+        e.stopPropagation();
+      }}
       className={cn(
         'flex w-full flex-col items-start justify-center gap-4 bg-gray-25 pt-5 pb-6',
         className
       )}
     >
-      {/* 성별 나이 */}
       <div className='flex w-full items-center justify-between text-13_M text-gray-700'>
         <div className='flex items-center gap-1.5'>
           <span>{genderLabel}</span>
@@ -53,20 +67,23 @@ const Application = ({
         <span>{formatNormalDate(applicationData.createdAt)}</span>
       </div>
       <div className='flex w-full justify-between gap-4'>
-        <div className='flex flex-1 flex-col gap-2 text-12_M text-gray-700'>
-          {/* 신청자, 방장 정보 */}
-          <div className='flex items-center gap-0.5'>
+        <div className='flex flex-1 flex-col gap-2'>
+          <button
+            className='flex items-center gap-0.5 text-12_M text-gray-700'
+            onClick={handleProfileClick}
+          >
             <ProfileImage
               size='xs'
               border={false}
+              src={applicationData.profileImage.src}
+              className='flex-shrink-0'
             />
             <span>{applicationData.userName}</span>
             <span className='flex'>
               (<StarIcon className='h-3 w-3' />
               {applicationData.rating})
             </span>
-          </div>
-          {/* 소개글 */}
+          </button>
           <p className='w-full text-14_body_M text-gray-950'>
             {applicationData.applicationText}
           </p>

--- a/src/components/pages/groupsManagement/Applications.tsx
+++ b/src/components/pages/groupsManagement/Applications.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import Button from '@/components/common/Button/Button';
 import Modal from '@/components/common/Modal/Modal';
 import ModalAction from '@/components/common/Modal/ModalAction';
@@ -21,6 +22,7 @@ import {
 import ApplicationComponent from './Application/Application';
 
 const Applications = () => {
+  const router = useRouter();
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isPending } =
     useGetApplications();
   const [actionType, setActionType] = useState<'accept' | 'reject' | null>(
@@ -30,7 +32,6 @@ const Applications = () => {
     string | null
   >(null);
   const { mutate: patchApplication } = usePatchApplication();
-
   const triggerRef = useRef<HTMLButtonElement>(null);
 
   const bottomRef = useInfiniteScroll<HTMLDivElement>(
@@ -81,10 +82,15 @@ const Applications = () => {
     setSelectedApplicationId(null);
   };
 
+  const handleCardClick = (groupId: string) => {
+    router.push(`/groups/${groupId}`);
+  };
+
   return (
     <div className='flex flex-col items-center gap-5 px-4'>
       {groups?.map((item) => (
         <SlideCard
+          onCardClick={() => handleCardClick(item.groupId)}
           key={item.groupId}
           type='application'
           groupInfo={extractGroupInfo(item) as ApplicationGroupInfo}
@@ -106,13 +112,21 @@ const Applications = () => {
                     className={
                       index !== item.applications.length - 1
                         ? 'border-b border-gray-200'
-                        : ''
+                        : 'pb-0'
                     }
                   />
                 ))}
               </>
             ) : (
-              <div className='flex items-center justify-center py-3 text-14_body_M text-gray-950'>
+              <div
+                className='flex items-center justify-center py-3 text-14_body_M text-gray-950'
+                role='button'
+                tabIndex={0}
+                onKeyDown={(e) => e.stopPropagation()}
+                onClick={(e) => {
+                  e.stopPropagation();
+                }}
+              >
                 <p>아직 신청자가 없습니다</p>
               </div>
             )

--- a/src/components/pages/groupsManagement/AppliedGroup/AppliedGroup.tsx
+++ b/src/components/pages/groupsManagement/AppliedGroup/AppliedGroup.tsx
@@ -100,27 +100,34 @@ const AppliedGroup = ({
             />
           </div>
         )}
-        <div className='flex flex-1 flex-col justify-between overflow-hidden'>
+        <div className='flex flex-1 flex-col overflow-hidden'>
           <h4 className='mb-1.5 truncate text-16_B text-black'>
             {applicationData.groupName}
           </h4>
           <div className='mb-4 text-13_M text-gray-700'>
             <span>{genderLabel}</span>
           </div>
-          <div className='flex items-center gap-0.5'>
+          <div className='mb-2 flex min-w-0 items-center'>
             <ProfileImage
               size='xs'
               border={false}
+              src={
+                typeof applicationData.hostProfileImage.src === 'string'
+                  ? applicationData.hostProfileImage.src
+                  : applicationData.hostProfileImage.src?.src
+              }
+              className='flex-shrink-0'
             />
-            <span className='text-12_M text-gray-700'>
+            <span className='ml-0.5 min-w-0 truncate text-12_M text-gray-700'>
               {applicationData.hostName}
+              {/* 이름완 */}
             </span>
-            <span className='flex text-12_M text-gray-700'>
+            <span className='ml-0.5 flex flex-shrink-0 items-center gap-0.5 text-12_M text-gray-700'>
               (<StarIcon className='h-3 w-3' />
               {applicationData.hostRating})
             </span>
           </div>
-          <p className='line-clamp-2 w-full text-14_body_M text-gray-950'>
+          <p className='line-clamp-2 w-full text-14_body_M break-all text-gray-950'>
             {applicationData.applicationText}
           </p>
         </div>


### PR DESCRIPTION
### 무엇을 위한 PR인가요? (: 뒤 설명 추가)

- 신규 기능 추가:  나의 모임 탭별로 작성자의 프로필 또는 모임 정보를 클릭했을 때, 해당 프로필 상세 페이지 또는 모임 상세 페이지로 이동
- 리펙토링: 텍스트가 컴포넌트 영역을 넘어가는 문제를 해결하기 위해 공연명, 모임명, 닉네임에 truncate 처리. 프로필 이미지 사이즈와 위치를 UI 가이드에 맞게 조정.


### 변경사항 및 이유 (bullet 으로 구분)

- 공연명, 모임명, 닉네임에 truncate 적용하여 레이아웃 깨짐 방지
- 프로필 이미지 사이즈 및 위치 조정으로 일관성 향상
- 클릭 시 해당 작성자의 프로필 또는 모임 상세 페이지로 이동 가능하도록 라우팅 추가
- 슬라이드 카드 전체 너비(w-full) 적용으로 반응형 개선
- 게시글 카드 작성자 정보 항목 간 gap 추가로 가독성 개선

### 작업 내역 (bullet 으로 구분)

- 공연명, 모임명, 닉네임 truncate 클래스 적용
- ProfileImage 스타일 조정 (크기, 마진 등)
- 프로필 및 모임 정보 클릭 시 라우터 이동 로직 추가
- 카드 레이아웃에 w-full 클래스 적용
- 작성자 정보(hostName, rating) 섹션에 gap 스타일 적용