### PR TITLE
[Bug/issue-519] 채팅 내 고정글 안보이는 버그 수정

### DIFF
--- a/src/components/pages/groupDetail/Chat/Chat.tsx
+++ b/src/components/pages/groupDetail/Chat/Chat.tsx
@@ -2,20 +2,29 @@
 
 import StateNotice from '@/components/common/StateNotice/StateNotice';
 import { Skeleton } from '@/components/ui/skeleton';
+import { useGetGroupPosts } from '@/hooks/groupHooks/groupHooks';
 import { useGetUserId } from '@/hooks/userHooks/userHooks';
 import { GroupInfo } from '@/types/group';
+import { Post } from '@/types/post';
 import PostNotice from '../PostNotice/PostNotice';
 import ChatArea from './ChatArea';
 import ChatInfo from './ChatInfo';
 
-const hasNotice = true;
-
 interface ChatProps {
-  groupInfo?: GroupInfo;
+  groupInfo: GroupInfo;
 }
 
 const Chat = ({ groupInfo }: ChatProps) => {
   const { data: userId, isPending, isError } = useGetUserId();
+  const { data: posts, isPending: isPostsPending } = useGetGroupPosts({
+    groupId: groupInfo.id,
+  });
+
+  const pinnedPost: Post | undefined =
+    posts !== undefined
+      ? posts.pages.flatMap((page) => page.data?.posts || [])[0]
+      : undefined;
+  const hasNotice: boolean = pinnedPost?.isPinned ? pinnedPost.isPinned : false;
 
   if (isPending)
     return (
@@ -25,7 +34,7 @@ const Chat = ({ groupInfo }: ChatProps) => {
       </div>
     );
 
-  if (isError || !userId || !groupInfo?.isMember) {
+  if (isError || !userId || !groupInfo.isMember) {
     return (
       <div className='flex h-full items-center justify-center py-20'>
         <StateNotice
@@ -40,10 +49,15 @@ const Chat = ({ groupInfo }: ChatProps) => {
     <div className='px-4 pt-4 pb-6'>
       <div className='flex flex-col rounded-[16px] bg-[#fffcfc] px-4 py-4 shadow-[0px_0px_6px_0px_rgba(0,0,0,0.16)]'>
         <ChatInfo groupInfo={groupInfo} />
-        {hasNotice && <PostNotice className='mt-3.5' />}
+        {!isPostsPending && hasNotice && (
+          <PostNotice
+            className='mt-3.5'
+            pinnedPost={pinnedPost}
+          />
+        )}
         <ChatArea
           userId={userId.data?.userId}
-          chatRoomId={groupInfo?.chatRoomId}
+          chatRoomId={groupInfo.chatRoomId}
         />
       </div>
     </div>

--- a/src/components/pages/groupDetail/GroupTabs.tsx
+++ b/src/components/pages/groupDetail/GroupTabs.tsx
@@ -25,7 +25,7 @@ const GroupTabs = ({ groupInfo }: GroupTabsProps) => {
       />
       <>
         {selectedTab === '게시글' && <GroupPosts />}
-        {selectedTab === '채팅' && <Chat groupInfo={groupInfo} />}
+        {selectedTab === '채팅' && groupInfo && <Chat groupInfo={groupInfo} />}
         {selectedTab === '캘린더' && groupInfo?.id && (
           <GroupCalendar groupId={groupInfo?.id} />
         )}

--- a/src/hooks/postHooks/postHook.ts
+++ b/src/hooks/postHooks/postHook.ts
@@ -67,7 +67,6 @@ export const usePinPost = () => {
     }) => postApi.pinPost({ groupId, postId, isPinned }),
 
     onSuccess: (_data, variables) => {
-      console.log('onSuccess', variables);
       queryClient.invalidateQueries({
         queryKey: [GROUP_QUERY_KEYS.groupPosts, String(variables.groupId)],
       });


### PR DESCRIPTION
### 무엇을 위한 PR인가요? (: 뒤 설명 추가)

- 버그 수정: 채팅 내 고정글 안보이는 버그 수정

### 변경사항 및 이유 (bullet 으로 구분)

- 고정글 여부(`hasNotice`)가 하드코딩되어 있어 채팅 탭에서 고정글이 보이지 않음
- props로 pinnedPost를 전달하지 않음

### 작업 내역 (bullet 으로 구분)

- 채팅 탭에서 게시글 목록을 조회한 후에 고정된 게시글이 있으면 hasNotice를 true로 설정, pinnedPost를 props로 전달해 공지글이 보이도록 수정

### Issue Number

close: #519 