### PR TITLE
[Bug/issue-463] 일정 관련 api 버그 수정

### DIFF
--- a/src/components/icons/MapPinIcon.tsx
+++ b/src/components/icons/MapPinIcon.tsx
@@ -8,9 +8,9 @@ const MapPinIcon = ({ className }: IconProps) => (
   <svg
     className={className}
     xmlns='http://www.w3.org/2000/svg'
-    width='20'
-    height='20'
-    viewBox='0 0 20 20'
+    width='17'
+    height='17'
+    viewBox='0 0 17 17'
     fill='none'
   >
     <path

--- a/src/components/pages/groupDetail/Chat/ChatDateDivider.tsx
+++ b/src/components/pages/groupDetail/Chat/ChatDateDivider.tsx
@@ -1,4 +1,6 @@
-import { formatToKSTDate } from '@/utils/date';
+import { format } from 'date-fns';
+import { ko } from 'date-fns/locale';
+import { formatToKST } from '@/utils/date';
 
 interface ChatDateDividerProps {
   date: string;
@@ -7,7 +9,9 @@ interface ChatDateDividerProps {
 const ChatDateDivider = ({ date }: ChatDateDividerProps) => (
   <div className='flex items-center justify-center px-4 py-1.5'>
     <span className='text-13_M leading-normal tracking-[-0.325px] text-gray-800'>
-      {formatToKSTDate(date)}
+      {format(formatToKST(date), 'yy년 MM월 dd일 (eee)', {
+        locale: ko,
+      })}
     </span>
   </div>
 );

--- a/src/components/pages/groupDetail/Chat/ChatMessage.tsx
+++ b/src/components/pages/groupDetail/Chat/ChatMessage.tsx
@@ -1,6 +1,8 @@
+import { format } from 'date-fns';
+import { ko } from 'date-fns/locale';
 import ProfileImage from '@/components/common/ProfileImage/ProfileImage';
 import { ChatMessage as ChatMessageType } from '@/types/chat';
-import { formatToKSTTime } from '@/utils/date';
+import { formatToKST } from '@/utils/date';
 
 interface ChatMessageProps {
   message: ChatMessageType;
@@ -12,7 +14,9 @@ const ChatMessage = ({ message, isMine }: ChatMessageProps) => {
     return (
       <div className='flex items-end justify-end gap-1.5'>
         <span className='text-right text-12_M leading-normal tracking-[-0.3px] text-gray-500'>
-          {formatToKSTTime(message.createdAt)}
+          {format(formatToKST(message.createdAt), 'a hh:mm', {
+            locale: ko,
+          })}
         </span>
         <div className='rounded-l-[20px] rounded-tr-[2px] rounded-br-[20px] bg-[#ececec] px-4 py-2.5'>
           <span className='text-16_M leading-normal tracking-[-0.4px] text-gray-950'>
@@ -42,7 +46,9 @@ const ChatMessage = ({ message, isMine }: ChatMessageProps) => {
             </span>
           </div>
           <span className='text-left text-12_M leading-normal tracking-[-0.3px] text-gray-500'>
-            {formatToKSTTime(message.createdAt)}
+            {format(formatToKST(message.createdAt), 'a hh:mm', {
+              locale: ko,
+            })}
           </span>
         </div>
       </div>

--- a/src/components/pages/groupDetail/GroupCalendar/GroupCalendar.tsx
+++ b/src/components/pages/groupDetail/GroupCalendar/GroupCalendar.tsx
@@ -34,7 +34,7 @@ const GroupCalendar = ({ groupId }: GroupCalendarProps) => {
   };
 
   return (
-    <>
+    <div className='pt-7.5 pb-6'>
       <CalendarBase<GroupSchedule>
         month={currentMonth}
         events={schedules}
@@ -69,7 +69,7 @@ const GroupCalendar = ({ groupId }: GroupCalendarProps) => {
           }}
         />
       )}
-    </>
+    </div>
   );
 };
 

--- a/src/components/pages/groupDetail/GroupCalendar/ScheduleDetailModal.tsx
+++ b/src/components/pages/groupDetail/GroupCalendar/ScheduleDetailModal.tsx
@@ -81,19 +81,21 @@ const ScheduleDetailModal = ({
                 {format(new Date(schedule.startAt), 'yyyy년 M월 d일')}
               </span>
               <span className='text-left'>
-                {format(new Date(schedule.startAt), 'a h시')}{' '}
+                {format(new Date(schedule.startAt), 'a h시 mm분')}{' '}
                 <span className='ml-[13px]'>~</span>
               </span>
 
               <span>{format(new Date(schedule.endAt), 'yyyy년 M월 d일')}</span>
               <span className='text-left'>
-                {format(new Date(schedule.endAt), 'a h시')}
+                {format(new Date(schedule.endAt), 'a h시 mm분')}
               </span>
             </div>
 
-            <div className='mt-[20px] flex items-center border-t border-gray-100 pt-[20px] text-14_M text-gray-700'>
-              <MapPinIcon />
-              {schedule.location}
+            <div className='mt-[20px] flex items-center border-t border-gray-100 pt-[20px]'>
+              <MapPinIcon className='aspect-square h-4 w-4 shrink-0 text-gray-700' />
+              <span className='text-14_M leading-normal tracking-[-0.35px] text-gray-700'>
+                {schedule.location}
+              </span>
             </div>
 
             <div className='mt-[10px] flex items-center gap-2'>

--- a/src/components/pages/groupDetail/GroupCalendar/ScheduleFormModal.tsx
+++ b/src/components/pages/groupDetail/GroupCalendar/ScheduleFormModal.tsx
@@ -19,6 +19,7 @@ import { cn } from '@/lib/utils';
 import { groupsApi } from '@/services/groupsService';
 import { EventColorName } from '@/types/enums';
 import { GroupSchedule, ScheduleRequest } from '@/types/group';
+import { formatScheduleDate } from '@/utils/date';
 
 //TODO: 모달위로 달력 구현해야함, timepicker로 교체해야 함
 
@@ -151,13 +152,11 @@ const ScheduleFormModal = ({
     try {
       const scheduleRequest: ScheduleRequest = {
         description: title,
-        startAt: startTime.toISOString(),
-        endAt: endTime.toISOString(),
+        startAt: formatScheduleDate(startDate, startTime),
+        endAt: formatScheduleDate(endDate || startDate, endTime),
         location: location ?? '',
         eventColor: eventColor,
       };
-
-      console.log('📝 일정 등록 요청:', scheduleRequest);
 
       await mutateAsync(scheduleRequest);
       return true;

--- a/src/hooks/useSchedules/useSchedules.ts
+++ b/src/hooks/useSchedules/useSchedules.ts
@@ -1,12 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
-import { format } from 'date-fns';
 import { GROUP_QUERY_KEYS } from '@/constants/queryKeys';
 import { groupsApi } from '@/services/groupsService';
 import { GroupSchedule } from '@/types/group';
 
 export const useSchedules = (groupId: string, start: Date, end: Date) => {
-  const startDate = format(start, 'yyyy-MM-dd');
-  const endDate = format(end, 'yyyy-MM-dd');
+  const startDate = start.toISOString();
+  const endDate = end.toISOString();
 
   return useQuery<GroupSchedule[], Error>({
     queryKey: [GROUP_QUERY_KEYS.schedules, groupId, startDate, endDate],

--- a/src/hooks/useSchedules/useSchedules.ts
+++ b/src/hooks/useSchedules/useSchedules.ts
@@ -1,11 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
+import { formatISO } from 'date-fns';
 import { GROUP_QUERY_KEYS } from '@/constants/queryKeys';
 import { groupsApi } from '@/services/groupsService';
 import { GroupSchedule } from '@/types/group';
 
 export const useSchedules = (groupId: string, start: Date, end: Date) => {
   const startDate = start.toISOString();
-  const endDate = end.toISOString();
+  const endDate = formatISO(end.valueOf() + 9 * 60 * 60 * 1000);
 
   return useQuery<GroupSchedule[], Error>({
     queryKey: [GROUP_QUERY_KEYS.schedules, groupId, startDate, endDate],

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,4 +1,4 @@
-import { format, parseISO } from 'date-fns';
+import { format, formatISO, parseISO } from 'date-fns';
 import { ko } from 'date-fns/locale';
 
 // mm전, hh시간전, dd일전, M월 d일
@@ -42,24 +42,24 @@ export const formatPostDate = (dateStr: string): string => {
   }
 };
 
-export const formatToKSTDate = (isoString: string) => {
-  const date = new Date(isoString);
-  const kstTimestamp = date.getTime() - 9 * 60 * 60 * 1000;
-  const formattedDate = format(kstTimestamp, 'yy년 MM월 dd일 (eee)', {
-    locale: ko,
-  });
-  return formattedDate;
-};
-
-export const formatToKSTTime = (isoString: string) => {
-  const date = new Date(isoString);
-  const kstTimestamp = date.getTime() - 9 * 60 * 60 * 1000;
-  const formattedTime = format(kstTimestamp, 'a hh:mm', {
-    locale: ko,
-  });
-  return formattedTime;
-};
-
 // yy.MM.dd
 export const formatNormalDate = (date: string | Date) =>
   format(new Date(date), 'yy.MM.dd', { locale: ko });
+
+export const formatToKST = (isoString: string) => {
+  const date = new Date(isoString);
+  const kstTimestamp = date.getTime() - 9 * 60 * 60 * 1000;
+  return kstTimestamp;
+};
+
+export const formatScheduleDate = (date: Date, time: Date) => {
+  const dateString = formatISO(date);
+  const timeString = formatISO(time);
+
+  const formattedDate = dateString.split('T')[0];
+  const formattedTime = timeString.split('T')[1];
+
+  const newDate = formattedDate + 'T' + formattedTime;
+
+  return newDate;
+};


### PR DESCRIPTION
### 무엇을 위한 PR인가요? (: 뒤 설명 추가)

- 버그 수정: 일정 관련 api 버그 수정

### 변경사항 및 이유 (bullet 으로 구분)

- 일정 조회, 등록, 수정 시 날짜가 안맞던 오류 수정
- 채팅 날짜, 시간 포맷팅 함수 리팩토링
- 모임 내 캘린더 디자인 수정

### 작업 내역 (bullet 으로 구분)

- 일정 조회 시 날짜 포맷팅이 달라 조회가 안되던 오류 수정
  - startDate는 달력 상 첫번째 날짜에서 -9시간, endDate는 달력 상 마지막 날짜에서 +9시간으로 포맷팅
  - ex) startDate 2025-06-01T00:00:00Z -> 2025-05-31T15:00:00.000Z
           endDate 2025-07-05T23:59:59+09:00 -> 2025-07-06T08:59:59+09:00
- 일정 등록/수정 시 날짜가 제대로 반영 안되던 오류 수정
  - startAt, endAt에 날짜, 시간이 모두 적용되지 않고 시간만 적용되어 적용되지 않았음
  - 날짜 Date 객체와 시간 Date 객체에서 필요한 부분만 가져와 합친 후 요청 데이터에 보냄
- 모임 내 캘린더 디자인과 다른 부분 수정
  - 캘린더 외부 여백 추가
  - 지도 아이콘 변경
- 채팅 날짜, 시간 포맷팅 함수 리팩토링
  - 기존에 각각 만들었던 날짜, 시간 포맷팅 함수를 하나로 합침 (`formatToKST`)

### 작업 후 기대 동작(스크린샷)

https://github.com/user-attachments/assets/a02de7fd-0f09-478c-8910-71a6f2cd07ab

https://github.com/user-attachments/assets/9ecda9bf-4c2a-4e44-9bf5-337b61f081bf

### PR 특이 사항

- 일정 등록/수정 모달 timepicker 수정 필요

### Issue Number

close: #463 