### PR TITLE
[Refactor/issue-494] 공연 상세, 모임 상세 에러 핸들링

### DIFF
--- a/src/components/pages/groupDetail/Chat/Chat.tsx
+++ b/src/components/pages/groupDetail/Chat/Chat.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import StateNotice from '@/components/common/StateNotice/StateNotice';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useGetUserId } from '@/hooks/userHooks/userHooks';
 import { GroupInfo } from '@/types/group';
@@ -26,10 +27,11 @@ const Chat = ({ groupInfo }: ChatProps) => {
 
   if (isError || !userId || !groupInfo?.isMember) {
     return (
-      <div className='flex flex-col items-center justify-center px-4 py-5'>
-        <p className='font-semibold text-gray-500'>
-          채팅 접근 권한이 없습니다.
-        </p>
+      <div className='flex h-full items-center justify-center py-20'>
+        <StateNotice
+          message='채팅 접근 권한이 없습니다.'
+          height='100%'
+        />
       </div>
     );
   }

--- a/src/components/pages/groupDetail/Members/MembersList.tsx
+++ b/src/components/pages/groupDetail/Members/MembersList.tsx
@@ -2,6 +2,7 @@ import { RefObject } from 'react';
 import { CrownIcon } from 'lucide-react';
 import Link from 'next/link';
 import ProfileImage from '@/components/common/ProfileImage/ProfileImage';
+import StateNotice from '@/components/common/StateNotice/StateNotice';
 import {
   Carousel,
   CarouselContent,
@@ -52,11 +53,11 @@ const MembersList = ({
 
   if (isError || members?.length === 0) {
     return (
-      <div className='flex flex-col items-center justify-center px-4 py-5'>
-        <p className='font-semibold text-gray-500'>
-          모임원 목록을 불러오지 못했습니다.
-        </p>
-      </div>
+      <StateNotice
+        message='모임원 목록을 불러오지 못했습니다.'
+        height='fit-content'
+        className='py-4'
+      />
     );
   }
 

--- a/src/components/pages/performanceDetail/CreateGroupButton.tsx
+++ b/src/components/pages/performanceDetail/CreateGroupButton.tsx
@@ -8,7 +8,7 @@ interface CreateGroupButtonProps {
 const CreateGroupButton = ({ onClick }: CreateGroupButtonProps) => (
   <Button
     onClick={onClick}
-    className='fixed right-4 bottom-23 z-20 w-fit min-w-30 gap-1 rounded-[100px] py-2.5 pr-4 pl-2.5'
+    className='fixed right-4 bottom-23 z-20 w-fit min-w-30 gap-1 rounded-[100px] py-2.5 pr-4 pl-2.5 select-none hover:bg-[#AF282A]'
   >
     <PlusIcon className='aspect-square h-6 w-6' />
     <span className='text-16_B leading-normal tracking-[-0.4px]'>

--- a/src/components/pages/performanceDetail/PerformanceDetailGroupsList.tsx
+++ b/src/components/pages/performanceDetail/PerformanceDetailGroupsList.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import GroupCard from '@/components/common/GroupCard/GroupCard';
+import StateNotice from '@/components/common/StateNotice/StateNotice';
 import Toast from '@/components/common/Toast/Toast';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useAuthStore } from '@/providers/AuthStoreProvider';
@@ -94,8 +95,8 @@ const PerformanceDetailGroupsList = ({
         </span>
 
         <div className='flex flex-col gap-5'>
-          {groups
-            && formatPerformanceGroups(groups).map((group) => (
+          {groups && formatPerformanceGroups(groups).length > 0 ? (
+            formatPerformanceGroups(groups).map((group) => (
               <div key={group.id}>
                 <GroupCard
                   onCardClick={() => routeToGroupPage(group.id)}
@@ -108,7 +109,10 @@ const PerformanceDetailGroupsList = ({
                   className='cursor-pointer'
                 />
               </div>
-            ))}
+            ))
+          ) : (
+            <StateNotice preset='groupEmpty' />
+          )}
 
           {/* 모임 참가 신청 모달 */}
           <GroupApplyModal

--- a/src/components/pages/performanceDetail/PerformanceDetailInfo.tsx
+++ b/src/components/pages/performanceDetail/PerformanceDetailInfo.tsx
@@ -46,7 +46,11 @@ const PerformanceDetailInfo = ({
       },
       {
         label: '공연 런타임',
-        value: performanceDetail?.runtime || '정보 없음',
+        value:
+          performanceDetail?.runtime === undefined
+          || performanceDetail?.runtime.trim() === ''
+            ? '정보 없음'
+            : performanceDetail?.runtime,
       },
       { label: '관람 연령', value: performanceDetail.age || '정보 없음' },
       { label: '공연 상태', value: performanceDetail.state || '정보 없음' },
@@ -101,24 +105,29 @@ const PerformanceDetailInfo = ({
         label: '제작사',
         value: (
           <div className='flex flex-col gap-1.5'>
-            {performanceDetail.productionCompany?.map((company: string) => (
-              <p key={company}>{company}</p>
-            ))}
+            {performanceDetail.productionCompany === undefined
+            || performanceDetail.productionCompany.length === 0
+            || performanceDetail.productionCompany[0].trim() === ''
+              ? '정보 없음'
+              : performanceDetail.productionCompany?.map((company: string) => (
+                  <p key={company}>{company}</p>
+                ))}
           </div>
         ),
       },
       {
         label: '기획사',
-        value:
-          performanceDetail.agency?.length === 0 ? (
-            '정보 없음'
-          ) : (
-            <div className='flex flex-col gap-1.5'>
-              {performanceDetail.agency?.map((agency: string) => (
-                <span key={agency}>{agency}</span>
-              ))}
-            </div>
-          ),
+        value: (
+          <div className='flex flex-col gap-1.5'>
+            {performanceDetail.agency === undefined
+            || performanceDetail.agency.length === 0
+            || performanceDetail.agency[0].trim() === ''
+              ? '정보 없음'
+              : performanceDetail.agency?.map((agency: string) => (
+                  <span key={agency}>{agency}</span>
+                ))}
+          </div>
+        ),
       },
     ];
   }, [performanceDetail]);

--- a/src/components/pages/performanceDetail/PerformanceDetailSummary.tsx
+++ b/src/components/pages/performanceDetail/PerformanceDetailSummary.tsx
@@ -119,7 +119,9 @@ const PerformanceDetailSummary = ({
               장소
             </span>
             <span className='text-16_M leading-normal tracking-[-0.4px] text-gray-700'>
-              {formatLocation(performanceDetail.location).place}
+              {formatLocation(performanceDetail.location).place === ''
+                ? '정보 없음'
+                : formatLocation(performanceDetail.location).place}
             </span>
 
             <span className='pr-7.5 text-16_B leading-normal tracking-[-0.4px] whitespace-nowrap text-gray-700'>

--- a/src/components/pages/performanceDetail/PerformanceDetailWrapper.tsx
+++ b/src/components/pages/performanceDetail/PerformanceDetailWrapper.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import StateNotice from '@/components/common/StateNotice/StateNotice';
 import Toast from '@/components/common/Toast/Toast';
 import { Summary, Tabs } from '@/components/pages/performanceDetail';
 import { useGetPerformanceDetail } from '@/hooks';
@@ -37,8 +38,8 @@ const PerformanceDetailWrapper = ({
 
   if (isError)
     return (
-      <div className='flex h-full flex-col items-center justify-center px-4 py-5'>
-        <p className='font-semibold text-gray-500'>존재하지 않는 공연입니다.</p>
+      <div className='flex h-[calc(100dvh-124px)] flex-col items-center justify-center'>
+        <StateNotice preset='notfound' />
       </div>
     );
 


### PR DESCRIPTION
### 무엇을 위한 PR인가요? (: 뒤 설명 추가)

- 리펙토링: 공연 상세 페이지 리팩토링

### 변경사항 및 이유 (bullet 으로 구분)

- 공연 상세 에러 핸들링 리팩토링
- 모임 상세 에러 핸들링 리팩토링

### 작업 내역 (bullet 으로 구분)

- 공연 상세 페이지
  - 공연 정보 중 데이터가 빈 값인 항목에 `정보 없음` 처리
  - 모임 개설 버튼 hover 스타일 추가
  - 없는 공연 페이지로 접속 시 notFound 처리
  - 공연에 개설된 모임이 없을 경우 groupEmpty 처리
- 모임 상세 페이지
  - 모임원 목록 불러오기 중 에러 발생 시 error 처리
  - 채팅 접근, 불러오기 중 에러 발생 시 errror 처리

### Issue Number

close: #494 