### PR TITLE
[Bug/issue-509] robots.txt valid 이슈 해결

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,12 +1,15 @@
 import { MetadataRoute } from 'next';
 
+const SITE_URL =
+  process.env.NEXT_PUBLIC_BASE_URL ?? 'https://ff-frontend-rust.vercel.app';
+
 const robots = (): MetadataRoute.Robots => ({
   rules: {
     userAgent: '*',
     allow: '/',
     disallow: '/admin/',
   },
-  sitemap: `${process.env.NEXT_PUBLIC_SITE_URL}/sitemap.xml`,
+  sitemap: `${SITE_URL}/sitemap.xml`,
 });
 
 export default robots;

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -3,22 +3,25 @@ import { PerformancesResponsePagination } from '@/types/performance';
 import { Performance } from '@/types/performance';
 import type { MetadataRoute } from 'next';
 
+const SITE_URL =
+  process.env.NEXT_PUBLIC_BASE_URL ?? 'https://ff-frontend-rust.vercel.app';
+
 const sitemap = async (): Promise<MetadataRoute.Sitemap> => {
   const staticRoutes: MetadataRoute.Sitemap = [
     {
-      url: `${process.env.NEXT_PUBLIC_SITE_URL}`,
+      url: `${SITE_URL}`,
       lastModified: new Date(),
       changeFrequency: 'weekly',
       priority: 1,
     },
     {
-      url: `${process.env.NEXT_PUBLIC_SITE_URL}/performances`,
+      url: `${SITE_URL}/performances`,
       lastModified: new Date(),
       changeFrequency: 'weekly',
       priority: 0.9,
     },
     {
-      url: `${process.env.NEXT_PUBLIC_SITE_URL}/calendar`,
+      url: `${SITE_URL}/calendar`,
       lastModified: new Date(),
       changeFrequency: 'weekly',
       priority: 0.6,
@@ -41,7 +44,7 @@ const sitemap = async (): Promise<MetadataRoute.Sitemap> => {
 
   const performanceRoutes: MetadataRoute.Sitemap = performances.map(
     (performance) => ({
-      url: `${process.env.NEXT_PUBLIC_SITE_URL}/performances/${performance.id}`,
+      url: `${SITE_URL}/performances/${performance.id}`,
       lastModified: new Date(
         performance.endDate ?? performance.startDate ?? Date.now()
       ),


### PR DESCRIPTION
### 무엇을 위한 PR인가요? (: 뒤 설명 추가)

- 버그 수정: robots.txt valid 이슈 해결

### 변경사항 및 이유 (bullet 으로 구분)

- env 파일의 서비스 url을 읽어오지 못해 robots.txt의 사이트맵 url이 undefied로 나타남

### 작업 내역 (bullet 으로 구분)

- robots.ts에 사이트 url 명시
- sitemap.ts에 사이트 url 명시

### Issue Number

close: #509 